### PR TITLE
Build Postgres connections with discrete fields

### DIFF
--- a/src/databases/postgres-adapter.test.ts
+++ b/src/databases/postgres-adapter.test.ts
@@ -177,7 +177,7 @@ describe('PostgresAdapter', () => {
       expect(mockEnd).toHaveBeenCalled()
     })
 
-    it('uses connection string without ssl when sslMode is disable', async () => {
+    it('passes discrete connection fields without ssl when sslMode is disable', async () => {
       mockQuery.mockResolvedValueOnce({ fields: [], rowCount: 0, rows: [] })
 
       const adapter = new PostgresAdapter({
@@ -188,7 +188,69 @@ describe('PostgresAdapter', () => {
       await adapter.runQuery('SELECT 1')
 
       expect(Client).toHaveBeenCalledWith({
-        connectionString: 'postgresql://testuser:secret@localhost:5432/testdb'
+        database: 'testdb',
+        host: 'localhost',
+        password: 'secret',
+        port: 5432,
+        user: 'testuser'
+      })
+    })
+
+    it('passes passwords with special characters verbatim', async () => {
+      mockQuery.mockResolvedValueOnce({ fields: [], rowCount: 0, rows: [] })
+
+      const adapter = new PostgresAdapter({
+        ...connectionInfo,
+        password: 'p@ss:w/rd#?'
+      })
+
+      await adapter.runQuery('SELECT 1')
+
+      expect(Client).toHaveBeenCalledWith({
+        database: 'testdb',
+        host: 'localhost',
+        password: 'p@ss:w/rd#?',
+        port: 5432,
+        user: 'testuser'
+      })
+    })
+
+    it('defaults the port to 5432 when omitted', async () => {
+      mockQuery.mockResolvedValueOnce({ fields: [], rowCount: 0, rows: [] })
+
+      const adapter = new PostgresAdapter({
+        ...connectionInfo,
+        port: undefined
+      })
+
+      await adapter.runQuery('SELECT 1')
+
+      expect(Client).toHaveBeenCalledWith({
+        database: 'testdb',
+        host: 'localhost',
+        password: 'secret',
+        port: 5432,
+        user: 'testuser'
+      })
+    })
+
+    it('disables certificate verification when sslMode is require', async () => {
+      mockQuery.mockResolvedValueOnce({ fields: [], rowCount: 0, rows: [] })
+
+      const adapter = new PostgresAdapter({
+        ...connectionInfo,
+        sslMode: 'require'
+      })
+
+      await adapter.runQuery('SELECT 1')
+
+      expect(Client).toHaveBeenCalledWith({
+        database: 'testdb',
+        host: 'localhost',
+        password: 'secret',
+        port: 5432,
+        ssl: { rejectUnauthorized: false },
+        user: 'testuser'
       })
     })
   })

--- a/src/databases/postgres-adapter.ts
+++ b/src/databases/postgres-adapter.ts
@@ -157,30 +157,29 @@ export class PostgresAdapter implements DatabaseAdapter {
 }
 
 function createClientConfig(info: PostgresConnectionInfo): ClientConfig {
-  const {
-    username,
-    password,
-    host,
-    port = 5432,
-    database,
-    sslMode,
-    sslRootCert
-  } = info
+  const { database, host, password, port, sslMode, sslRootCert, username } =
+    info
 
-  const connectionString = `postgresql://${username}:${password}@${host}:${port}/${database}`
+  const base: ClientConfig = {
+    database,
+    host,
+    password,
+    port: port ?? 5432,
+    user: username
+  }
 
   if (!sslMode || sslMode === 'disable') {
-    return { connectionString }
+    return base
   }
 
   if (sslMode === 'require') {
-    return { connectionString, ssl: { rejectUnauthorized: false } }
+    return { ...base, ssl: { rejectUnauthorized: false } }
   }
 
   // verify-full
   if (sslRootCert && sslRootCert !== 'system') {
     return {
-      connectionString,
+      ...base,
       ssl: {
         ca: fs.readFileSync(sslRootCert).toString(),
         rejectUnauthorized: true
@@ -188,5 +187,5 @@ function createClientConfig(info: PostgresConnectionInfo): ClientConfig {
     }
   }
 
-  return { connectionString, ssl: { rejectUnauthorized: true } }
+  return { ...base, ssl: { rejectUnauthorized: true } }
 }

--- a/todo.md
+++ b/todo.md
@@ -31,7 +31,7 @@ at the code to change.
       `~/.../squeal.sqlite3`. Encrypt secrets with Electron `safeStorage`
       (OS-keychain backed) before persisting, and never return the password to
       the renderer in `GET /databases`.
-- [ ] **Build the Postgres connection with discrete fields, not string
+- [x] **Build the Postgres connection with discrete fields, not string
       interpolation.** `src/databases/postgres-adapter.ts:169` interpolates
       `postgresql://${username}:${password}@...`; a password containing
       `@ / : # ?` corrupts the URL. Pass a `ClientConfig` object


### PR DESCRIPTION
## Security: stop interpolating credentials into the connection URL

`createClientConfig` in `src/databases/postgres-adapter.ts` built the connection as `postgresql://${username}:${password}@${host}:${port}/${database}`. A password containing `@ : / # ?` corrupts the URL — at best the connection fails, at worst parts of the password are parsed as host/path components.

### Changes

- Pass a discrete `ClientConfig` (`{ database, host, password, port, user }`) to `pg`, mirroring the existing pattern in `mysql-adapter.ts`. The four SSL branches are unchanged, now spreading the base config.
- Updated the existing config assertion and added tests for special-character passwords, the default port, and `sslMode: 'require'`.
- Ticked the corresponding `todo.md` item.

### Verification

- `yarn vitest run src/databases/postgres-adapter.test.ts` — 13/13 pass
- `yarn lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)