### PR TITLE
Migrate server state from TanStack Query to TanStack DB

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -47,7 +47,8 @@
       "Bash(grep -r \"Pool\\\\|pool\\\\|connection\" /Users/artmann/code/squeal/src/databases/*.ts)",
       "Bash(head -30 /Users/artmann/code/squeal/tsconfig.*.json)",
       "Bash(git commit:*)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "mcp__package-registry__get-npm-package-details"
     ],
     "deny": [],
     "ask": []

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@reduxjs/toolkit": "^2.11.0",
     "@tailwindcss/vite": "^4.1.17",
+    "@tanstack/query-db-collection": "1.0.45",
+    "@tanstack/react-db": "0.1.91",
     "@tanstack/react-query": "^5.100.5",
     "@uiw/react-codemirror": "^4.25.3",
     "ai": "^5.0.98",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,17 +28,14 @@ import { Button } from './components/ui/button'
 import { Separator } from './components/ui/separator'
 
 import { WorksheetEditor } from './components/WorksheetEditor'
+import { useCollections } from './collections-context'
 import {
   useDatabases,
   useQueriesList,
   useQueryById,
   useWorksheets
 } from './hooks/queries'
-import {
-  useCancelQuery,
-  useCreateQuery,
-  useUpdateWorksheet
-} from './hooks/mutations'
+import { useCancelQuery, useCreateQuery } from './hooks/mutations'
 import { useAppSelector } from './store'
 import { createAstFromSql } from './sql-parser'
 import { canceledQueryMessage } from '@/glue/queries'
@@ -126,7 +123,7 @@ export function App(): ReactElement {
 
   const isQueryRunning = Boolean(query && !query.finishedAt)
 
-  const updateWorksheet = useUpdateWorksheet()
+  const { worksheets: worksheetsCollection } = useCollections()
   const createQuery = useCreateQuery()
   const cancelQuery = useCancelQuery()
 
@@ -137,8 +134,6 @@ export function App(): ReactElement {
       mutateCancelQuery(query.id)
     }
   }, [mutateCancelQuery, query?.id])
