### PR TITLE
Lock down the localhost API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ Ergonomic SQL Client for Humans. Electron desktop app with React frontend.
 
 - **Main process** (`src/main.ts`): Electron app + Hono API server on port 7847
 - **Renderer process** (`src/app/`): React frontend
-- **API routes**: `src/main/queries/`, `src/main/auth/`, `src/main/chat/`
+- **API routes**: `src/databases/`, `src/main/chat/`, `src/main/queries/`,
+  `src/main/worksheets/`
 - **Database**: SQLite via Drizzle for app state, PostgreSQL for user queries
 
 ## Key Files
@@ -14,7 +15,7 @@ Ergonomic SQL Client for Humans. Electron desktop app with React frontend.
 - `src/api.ts` - Hono server setup, mounts all routers
 - `src/database/schema.ts` - Drizzle schema definitions
 - `src/main/queries/query-runner.ts` - Executes queries against PostgreSQL
-- `src/main/queries/postgres-adapter.ts` - PostgreSQL connection handling
+- `src/databases/postgres-adapter.ts` - PostgreSQL connection handling
 - `src/app/App.tsx` - Main React component
 
 ## Commands
@@ -27,7 +28,12 @@ Ergonomic SQL Client for Humans. Electron desktop app with React frontend.
 ## Notes
 
 - Native packages (`pg`, `@libsql`) are externalized in `vite.main.config.ts`
-- API base URL in frontend: `http://localhost:7847`
+- API base URL in frontend: `http://127.0.0.1:7847` (the server binds loopback
+  only)
+- The API requires a per-session bearer token on every route except `/health`.
+  The renderer gets it via `window.electron.getApiToken()`; in development the
+  token is printed at startup, so test with
+  `curl -H "Authorization: Bearer <token>" http://127.0.0.1:7847/databases`
 - Query execution is async: POST creates query, poll GET `/queries/:id` for
   results
 - Refer to @CODE_STYLE.md

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,0 +1,63 @@
+import type { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { resetTestDatabase, setupApiMocks } from '@/test/api-test-helper'
+
+setupApiMocks()
+
+import { createApp } from '@/api'
+
+describe('authentication', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+
+    app = createApp({ enableLogging: false, token: 'secret-token' })
+  })
+
+  it('rejects requests without an Authorization header', async () => {
+    const response = await app.request('/databases')
+
+    expect(response.status).toEqual(401)
+    expect(await response.json()).toEqual({
+      error: { message: 'Unauthorized', status: 401 }
+    })
+  })
+
+  it('rejects requests with the wrong token', async () => {
+    const response = await app.request('/databases', {
+      headers: { Authorization: 'Bearer wrong-token' }
+    })
+
+    expect(response.status).toEqual(401)
+    expect(await response.json()).toEqual({
+      error: { message: 'Unauthorized', status: 401 }
+    })
+  })
+
+  it('accepts requests with the correct token', async () => {
+    const response = await app.request('/databases', {
+      headers: { Authorization: 'Bearer secret-token' }
+    })
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ databases: [] })
+  })
+
+  it('allows health checks without a token', async () => {
+    const response = await app.request('/health')
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ status: 'ok' })
+  })
+
+  it('does not require a token when none is configured', async () => {
+    const openApp = createApp({ enableLogging: false })
+
+    const response = await openApp.request('/databases')
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ databases: [] })
+  })
+})

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
 import { prettyJSON } from 'hono/pretty-json'
 import { requestId } from 'hono/request-id'
+import { randomBytes } from 'node:crypto'
 
 import { connectionTestRouter, databaseRouter } from './databases'
 import { chatRouter } from './main/chat/routes'
@@ -13,12 +14,25 @@ import { worksheetRouter } from './main/worksheets'
 
 export const apiPort = 7847
 
+// 'null' is the Origin a packaged renderer sends when loaded from file://.
+const defaultAllowedOrigins = ['null']
+
 export interface CreateAppOptions {
+  allowedOrigins?: string[]
   enableLogging?: boolean
+  token?: string
+}
+
+export interface StartServerOptions {
+  allowedOrigins?: string[]
 }
 
 export function createApp(options: CreateAppOptions = {}) {
-  const { enableLogging = true } = options
+  const {
+    allowedOrigins = defaultAllowedOrigins,
+    enableLogging = true,
+    token
+  } = options
 
   const app = new Hono()
 
@@ -29,7 +43,33 @@ export function createApp(options: CreateAppOptions = {}) {
   }
 
   app.use('*', prettyJSON())
-  app.use('*', cors())
+
+  // CORS runs before auth so OPTIONS preflights (which never carry an
+  // Authorization header) still succeed for the allowed origins.
+  app.use(
+    '*',
+    cors({
+      allowHeaders: ['Authorization', 'Content-Type'],
+      origin: allowedOrigins
+    })
+  )
+
+  if (token) {
+    app.use('*', async (context, next) => {
+      if (context.req.path === '/health') {
+        return next()
+      }
+
+      if (context.req.header('Authorization') !== `Bearer ${token}`) {
+        return context.json(
+          { error: { message: 'Unauthorized', status: 401 } },
+          401
+        )
+      }
+
+      return next()
+    })
+  }
 
   app.get('/health', (c) => {
     return c.json({ status: 'ok' })
@@ -46,15 +86,17 @@ export function createApp(options: CreateAppOptions = {}) {
   return app
 }
 
-export function startServer(port = 3000) {
-  const app = createApp()
+export function startServer(port = 3000, options: StartServerOptions = {}) {
+  const token = randomBytes(32).toString('hex')
+  const app = createApp({ allowedOrigins: options.allowedOrigins, token })
 
   serve({
     fetch: app.fetch,
+    hostname: '127.0.0.1',
     port
   })
 
-  console.log(`API server running on http://localhost:${port}`)
+  console.log(`API server running on http://127.0.0.1:${port}`)
 
-  return port
+  return { port, token }
 }

--- a/src/app/api-client.test.ts
+++ b/src/app/api-client.test.ts
@@ -61,10 +61,13 @@ describe('apiClient', () => {
       await apiClient.createDatabase(request)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:7847/databases',
+        'http://127.0.0.1:7847/databases',
         {
           body: JSON.stringify(request),
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            Authorization: 'Bearer test-token',
+            'Content-Type': 'application/json'
+          },
           method: 'POST'
         }
       )
@@ -133,7 +136,14 @@ describe('apiClient', () => {
       await apiClient.getDatabaseSchema(databaseId)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:7847/databases/db-123/schema'
+        'http://127.0.0.1:7847/databases/db-123/schema',
+        {
+          headers: {
+            Authorization: 'Bearer test-token',
+            'Content-Type': 'application/json'
+          },
+          method: 'GET'
+        }
       )
     })
 
@@ -209,9 +219,12 @@ describe('apiClient', () => {
 
       await apiClient.createQuery(request)
 
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost:7847/queries', {
+      expect(mockFetch).toHaveBeenCalledWith('http://127.0.0.1:7847/queries', {
         body: JSON.stringify(request),
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json'
+        },
         method: 'POST'
       })
     })
@@ -259,7 +272,14 @@ describe('apiClient', () => {
       await apiClient.getQuery(queryId)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:7847/queries/query-123'
+        'http://127.0.0.1:7847/queries/query-123',
+        {
+          headers: {
+            Authorization: 'Bearer test-token',
+            'Content-Type': 'application/json'
+          },
+          method: 'GET'
+        }
       )
     })
 
@@ -315,10 +335,13 @@ describe('apiClient', () => {
       await apiClient.testConnection(connectionInfo, 'postgres')
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:7847/connection-tests',
+        'http://127.0.0.1:7847/connection-tests',
         {
           body: JSON.stringify({ connectionInfo, type: 'postgres' }),
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            Authorization: 'Bearer test-token',
+            'Content-Type': 'application/json'
+          },
           method: 'POST'
         }
       )
@@ -370,10 +393,13 @@ describe('apiClient', () => {
       await apiClient.updateWorksheet(worksheetId, updates)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:7847/worksheets/ws-123',
+        'http://127.0.0.1:7847/worksheets/ws-123',
         {
           body: JSON.stringify(updates),
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            Authorization: 'Bearer test-token',
+            'Content-Type': 'application/json'
+          },
           method: 'PATCH'
         }
       )
@@ -410,10 +436,13 @@ describe('apiClient', () => {
       const result = await apiClient.updateWorksheet(worksheetId, nameUpdate)
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:7847/worksheets/ws-123',
+        'http://127.0.0.1:7847/worksheets/ws-123',
         {
           body: JSON.stringify(nameUpdate),
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            Authorization: 'Bearer test-token',
+            'Content-Type': 'application/json'
+          },
           method: 'PATCH'
         }
       )

--- a/src/app/api-client.ts
+++ b/src/app/api-client.ts
@@ -20,7 +20,7 @@ import {
   UpdateWorksheetResponse
 } from '@/main/worksheets'
 
-const baseUrl = 'http://localhost:7847'
+const baseUrl = 'http://127.0.0.1:7847'
 
 interface CreateDatabaseResponse {
   database: DatabaseDto
@@ -45,6 +45,19 @@ interface ApiErrorResponse {
     message: string
     status: number
   }
+}
+
+interface RequestOptions {
+  body?: unknown
+  method?: string
+}
+
+let apiTokenPromise: Promise<string> | undefined
+
+function getApiToken(): Promise<string> {
+  apiTokenPromise ??= window.electron.getApiToken()
+
+  return apiTokenPromise
 }
 
 function isApiErrorResponse(data: unknown): data is ApiErrorResponse {
@@ -74,17 +87,32 @@ async function handleResponse<T>(response: Response): Promise<T> {
   return data as T
 }
 
+async function apiRequest<T>(
+  path: string,
+  options: RequestOptions = {}
+): Promise<T> {
+  const token = await getApiToken()
+
+  const response = await fetch(`${baseUrl}${path}`, {
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    method: options.method ?? 'GET'
+  })
+
+  return handleResponse<T>(response)
+}
+
 export const apiClient = {
   async createWorksheet(
     request: CreateWorksheetRequest
   ): Promise<WorksheetDto> {
-    const response = await fetch(`${baseUrl}/worksheets`, {
-      body: JSON.stringify(request),
-      headers: { 'Content-Type': 'application/json' },
+    const data = await apiRequest<CreateWorksheetResponse>('/worksheets', {
+      body: request,
       method: 'POST'
     })
-
-    const data = await handleResponse<CreateWorksheetResponse>(response)
 
     return data.worksheet
   },
@@ -92,32 +120,28 @@ export const apiClient = {
   async createDatabase(
     request: CreateDatabaseRequest
   ): Promise<CreateDatabaseResponse> {
-    const response = await fetch(`${baseUrl}/databases`, {
-      body: JSON.stringify(request),
-      headers: { 'Content-Type': 'application/json' },
+    return apiRequest<CreateDatabaseResponse>('/databases', {
+      body: request,
       method: 'POST'
     })
-
-    return handleResponse<CreateDatabaseResponse>(response)
   },
 
   async getDatabases(): Promise<DatabaseDto[]> {
-    const response = await fetch(`${baseUrl}/databases`)
-    const data = await handleResponse<GetDatabasesResponse>(response)
+    const data = await apiRequest<GetDatabasesResponse>('/databases')
 
     return data.databases
   },
 
   async getWorksheets(): Promise<WorksheetDto[]> {
-    const response = await fetch(`${baseUrl}/worksheets`)
-    const data = await handleResponse<ListWorksheetsResponse>(response)
+    const data = await apiRequest<ListWorksheetsResponse>('/worksheets')
 
     return data.worksheets
   },
 
   async getDatabaseSchema(databaseId: string): Promise<SchemaInfo> {
-    const response = await fetch(`${baseUrl}/databases/${databaseId}/schema`)
-    const data = await handleResponse<GetSchemaResponse>(response)
+    const data = await apiRequest<GetSchemaResponse>(
+      `/databases/${databaseId}/schema`
+    )
 
     return data.schema
   },
@@ -129,33 +153,26 @@ export const apiClient = {
     queriedAt: number
     worksheetId: string
   }): Promise<CreateQueryResponse> {
-    const response = await fetch(`${baseUrl}/queries`, {
-      body: JSON.stringify(request),
-      headers: { 'Content-Type': 'application/json' },
+    return apiRequest<CreateQueryResponse>('/queries', {
+      body: request,
       method: 'POST'
     })
-
-    return handleResponse<CreateQueryResponse>(response)
   },
 
   async cancelQuery(queryId: string): Promise<void> {
-    const response = await fetch(`${baseUrl}/queries/${queryId}/cancel`, {
+    await apiRequest<{ success: boolean }>(`/queries/${queryId}/cancel`, {
       method: 'POST'
     })
-
-    await handleResponse<{ success: boolean }>(response)
   },
 
   async getQueries(): Promise<QueryDto[]> {
-    const response = await fetch(`${baseUrl}/queries`)
-    const data = await handleResponse<GetQueriesResponse>(response)
+    const data = await apiRequest<GetQueriesResponse>('/queries')
 
     return data.queries
   },
 
   async getQuery(queryId: string): Promise<QueryDto> {
-    const response = await fetch(`${baseUrl}/queries/${queryId}`)
-    const data = await handleResponse<GetQueryResponse>(response)
+    const data = await apiRequest<GetQueryResponse>(`/queries/${queryId}`)
 
     return data.query
   },
@@ -164,26 +181,20 @@ export const apiClient = {
     connectionInfo: ConnectionInfo,
     type: DatabaseType
   ): Promise<CreateConnectionTestResponse> {
-    const response = await fetch(`${baseUrl}/connection-tests`, {
-      body: JSON.stringify({ connectionInfo, type }),
-      headers: { 'Content-Type': 'application/json' },
+    return apiRequest<CreateConnectionTestResponse>('/connection-tests', {
+      body: { connectionInfo, type },
       method: 'POST'
     })
-
-    return handleResponse<CreateConnectionTestResponse>(response)
   },
 
   async updateDatabase(
     databaseId: string,
     request: CreateDatabaseRequest
   ): Promise<UpdateDatabaseResponse> {
-    const response = await fetch(`${baseUrl}/databases/${databaseId}`, {
-      body: JSON.stringify(request),
-      headers: { 'Content-Type': 'application/json' },
+    return apiRequest<UpdateDatabaseResponse>(`/databases/${databaseId}`, {
+      body: request,
       method: 'PATCH'
     })
-
-    return handleResponse<UpdateDatabaseResponse>(response)
   },
 
   async updateWorksheet(
@@ -195,13 +206,13 @@ export const apiClient = {
       name?: string
     }
   ): Promise<WorksheetDto> {
-    const response = await fetch(`${baseUrl}/worksheets/${worksheetId}`, {
-      body: JSON.stringify(updates),
-      headers: { 'Content-Type': 'application/json' },
-      method: 'PATCH'
-    })
-
-    const data = await handleResponse<UpdateWorksheetResponse>(response)
+    const data = await apiRequest<UpdateWorksheetResponse>(
+      `/worksheets/${worksheetId}`,
+      {
+        body: updates,
+        method: 'PATCH'
+      }
+    )
 
     return data.worksheet
   }

--- a/src/app/types/bootstrap.d.ts
+++ b/src/app/types/bootstrap.d.ts
@@ -1,6 +1,7 @@
 declare global {
   interface Window {
     electron: {
+      getApiToken: () => Promise<string>
       openFileDialog: () => Promise<string | null>
       windowClose: () => Promise<void>
       windowMaximize: () => Promise<void>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,10 @@ if (!app.isPackaged) {
   app.commandLine.appendSwitch('remote-debugging-port', '9222')
 }
 
+let apiToken = ''
+
+ipcMain.handle('get-api-token', () => apiToken)
+
 ipcMain.handle('window-minimize', () => {
   mainWindow?.minimize()
 })
@@ -71,7 +75,19 @@ const createWindow = async () => {
 app.on('ready', async () => {
   await initializeDatabase()
 
-  startServer(apiPort)
+  const allowedOrigins = ['null']
+
+  if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+    allowedOrigins.push(new URL(MAIN_WINDOW_VITE_DEV_SERVER_URL).origin)
+  }
+
+  const { token } = startServer(apiPort, { allowedOrigins })
+
+  apiToken = token
+
+  if (!app.isPackaged) {
+    console.log(`API token: ${apiToken}`)
+  }
 
   createWindow()
 })

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('electron', {
+  getApiToken: () => ipcRenderer.invoke('get-api-token'),
   openFileDialog: () => ipcRenderer.invoke('open-file-dialog'),
   windowClose: () => ipcRenderer.invoke('window-close'),
   windowMaximize: () => ipcRenderer.invoke('window-maximize'),

--- a/todo.md
+++ b/todo.md
@@ -17,7 +17,7 @@ at the code to change.
 
 ## 🔴 Security (do first)
 
-- [ ] **Lock down the localhost API (CORS + auth).** `src/api.ts:32` uses
+- [x] **Lock down the localhost API (CORS + auth).** `src/api.ts:32` uses
       `app.use('*', cors())` — wildcard origin, no auth — on a server that runs
       arbitrary user SQL (`POST /queries`) and returns stored DB credentials
       (`GET /databases`). Any web page the user visits can `fetch` connection

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,13 @@
 import '@testing-library/jest-dom/vitest'
+
+if (typeof window !== 'undefined') {
+  Object.assign(window, {
+    electron: {
+      getApiToken: () => Promise.resolve('test-token'),
+      openFileDialog: () => Promise.resolve(null),
+      windowClose: () => Promise.resolve(),
+      windowMaximize: () => Promise.resolve(),
+      windowMinimize: () => Promise.resolve()
+    }
+  })
+}


### PR DESCRIPTION
## Security: the API on port 7847 was open to any web page and the whole LAN

`serve()` had no hostname (bound to all interfaces), `cors()` reflected any origin, and there was no authentication — so any website in any browser on the machine, or any LAN host, could fetch stored connection info or run arbitrary SQL through `POST /queries`.

### Changes

- **Loopback only:** the server now binds `127.0.0.1` explicitly; the renderer's base URL follows.
- **CORS allow-list:** only the renderer origin is granted — the Vite dev-server origin (passed from `MAIN_WINDOW_VITE_DEV_SERVER_URL`, so it tracks whatever port Vite picks) in development, and the `null` origin the packaged `file://` renderer sends.
- **Per-session bearer token:** generated with `crypto.randomBytes(32)` in the main process, required on every route except `/health`, returning the app's standard error envelope on 401. The renderer fetches it once via a new `getApiToken` preload/IPC call.
- **Single request path:** `api-client.ts` now funnels all ~12 methods through one `apiRequest()` helper that attaches the `Authorization` header, so future changes (like PR C's) touch one place.
- In development the token is logged at startup for manual `curl` use.
- Existing router tests are unaffected: `createApp()` without a `token` installs no auth middleware; auth behavior has dedicated tests in `src/api.test.ts`.

### Verification

- `yarn vitest run` — 281/281 pass (new: 5 auth tests; updated: api-client fetch assertions)
- `yarn lint`, `tsc --noEmit` — clean
- Manual, app running via `yarn start`: `curl /databases` → 401 without token, 200 with the logged token; `/health` → 200 unauthenticated; `lsof` shows the listener on `127.0.0.1:7847` only; preflight with a foreign `Origin` gets no `access-control-allow-origin`, the renderer origin does.
- Drove the UI via agent-browser: worksheets and databases load, a query was created, polled, and cancelled — the full renderer → token → API path works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)