-
-  const { mutate: mutateWorksheet } = updateWorksheet
 
   const saveTimer = useRef<NodeJS.Timeout | undefined>(undefined)
   const pendingSave = useRef<{ content: string; id: string } | undefined>(
@@ -160,19 +155,19 @@ export function App(): ReactElement {
 
     pendingSave.current = undefined
 
-    mutateWorksheet(
-      { id: pending.id, updates: { content: pending.content } },
-      {
-        onSuccess: () => {
-          setSaveState('saved')
-        },
-        onError: () => {
-          setSaveState('error')
-          toast.error('Failed to save worksheet')
-        }
-      }
-    )
-  }, [mutateWorksheet])
+    const transaction = worksheetsCollection.update(pending.id, (draft) => {
+      draft.content = pending.content
+    })
+
+    void transaction.isPersisted.promise
+      .then(() => {
+        setSaveState('saved')
+      })
+      .catch(() => {
+        setSaveState('error')
+        toast.error('Failed to save worksheet')
+      })
+  }, [worksheetsCollection])
 
   useEffect(() => {
     // Flush any pending save when switching worksheets or unmounting so the

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -32,10 +32,11 @@ import { useCollections } from './collections-context'
 import {
   useDatabases,
   useQueriesList,
-  useQueryById,
+  useQueryResultSync,
   useWorksheets
 } from './hooks/queries'
-import { useCancelQuery, useCreateQuery } from './hooks/mutations'
+import { useCancelQuery } from './hooks/mutations'
+import { QueryDto } from '@/main/queries'
 import { useAppSelector } from './store'
 import { createAstFromSql } from './sql-parser'
 import { canceledQueryMessage } from '@/glue/queries'
@@ -110,7 +111,7 @@ export function App(): ReactElement {
     return statements[activeStatementIndex]
   }, [statements, activeStatementIndex])
 
-  const latestQueryForWorksheet = useMemo(() => {
+  const query = useMemo(() => {
     const sorted = queries.data
       .filter((q) => q.worksheetId === openWorksheetId)
       .sort((a, b) => b.queriedAt - a.queriedAt)
@@ -118,22 +119,21 @@ export function App(): ReactElement {
     return sorted[0]
   }, [queries.data, openWorksheetId])
 
-  const liveQueryResult = useQueryById(latestQueryForWorksheet?.id)
-  const query = liveQueryResult.data ?? latestQueryForWorksheet
+  useQueryResultSync(query)
 
   const isQueryRunning = Boolean(query && !query.finishedAt)
 
-  const { worksheets: worksheetsCollection } = useCollections()
-  const createQuery = useCreateQuery()
+  const { queries: queriesCollection, worksheets: worksheetsCollection } =
+    useCollections()
   const cancelQuery = useCancelQuery()
 
-  const { mutate: mutateCancelQuery } = cancelQuery
+  const { cancel: cancelQueryById } = cancelQuery
 
   const handleCancelQuery = useCallback(() => {
     if (query?.id) {
-      mutateCancelQuery(query.id)
+      cancelQueryById(query.id)
     }
-  }, [mutateCancelQuery, query?.id])
+  }, [cancelQueryById, query?.id])
 
   const saveTimer = useRef<NodeJS.Timeout | undefined>(undefined)
   const pendingSave = useRef<{ content: string; id: string } | undefined>(
@@ -201,31 +201,32 @@ export function App(): ReactElement {
       return
     }
 
-    const queryId = v7()
-    const queriedAt = Date.now()
+    const optimistic: QueryDto = {
+      content: activeStatement.text,
+      databaseId: currentWorksheet?.databaseId ?? '',
+      error: null,
+      finishedAt: null,
+      id: v7(),
+      queriedAt: Date.now(),
+      result: null,
+      truncated: false,
+      worksheetId: openWorksheetId ?? ''
+    }
 
-    createQuery.mutate(
-      {
-        content: activeStatement.text,
-        databaseId: currentWorksheet?.databaseId ?? undefined,
-        id: queryId,
-        queriedAt,
-        worksheetId: openWorksheetId ?? ''
-      },
-      {
-        onError: (error) => {
-          const message =
-            error instanceof Error ? error.message : 'Failed to run query'
+    const transaction = queriesCollection.insert(optimistic)
 
-          toast.error('Query failed', { description: message })
-        }
-      }
-    )
+    // The optimistic row rolls back automatically if the create fails.
+    void transaction.isPersisted.promise.catch((error: unknown) => {
+      const message =
+        error instanceof Error ? error.message : 'Failed to run query'
+
+      toast.error('Query failed', { description: message })
+    })
   }, [
     activeStatement,
-    createQuery,
     currentWorksheet?.databaseId,
-    openWorksheetId
+    openWorksheetId,
+    queriesCollection
   ])
 
   if (!currentWorksheet) {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,7 +1,15 @@
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { Loader2Icon } from 'lucide-react'
-import { Component, ErrorInfo, ReactNode, Suspense, useEffect } from 'react'
+import {
+  Component,
+  ErrorInfo,
+  ReactNode,
+  Suspense,
+  useCallback,
+  useEffect
+} from 'react'
 
+import { useCollections } from './collections-context'
 import { Button } from './components/ui/button'
 import { useQueriesList, useWorksheets } from './hooks/queries'
 import { useAppDispatch, useAppSelector } from './store'
@@ -109,12 +117,33 @@ function AppDataLoader({ children }: { children: ReactNode }): ReactNode {
 }
 
 export function AppShell({ children }: { children: ReactNode }): ReactNode {
+  const collections = useCollections()
+
+  // Resetting the query error boundary is not enough to restart a collection
+  // whose sync failed, so clear collection errors too.
+  const clearCollectionErrors = useCallback(() => {
+    const all = [
+      collections.databases,
+      collections.queries,
+      collections.worksheets
+    ]
+
+    for (const collection of all) {
+      if (collection.utils.isError) {
+        void collection.utils.clearError().catch((): void => undefined)
+      }
+    }
+  }, [collections])
+
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
         <ErrorBoundary
           fallback={(retry) => <DataLoadError onRetry={retry} />}
-          onReset={reset}
+          onReset={() => {
+            reset()
+            clearCollectionErrors()
+          }}
         >
           <Suspense fallback={<FullScreenSpinner />}>
             <AppDataLoader>{children}</AppDataLoader>

--- a/src/app/collections-context.tsx
+++ b/src/app/collections-context.tsx
@@ -1,0 +1,33 @@
+import { createContext, ReactNode, useContext } from 'react'
+import invariant from 'tiny-invariant'
+
+import { Collections } from './collections'
+
+const CollectionsContext = createContext<Collections | undefined>(undefined)
+
+interface CollectionsProviderProps {
+  children: ReactNode
+  collections: Collections
+}
+
+export function CollectionsProvider({
+  children,
+  collections
+}: CollectionsProviderProps): ReactNode {
+  return (
+    <CollectionsContext.Provider value={collections}>
+      {children}
+    </CollectionsContext.Provider>
+  )
+}
+
+export function useCollections(): Collections {
+  const collections = useContext(CollectionsContext)
+
+  invariant(
+    collections,
+    'useCollections must be used within a CollectionsProvider'
+  )
+
+  return collections
+}

--- a/src/app/collections.test.tsx
+++ b/src/app/collections.test.tsx
@@ -1,0 +1,55 @@
+import { useLiveQuery } from '@tanstack/react-db'
+import { screen } from '@testing-library/react'
+import { ReactElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { WorksheetDto } from '@/glue/worksheets'
+
+import { apiClient } from './api-client'
+import { useCollections } from './collections-context'
+import { renderWithProviders } from './test-utils'
+
+vi.mock('./api-client', () => ({
+  apiClient: {
+    getDatabases: vi.fn(),
+    getQueries: vi.fn(),
+    getWorksheets: vi.fn()
+  }
+}))
+
+const testWorksheet: WorksheetDto = {
+  content: 'SELECT * FROM users',
+  createdAt: 1704067200000,
+  databaseId: null,
+  id: 'ws-1',
+  lastOpenedAt: null,
+  name: 'Smoke Test Worksheet'
+}
+
+function WorksheetNames(): ReactElement {
+  const { worksheets } = useCollections()
+
+  const { data } = useLiveQuery((query) =>
+    query.from({ worksheet: worksheets })
+  )
+
+  return (
+    <ul>
+      {data.map((worksheet) => (
+        <li key={worksheet.id}>{worksheet.name}</li>
+      ))}
+    </ul>
+  )
+}
+
+describe('collections', () => {
+  it('serves seeded data without fetching from the api', async () => {
+    renderWithProviders(<WorksheetNames />, {
+      worksheets: [testWorksheet]
+    })
+
+    expect(await screen.findByText('Smoke Test Worksheet')).toBeInTheDocument()
+
+    expect(apiClient.getWorksheets).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/collections.ts
+++ b/src/app/collections.ts
@@ -1,0 +1,103 @@
+import { queryCollectionOptions } from '@tanstack/query-db-collection'
+import { createCollection } from '@tanstack/react-db'
+import { QueryClient } from '@tanstack/react-query'
+
+import { DatabaseDto } from '@/glue/databases'
+import { WorksheetDto } from '@/glue/worksheets'
+import { QueryDto } from '@/main/queries'
+
+import { apiClient } from './api-client'
+import { queryKeys } from './query-keys'
+
+export type Collections = ReturnType<typeof createCollections>
+
+interface WorksheetPatch {
+  content?: string
+  databaseId?: string | null
+  lastOpenedAt?: number
+  name?: string
+}
+
+// The PATCH endpoint rejects null for lastOpenedAt, so only forward fields the
+// backend accepts.
+function toWorksheetPatch(changes: Partial<WorksheetDto>): WorksheetPatch {
+  const patch: WorksheetPatch = {}
+
+  if (changes.content !== undefined) {
+    patch.content = changes.content
+  }
+
+  if (changes.databaseId !== undefined) {
+    patch.databaseId = changes.databaseId
+  }
+
+  if (changes.lastOpenedAt !== undefined && changes.lastOpenedAt !== null) {
+    patch.lastOpenedAt = changes.lastOpenedAt
+  }
+
+  if (changes.name !== undefined) {
+    patch.name = changes.name
+  }
+
+  return patch
+}
+
+export function createCollections(queryClient: QueryClient) {
+  const databases = createCollection(
+    queryCollectionOptions({
+      getKey: (item: DatabaseDto) => item.id,
+      queryClient,
+      queryFn: () => apiClient.getDatabases(),
+      queryKey: queryKeys.databases
+    })
+  )
+
+  const queries = createCollection(
+    queryCollectionOptions({
+      getKey: (item: QueryDto) => item.id,
+      onInsert: async ({ transaction }) => {
+        for (const mutation of transaction.mutations) {
+          const query = mutation.modified
+
+          const response = await apiClient.createQuery({
+            content: query.content,
+            databaseId: query.databaseId === '' ? undefined : query.databaseId,
+            id: query.id,
+            queriedAt: query.queriedAt,
+            worksheetId: query.worksheetId
+          })
+
+          queries.utils.writeUpsert(response.query)
+        }
+
+        return { refetch: false }
+      },
+      queryClient,
+      queryFn: () => apiClient.getQueries(),
+      queryKey: queryKeys.queries
+    })
+  )
+
+  const worksheets = createCollection(
+    queryCollectionOptions({
+      getKey: (item: WorksheetDto) => item.id,
+      onUpdate: async ({ transaction }) => {
+        for (const mutation of transaction.mutations) {
+          const worksheet = await apiClient.updateWorksheet(
+            String(mutation.key),
+            toWorksheetPatch(mutation.changes)
+          )
+
+          worksheets.utils.writeUpsert(worksheet)
+        }
+
+        return { refetch: false }
+      },
+      queryClient,
+      queryFn: () => apiClient.getWorksheets(),
+      queryKey: queryKeys.worksheets
+    })
+  )
+
+  return { databases, queries, worksheets }
+}

--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -12,6 +12,8 @@ import {
   vi
 } from 'vitest'
 
+import { createCollections } from '../collections'
+import { CollectionsProvider } from '../collections-context'
 import { DatabaseForm } from './DatabaseForm'
 
 // Radix UI Select uses DOM APIs not available in jsdom
@@ -48,10 +50,14 @@ function renderDatabaseForm(props: Parameters<typeof DatabaseForm>[0] = {}) {
     }
   })
 
+  const collections = createCollections(queryClient)
+
   return render(
     <QueryClientProvider client={queryClient}>
-      <DatabaseForm {...props} />
-      <Toaster />
+      <CollectionsProvider collections={collections}>
+        <DatabaseForm {...props} />
+        <Toaster />
+      </CollectionsProvider>
     </QueryClientProvider>
   )
 }

--- a/src/app/components/DatabaseSelector.test.tsx
+++ b/src/app/components/DatabaseSelector.test.tsx
@@ -5,7 +5,6 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DatabaseDto } from '@/glue/databases'
 import { WorksheetDto } from '@/glue/worksheets'
 
-import { queryKeys } from '../hooks/queries'
 import { renderWithProviders } from '../test-utils'
 import { DatabaseSelector } from './DatabaseSelector'
 
@@ -119,7 +118,7 @@ describe('DatabaseSelector', () => {
         })
     )
 
-    const { queryClient } = renderWithProviders(<DatabaseSelector />, {
+    const { collections } = renderWithProviders(<DatabaseSelector />, {
       databases: [testDatabase, testDatabase2],
       editor: { openWorksheetId: 'ws-123' },
       worksheets: [testWorksheet]
@@ -129,12 +128,12 @@ describe('DatabaseSelector', () => {
     await user.click(screen.getByText('Staging DB'))
 
     await waitFor(() => {
-      const worksheets = queryClient.getQueryData<WorksheetDto[]>(
-        queryKeys.worksheets
-      )
-
-      expect(worksheets?.[0]).toEqual({
+      expect(collections.worksheets.get('ws-123')).toEqual({
         ...testWorksheet,
+        $collectionId: expect.any(String),
+        $key: 'ws-123',
+        $origin: 'local',
+        $synced: false,
         databaseId: 'db-2'
       })
     })

--- a/src/app/components/DatabaseSelector.tsx
+++ b/src/app/components/DatabaseSelector.tsx
@@ -2,8 +2,8 @@ import { DatabaseIcon } from 'lucide-react'
 import invariant from 'tiny-invariant'
 import { ReactElement, useCallback, useMemo } from 'react'
 
+import { useCollections } from '../collections-context'
 import { useDatabases, useWorksheets } from '../hooks/queries'
-import { useUpdateWorksheet } from '../hooks/mutations'
 import { useAppSelector } from '../store'
 import {
   Select,
@@ -19,7 +19,7 @@ export function DatabaseSelector(): ReactElement {
   const openWorksheetId = useAppSelector(
     (state) => state.editor.openWorksheetId
   )
-  const updateWorksheet = useUpdateWorksheet()
+  const { worksheets: worksheetsCollection } = useCollections()
 
   const currentWorksheet = useMemo(
     () => worksheets.data.find((worksheet) => worksheet.id === openWorksheetId),
@@ -34,12 +34,17 @@ export function DatabaseSelector(): ReactElement {
 
       invariant(currentWorksheet, 'No current worksheet found.')
 
-      updateWorksheet.mutate({
-        id: openWorksheetId,
-        updates: { databaseId }
-      })
+      const transaction = worksheetsCollection.update(
+        openWorksheetId,
+        (draft) => {
+          draft.databaseId = databaseId
+        }
+      )
+
+      // The optimistic change rolls back automatically if the save fails.
+      void transaction.isPersisted.promise.catch((): void => undefined)
     },
-    [currentWorksheet, openWorksheetId, updateWorksheet]
+    [currentWorksheet, openWorksheetId, worksheetsCollection]
   )
 
   if (databases.data.length === 0) {

--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -2,8 +2,9 @@ import { FileBracesIcon, PlusIcon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import { useCollections } from '../collections-context'
 import { useWorksheets } from '../hooks/queries'
-import { useCreateWorksheet, useUpdateWorksheet } from '../hooks/mutations'
+import { useCreateWorksheet } from '../hooks/mutations'
 import { cn } from '../lib/utils'
 import { useAppDispatch, useAppSelector } from '../store'
 import {
@@ -26,7 +27,7 @@ export function WorksheetExplorer(): ReactElement {
   )
 
   const createWorksheet = useCreateWorksheet()
-  const updateWorksheet = useUpdateWorksheet()
+  const { worksheets: worksheetsCollection } = useCollections()
 
   const [editingWorksheetId, setEditingWorksheetId] = useState<string | null>(
     null
@@ -48,16 +49,23 @@ export function WorksheetExplorer(): ReactElement {
     a.createdAt > b.createdAt ? -1 : 1
   )
 
+  const touchWorksheet = useCallback(
+    (worksheetId: string) => {
+      const transaction = worksheetsCollection.update(worksheetId, (draft) => {
+        draft.lastOpenedAt = Date.now()
+      })
+
+      void transaction.isPersisted.promise.catch((): void => undefined)
+    },
+    [worksheetsCollection]
+  )
+
   const handleSelectWorksheet = useCallback(
     (worksheetId: string) => {
       dispatch(worksheetSelected(worksheetId))
-
-      updateWorksheet.mutate({
-        id: worksheetId,
-        updates: { lastOpenedAt: Date.now() }
-      })
+      touchWorksheet(worksheetId)
     },
-    [dispatch, updateWorksheet]
+    [dispatch, touchWorksheet]
   )
 
   const handleNewWorksheet = useCallback(() => {
@@ -70,11 +78,7 @@ export function WorksheetExplorer(): ReactElement {
     createWorksheet.mutate(name, {
       onSuccess: (worksheet) => {
         dispatch(worksheetSelected(worksheet.id))
-
-        updateWorksheet.mutate({
-          id: worksheet.id,
-          updates: { lastOpenedAt: Date.now() }
-        })
+        touchWorksheet(worksheet.id)
 
         setEditingWorksheetId(worksheet.id)
         setEditingName(worksheet.name)
@@ -85,7 +89,7 @@ export function WorksheetExplorer(): ReactElement {
         toast.error('Failed to create worksheet', { description: message })
       }
     })
-  }, [createWorksheet, dispatch, updateWorksheet, worksheets.data])
+  }, [createWorksheet, dispatch, touchWorksheet, worksheets.data])
 
   const handleDoubleClick = useCallback((worksheet: WorksheetDto) => {
     setEditingWorksheetId(worksheet.id)
@@ -117,21 +121,19 @@ export function WorksheetExplorer(): ReactElement {
 
       setEditingWorksheetId(null)
 
-      updateWorksheet.mutate(
-        { id: worksheetId, updates: { name: trimmedName } },
-        {
-          onError: (error) => {
-            const message =
-              error instanceof Error ? error.message : 'Unknown error'
+      const transaction = worksheetsCollection.update(worksheetId, (draft) => {
+        draft.name = trimmedName
+      })
 
-            toast.error('Failed to rename worksheet', { description: message })
-          }
-        }
-      )
+      void transaction.isPersisted.promise.catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+
+        toast.error('Failed to rename worksheet', { description: message })
+      })
 
       setEditingName('')
     },
-    [editingName, handleRenameCancel, updateWorksheet, worksheets.data]
+    [editingName, handleRenameCancel, worksheetsCollection, worksheets.data]
   )
 
   const handleKeyDown = useCallback(

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -1,95 +1,78 @@
+import { createOptimisticAction } from '@tanstack/react-db'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useMemo, useState } from 'react'
 
 import { apiClient } from '../api-client'
 import { useCollections } from '../collections-context'
+import { queryPollInterval } from './queries'
 import { queryKeys } from '../query-keys'
 import { CreateDatabaseRequest } from '@/databases/schemas'
-import { DatabaseDto } from '@/glue/databases'
-import { WorksheetDto } from '@/glue/worksheets'
+import { canceledQueryMessage } from '@/glue/queries'
 import { QueryDto } from '@/main/queries'
 
-export interface CreateQueryInput {
-  content: string
-  databaseId?: string
-  id: string
-  queriedAt: number
-  worksheetId: string
-}
+const cancelPollAttempts = 20
 
-export function useCreateQuery() {
-  const queryClient = useQueryClient()
+// The cancel endpoint only signals the running adapter; the backend finalizes
+// the row afterwards. Wait for that so the optimistic canceled state is not
+// dropped before the server row catches up.
+async function waitForQueryToFinish(
+  queryId: string
+): Promise<QueryDto | undefined> {
+  for (let attempt = 0; attempt < cancelPollAttempts; attempt++) {
+    const query = await apiClient.getQuery(queryId)
 
-  return useMutation({
-    mutationFn: (input: CreateQueryInput) => apiClient.createQuery(input),
-    onMutate: async (input) => {
-      await queryClient.cancelQueries({ queryKey: queryKeys.queries })
-
-      const previous = queryClient.getQueryData<QueryDto[]>(queryKeys.queries)
-
-      const optimistic: QueryDto = {
-        content: input.content,
-        databaseId: input.databaseId ?? '',
-        error: null,
-        finishedAt: null,
-        id: input.id,
-        queriedAt: input.queriedAt,
-        result: null,
-        truncated: false,
-        worksheetId: input.worksheetId
-      }
-
-      queryClient.setQueryData<QueryDto[]>(queryKeys.queries, (old) => {
-        const next = old ? [...old] : []
-        next.unshift(optimistic)
-
-        return next
-      })
-
-      queryClient.setQueryData(queryKeys.query(input.id), optimistic)
-
-      return { previous }
-    },
-    onError: (_error, _input, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(queryKeys.queries, context.previous)
-      }
-    },
-    onSuccess: (response) => {
-      queryClient.setQueryData<QueryDto[]>(queryKeys.queries, (old) => {
-        if (!old) {
-          return [response.query]
-        }
-
-        const index = old.findIndex((query) => query.id === response.query.id)
-
-        if (index < 0) {
-          return [response.query, ...old]
-        }
-
-        const next = [...old]
-        next[index] = response.query
-
-        return next
-      })
-
-      queryClient.setQueryData(
-        queryKeys.query(response.query.id),
-        response.query
-      )
+    if (query.finishedAt) {
+      return query
     }
-  })
+
+    await new Promise((resolve) => setTimeout(resolve, queryPollInterval))
+  }
+
+  return undefined
 }
 
 export function useCancelQuery() {
-  const queryClient = useQueryClient()
+  const { queries } = useCollections()
+  const [isPending, setIsPending] = useState(false)
 
-  return useMutation({
-    mutationFn: (queryId: string) => apiClient.cancelQuery(queryId),
-    onSuccess: (_result, queryId) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.query(queryId) })
-      queryClient.invalidateQueries({ queryKey: queryKeys.queries })
-    }
-  })
+  const cancelAction = useMemo(
+    () =>
+      createOptimisticAction<string>({
+        onMutate: (queryId) => {
+          queries.update(queryId, (draft) => {
+            draft.error = canceledQueryMessage
+            draft.finishedAt = Date.now()
+          })
+        },
+        mutationFn: async (queryId) => {
+          await apiClient.cancelQuery(queryId)
+
+          const finalQuery = await waitForQueryToFinish(queryId)
+
+          if (finalQuery && queries.status === 'ready') {
+            queries.utils.writeUpsert(finalQuery)
+          }
+        }
+      }),
+    [queries]
+  )
+
+  const cancel = useCallback(
+    (queryId: string) => {
+      setIsPending(true)
+
+      const transaction = cancelAction(queryId)
+
+      void transaction.isPersisted.promise
+        .catch((): void => undefined)
+        .finally(() => {
+          setIsPending(false)
+        })
+    },
+    [cancelAction]
+  )
+
+  return { cancel, isPending }
 }
 
 export function useCreateWorksheet() {

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { apiClient } from '../api-client'
+import { useCollections } from '../collections-context'
 import { queryKeys } from '../query-keys'
 import { CreateDatabaseRequest } from '@/databases/schemas'
 import { DatabaseDto } from '@/glue/databases'
@@ -92,74 +93,12 @@ export function useCancelQuery() {
 }
 
 export function useCreateWorksheet() {
-  const queryClient = useQueryClient()
+  const { worksheets } = useCollections()
 
   return useMutation({
     mutationFn: (name: string) => apiClient.createWorksheet(name),
     onSuccess: (worksheet) => {
-      queryClient.setQueryData<WorksheetDto[]>(queryKeys.worksheets, (old) => {
-        if (!old) {
-          return [worksheet]
-        }
-
-        return [...old, worksheet]
-      })
-    }
-  })
-}
-
-export interface UpdateWorksheetInput {
-  databaseId?: string | null
-  content?: string
-  lastOpenedAt?: number
-  name?: string
-}
-
-export function useUpdateWorksheet() {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    mutationFn: ({
-      id,
-      updates
-    }: {
-      id: string
-      updates: UpdateWorksheetInput
-    }) => apiClient.updateWorksheet(id, updates),
-    onMutate: async ({ id, updates }) => {
-      await queryClient.cancelQueries({ queryKey: queryKeys.worksheets })
-
-      const previous = queryClient.getQueryData<WorksheetDto[]>(
-        queryKeys.worksheets
-      )
-
-      queryClient.setQueryData<WorksheetDto[]>(queryKeys.worksheets, (old) => {
-        if (!old) {
-          return old
-        }
-
-        return old.map((worksheet) =>
-          worksheet.id === id ? { ...worksheet, ...updates } : worksheet
-        )
-      })
-
-      return { previous }
-    },
-    onError: (_error, _input, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(queryKeys.worksheets, context.previous)
-      }
-    },
-    onSuccess: (worksheet) => {
-      queryClient.setQueryData<WorksheetDto[]>(queryKeys.worksheets, (old) => {
-        if (!old) {
-          return [worksheet]
-        }
-
-        return old.map((existing) =>
-          existing.id === worksheet.id ? worksheet : existing
-        )
-      })
+      worksheets.utils.writeInsert(worksheet)
     }
   })
 }

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -98,47 +98,36 @@ export function useCreateWorksheet() {
   return useMutation({
     mutationFn: (name: string) => apiClient.createWorksheet(name),
     onSuccess: (worksheet) => {
-      worksheets.utils.writeInsert(worksheet)
+      if (worksheets.status === 'ready') {
+        worksheets.utils.writeInsert(worksheet)
+      }
     }
   })
 }
 
 export function useCreateDatabase() {
-  const queryClient = useQueryClient()
+  const { databases, worksheets } = useCollections()
 
   return useMutation({
     mutationFn: (request: CreateDatabaseRequest) =>
       apiClient.createDatabase(request),
     onSuccess: (response) => {
-      queryClient.setQueryData<DatabaseDto[]>(queryKeys.databases, (old) => {
-        if (!old) {
-          return [response.database]
-        }
+      // Manual writes reconcile already-synced state. A collection that has
+      // not started syncing will fetch fresh data, new row included, on first
+      // read instead.
+      if (databases.status === 'ready') {
+        databases.utils.writeInsert(response.database)
+      }
 
-        return [...old, response.database]
-      })
-
-      if (response.updatedWorksheet) {
-        const updated = response.updatedWorksheet
-
-        queryClient.setQueryData<WorksheetDto[]>(
-          queryKeys.worksheets,
-          (old) => {
-            if (!old) {
-              return [updated]
-            }
-
-            return old.map((worksheet) =>
-              worksheet.id === updated.id ? updated : worksheet
-            )
-          }
-        )
+      if (response.updatedWorksheet && worksheets.status === 'ready') {
+        worksheets.utils.writeUpsert(response.updatedWorksheet)
       }
     }
   })
 }
 
 export function useUpdateDatabase() {
+  const { databases } = useCollections()
   const queryClient = useQueryClient()
 
   return useMutation({
@@ -150,15 +139,9 @@ export function useUpdateDatabase() {
       request: CreateDatabaseRequest
     }) => apiClient.updateDatabase(id, request),
     onSuccess: (response) => {
-      queryClient.setQueryData<DatabaseDto[]>(queryKeys.databases, (old) => {
-        if (!old) {
-          return [response.database]
-        }
-
-        return old.map((existing) =>
-          existing.id === response.database.id ? response.database : existing
-        )
-      })
+      if (databases.status === 'ready') {
+        databases.utils.writeUpsert(response.database)
+      }
 
       queryClient.invalidateQueries({
         queryKey: queryKeys.schema(response.database.id)

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { apiClient } from '../api-client'
-import { queryKeys } from './queries'
+import { queryKeys } from '../query-keys'
 import { CreateDatabaseRequest } from '@/databases/schemas'
 import { DatabaseDto } from '@/glue/databases'
 import { WorksheetDto } from '@/glue/worksheets'

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -1,9 +1,10 @@
+import { useLiveSuspenseQuery } from '@tanstack/react-db'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 
 import { apiClient } from '../api-client'
+import { useCollections } from '../collections-context'
 import { queryKeys } from '../query-keys'
 import { DatabaseDto } from '@/glue/databases'
-import { WorksheetDto } from '@/glue/worksheets'
 import { QueryDto } from '@/main/queries'
 import { SchemaInfo } from '@/databases/adapter'
 
@@ -17,10 +18,12 @@ export function useDatabases() {
 }
 
 export function useWorksheets() {
-  return useSuspenseQuery<WorksheetDto[]>({
-    queryKey: queryKeys.worksheets,
-    queryFn: () => apiClient.getWorksheets()
-  })
+  const { worksheets } = useCollections()
+
+  return useLiveSuspenseQuery(
+    (query) => query.from({ worksheet: worksheets }),
+    [worksheets]
+  )
 }
 
 export function useQueriesList() {

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -1,18 +1,13 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 
 import { apiClient } from '../api-client'
+import { queryKeys } from '../query-keys'
 import { DatabaseDto } from '@/glue/databases'
 import { WorksheetDto } from '@/glue/worksheets'
 import { QueryDto } from '@/main/queries'
 import { SchemaInfo } from '@/databases/adapter'
 
-export const queryKeys = {
-  databases: ['databases'] as const,
-  queries: ['queries'] as const,
-  query: (id: string) => ['query', id] as const,
-  schema: (databaseId: string) => ['schema', databaseId] as const,
-  worksheets: ['worksheets'] as const
-}
+export { queryKeys } from '../query-keys'
 
 export function useDatabases() {
   return useSuspenseQuery<DatabaseDto[]>({

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -11,10 +11,12 @@ import { SchemaInfo } from '@/databases/adapter'
 export { queryKeys } from '../query-keys'
 
 export function useDatabases() {
-  return useSuspenseQuery<DatabaseDto[]>({
-    queryKey: queryKeys.databases,
-    queryFn: () => apiClient.getDatabases()
-  })
+  const { databases } = useCollections()
+
+  return useLiveSuspenseQuery(
+    (query) => query.from({ database: databases }),
+    [databases]
+  )
 }
 
 export function useWorksheets() {

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -87,11 +87,14 @@ export function useQueryResultSync(query: QueryDto | undefined): void {
   useEffect(() => {
     // Also re-runs when the collection row regresses to running (for example
     // when a slow insert response lands after the poller saw the query
-    // finish) so the finished result always wins.
-    if (!finished || !isRunning || queries.status !== 'ready') {
+    // finish) so the finished result always wins. Collection status is not
+    // reactive, so wait for readiness instead of checking it once.
+    if (!finished || !isRunning) {
       return
     }
 
-    queries.utils.writeUpsert(finished)
+    void queries.stateWhenReady().then(() => {
+      queries.utils.writeUpsert(finished)
+    })
   }, [finished, isRunning, queries])
 }

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -1,20 +1,22 @@
 import { useLiveSuspenseQuery } from '@tanstack/react-db'
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect } from 'react'
 
 import { apiClient } from '../api-client'
 import { useCollections } from '../collections-context'
 import { queryKeys } from '../query-keys'
-import { DatabaseDto } from '@/glue/databases'
 import { QueryDto } from '@/main/queries'
 import { SchemaInfo } from '@/databases/adapter'
 
 export { queryKeys } from '../query-keys'
 
+export const queryPollInterval = 250
+
 export function useDatabases() {
   const { databases } = useCollections()
 
   return useLiveSuspenseQuery(
-    (query) => query.from({ database: databases }),
+    (builder) => builder.from({ database: databases }),
     [databases]
   )
 }
@@ -23,16 +25,18 @@ export function useWorksheets() {
   const { worksheets } = useCollections()
 
   return useLiveSuspenseQuery(
-    (query) => query.from({ worksheet: worksheets }),
+    (builder) => builder.from({ worksheet: worksheets }),
     [worksheets]
   )
 }
 
 export function useQueriesList() {
-  return useSuspenseQuery<QueryDto[]>({
-    queryKey: queryKeys.queries,
-    queryFn: () => apiClient.getQueries()
-  })
+  const { queries } = useCollections()
+
+  return useLiveSuspenseQuery(
+    (builder) => builder.from({ query: queries }),
+    [queries]
+  )
 }
 
 export function useDatabaseSchema(databaseId: string | undefined) {
@@ -50,10 +54,16 @@ export function useDatabaseSchema(databaseId: string | undefined) {
   })
 }
 
-const pollInterval = 250
+// The backend finishes queries out-of-band, so while the given query is
+// unfinished this polls the single row and writes the terminal result into
+// the queries collection, where the rest of the app reads it.
+export function useQueryResultSync(query: QueryDto | undefined): void {
+  const { queries } = useCollections()
 
-export function useQueryById(queryId: string | undefined) {
-  return useQuery<QueryDto>({
+  const queryId = query?.id
+  const isRunning = Boolean(query && !query.finishedAt)
+
+  const polled = useQuery<QueryDto>({
     queryKey: queryId ? queryKeys.query(queryId) : ['query', 'noop'],
     queryFn: () => {
       if (!queryId) {
@@ -62,15 +72,28 @@ export function useQueryById(queryId: string | undefined) {
 
       return apiClient.getQuery(queryId)
     },
-    enabled: Boolean(queryId),
-    refetchInterval: (query) => {
-      const data = query.state.data
+    enabled: Boolean(queryId) && isRunning,
+    refetchInterval: (pollQuery) => {
+      const data = pollQuery.state.data
 
       if (!data) {
-        return pollInterval
+        return queryPollInterval
       }
 
-      return data.finishedAt ? false : pollInterval
+      return data.finishedAt ? false : queryPollInterval
     }
   })
+
+  const finished = polled.data?.finishedAt ? polled.data : undefined
+
+  useEffect(() => {
+    // Also re-runs when the collection row regresses to running (for example
+    // when a slow insert response lands after the poller saw the query
+    // finish) so the finished result always wins.
+    if (!finished || !isRunning || queries.status !== 'ready') {
+      return
+    }
+
+    queries.utils.writeUpsert(finished)
+  }, [finished, isRunning, queries])
 }

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -8,8 +8,6 @@ import { queryKeys } from '../query-keys'
 import { QueryDto } from '@/main/queries'
 import { SchemaInfo } from '@/databases/adapter'
 
-export { queryKeys } from '../query-keys'
-
 export const queryPollInterval = 250
 
 export function useDatabases() {

--- a/src/app/query-keys.ts
+++ b/src/app/query-keys.ts
@@ -1,0 +1,7 @@
+export const queryKeys = {
+  databases: ['databases'] as const,
+  queries: ['queries'] as const,
+  query: (id: string) => ['query', id] as const,
+  schema: (databaseId: string) => ['schema', databaseId] as const,
+  worksheets: ['worksheets'] as const
+}

--- a/src/app/test-utils.tsx
+++ b/src/app/test-utils.tsx
@@ -10,7 +10,9 @@ import { DatabaseDto } from '@/glue/databases'
 import { QueryDto } from '@/main/queries'
 import { WorksheetDto } from '@/glue/worksheets'
 
-import { queryKeys } from './hooks/queries'
+import { createCollections } from './collections'
+import { CollectionsProvider } from './collections-context'
+import { queryKeys } from './query-keys'
 import databaseExplorerReducer, {
   DatabaseExplorerState
 } from './store/database-explorer-slice'
@@ -58,6 +60,10 @@ export function renderWithProviders(
     queryClient.setQueryData(queryKeys.schema(databaseId), schema)
   }
 
+  // Created after seeding so the collections hydrate from the query cache
+  // instead of fetching.
+  const collections = createCollections(queryClient)
+
   const store = configureStore({
     reducer: {
       databaseExplorer: databaseExplorerReducer,
@@ -80,12 +86,14 @@ export function renderWithProviders(
 
   const result = render(
     <QueryClientProvider client={queryClient}>
-      <Provider store={store}>
-        {ui}
-        <Toaster />
-      </Provider>
+      <CollectionsProvider collections={collections}>
+        <Provider store={store}>
+          {ui}
+          <Toaster />
+        </Provider>
+      </CollectionsProvider>
     </QueryClientProvider>
   )
 
-  return { ...result, queryClient, store }
+  return { ...result, collections, queryClient, store }
 }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -6,6 +6,8 @@ import { Toaster } from 'sonner'
 
 import { App } from './app/App'
 import { AppShell } from './app/AppShell'
+import { createCollections } from './app/collections'
+import { CollectionsProvider } from './app/collections-context'
 import { ThemeProvider } from './app/components/ThemeProvider'
 import './app/index.css'
 import { createQueryClient } from './app/query-client'
@@ -20,18 +22,21 @@ function main() {
 
   const store = createStore()
   const queryClient = createQueryClient()
+  const collections = createCollections(queryClient)
 
   createRoot(root).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
-        <Provider store={store}>
-          <ThemeProvider>
-            <AppShell>
-              <App />
-              <Toaster />
-            </AppShell>
-          </ThemeProvider>
-        </Provider>
+        <CollectionsProvider collections={collections}>
+          <Provider store={store}>
+            <ThemeProvider>
+              <AppShell>
+                <App />
+                <Toaster />
+              </AppShell>
+            </ThemeProvider>
+          </Provider>
+        </CollectionsProvider>
       </QueryClientProvider>
     </React.StrictMode>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2648,10 +2648,48 @@
     "@tailwindcss/oxide" "4.1.17"
     tailwindcss "4.1.17"
 
+"@tanstack/db-ivm@0.1.18":
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/@tanstack/db-ivm/-/db-ivm-0.1.18.tgz#c6feaa56e6d15f6de121c28c5560e4af62501df9"
+  integrity sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw==
+  dependencies:
+    fractional-indexing "^3.2.0"
+    sorted-btree "^1.8.1"
+
+"@tanstack/db@0.6.13":
+  version "0.6.13"
+  resolved "https://registry.yarnpkg.com/@tanstack/db/-/db-0.6.13.tgz#4e6866a8c03c87376155003be208e504d564ebac"
+  integrity sha512-EWR/eE2TO0CIh/nC5P4Ct6UCzDDyX94fnEXxqMMi0/5pbZDa/MCKB1PYad9jqZRSK4AEu2uoF6Y8aOUaZJd24A==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@tanstack/db-ivm" "0.1.18"
+    "@tanstack/pacer-lite" "^0.2.1"
+
+"@tanstack/pacer-lite@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/pacer-lite/-/pacer-lite-0.2.2.tgz#a9d51cb91ecb277ec8b4756d00894c1d1c74809a"
+  integrity sha512-eQ1MyLKCHyXiH7NbdmB80W77OhiMgGBUb+qDx/8WMGbwg5Lf/NlfD0TfNYAqY77i8V3AxoDoYdICrQE5ADw4Yw==
+
 "@tanstack/query-core@5.100.5":
   version "5.100.5"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.100.5.tgz#90808dd097896ab62cfdfb5cf997564f602cf3ad"
   integrity sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==
+
+"@tanstack/query-db-collection@1.0.45":
+  version "1.0.45"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-db-collection/-/query-db-collection-1.0.45.tgz#e6f0b96d52dfccb670b85ed16b6ecb3d20cc539f"
+  integrity sha512-BS5Cp+gwguQoL1CBWycKeOXHXfxw8OF5vuK34n6GT8V3wqSmrz0Nj7EHQEKdK8A+QTZwSSj/SiRBmYLHHkg2Cw==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@tanstack/db" "0.6.13"
+
+"@tanstack/react-db@0.1.91":
+  version "0.1.91"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-db/-/react-db-0.1.91.tgz#d0e38bd535b5e37db629879f6255a9cdbc67d13b"
+  integrity sha512-iiGXa0NUR5ZgWnaIzUw6T+VvkKv2kTo5jYYK57EtajDcrJbBlNw2+pnRp8Ni2QhXWG7GxFbDEuyY8aj4V975NA==
+  dependencies:
+    "@tanstack/db" "0.6.13"
+    use-sync-external-store "^1.6.0"
 
 "@tanstack/react-query@^5.100.5":
   version "5.100.5"
@@ -4936,6 +4974,11 @@ fraction.js@^5.3.4:
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
+
+fractional-indexing@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/fractional-indexing/-/fractional-indexing-3.4.0.tgz#b1dc2f12e4e51acfa3f57cbadb666194eaf3cb73"
+  integrity sha512-8J3glhz2rrpKG6KmI7wmJo3zH1VjeOpN+vTJSw1fOyO+Viqq3zX6/5NGh6oaZB2qIAYdOYuu5Dz9xp4faOO0Pg==
 
 fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
@@ -7631,6 +7674,11 @@ sonner@^2.0.7:
   resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
   integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
 
+sorted-btree@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/sorted-btree/-/sorted-btree-1.8.1.tgz#6e6275f7955e5892bb8737149cbe495be10f426f"
+  integrity sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==
+
 source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -8269,7 +8317,7 @@ use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1.4.0:
+use-sync-external-store@^1.4.0, use-sync-external-store@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==


### PR DESCRIPTION
## Summary

Adopts [TanStack DB](https://tanstack.com/db) on top of the existing TanStack Query setup. Server state (databases, worksheets, queries) now lives in client-side collections with built-in optimistic mutations and automatic rollback, persisting to the existing Hono REST API through collection mutation handlers. All hand-rolled optimistic cache code is gone.

## Changes

- **Infrastructure**: `createCollections(queryClient)` in `src/app/collections.ts` builds the three collections via `queryCollectionOptions`, reusing the existing query keys and `apiClient`. Provided through React context so tests get fresh instances per QueryClient. Versions pinned exactly (`@tanstack/react-db@0.1.91`, `@tanstack/query-db-collection@1.0.45`) since the core is pre-1.0.
- **Worksheets**: autosave, rename, and database selection are direct optimistic `collection.update()` calls; the save indicator hangs off `transaction.isPersisted.promise`. The 300ms autosave debounce stays (TanStack DB does not batch network calls).
- **Databases**: reads via `useLiveSuspenseQuery`; create/update keep `useMutation` (server-generated ids) and reconcile responses into the collections with `writeInsert`/`writeUpsert`.
- **Queries**: running a query is an optimistic `queries.insert()` whose `onInsert` handler posts to the backend. `useQueryResultSync` polls the in-flight query at 250ms and writes the terminal row into the collection. Cancel is a `createOptimisticAction` that marks the row canceled instantly, then waits for the backend to finalize it.
- The `AppShell` error-boundary retry also clears failed collection sync state, since a query-cache reset alone no longer restarts a collection.

## Notes

- Manual cache writes are skipped when a collection has not started syncing — its first read fetches fresh data anyway.
- Found during e2e testing: collection `status` is not reactive, so the result write-back waits on `stateWhenReady()` instead of checking status once (fixed in the last commit).
- Redux UI slices (search, open worksheet, tree expansion) are intentionally untouched; removing Redux is a possible follow-up.

## Testing

- 274/274 vitest tests pass, lint and typecheck clean.
- Verified end-to-end in the running app via agent-browser against a seeded Postgres: create/rename worksheet, database selection, autosave (Saving/Saved), query run showing results, `pg_sleep(30)` + instant cancel, and persistence across app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)