### PR TITLE
Harden the BrowserWindow

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,25 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <title>Squeal</title>
-    <script>
-      ;(function () {
-        try {
-          var stored = localStorage.getItem('theme')
-          var theme = stored
-            ? JSON.parse(stored)
-            : { mode: 'system', name: 'catppuccin' }
-          var mode =
-            theme.mode === 'system'
-              ? window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'dark'
-                : 'light'
-              : theme.mode
-
-          document.documentElement.setAttribute('data-theme', theme.name)
-          document.documentElement.setAttribute('data-mode', mode)
-        } catch (e) {}
-      })()
-    </script>
+    <script
+      type="module"
+      src="/src/theme-bootstrap.ts"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import path from 'node:path'
 import started from 'electron-squirrel-startup'
 
@@ -54,9 +54,32 @@ const createWindow = async () => {
     titleBarStyle: 'hidden',
     trafficLightPosition: { x: 12, y: 8 },
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: path.join(__dirname, 'preload.js'),
+      sandbox: true
     },
     width: 1300
+  })
+
+  // The renderer only ever shows the app itself — deny every navigation away
+  // from it and every attempt to open a child window.
+  const allowedOrigin = MAIN_WINDOW_VITE_DEV_SERVER_URL
+    ? new URL(MAIN_WINDOW_VITE_DEV_SERVER_URL).origin
+    : 'file://'
+
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!url.startsWith(allowedOrigin)) {
+      event.preventDefault()
+    }
+  })
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('https://')) {
+      void shell.openExternal(url)
+    }
+
+    return { action: 'deny' }
   })
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {

--- a/src/theme-bootstrap.ts
+++ b/src/theme-bootstrap.ts
@@ -1,0 +1,28 @@
+// Applies the stored theme before first paint to avoid a flash of the wrong
+// mode. Loaded from index.html instead of an inline script so the renderer
+// works under a script-src 'self' Content-Security-Policy.
+
+interface StoredTheme {
+  mode: string
+  name: string
+}
+
+try {
+  const stored = localStorage.getItem('theme')
+  const theme: StoredTheme = stored
+    ? (JSON.parse(stored) as StoredTheme)
+    : { mode: 'system', name: 'catppuccin' }
+  const mode =
+    theme.mode === 'system'
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
+      : theme.mode
+
+  document.documentElement.setAttribute('data-theme', theme.name)
+  document.documentElement.setAttribute('data-mode', mode)
+} catch {
+  // A malformed stored theme falls back to the default styling.
+}
+
+export {}

--- a/todo.md
+++ b/todo.md
@@ -37,11 +37,11 @@ at the code to change.
       `@ / : # ?` corrupts the URL. Pass a `ClientConfig` object
       (`{ user, password, host, port, database }`) like `mysql-adapter.ts:89`
       already does.
-- [ ] **Harden `BrowserWindow`.** `src/main.ts:56-58` sets only `preload`. Set
+- [x] **Harden `BrowserWindow`.** `src/main.ts:56-58` sets only `preload`. Set
       `contextIsolation: true`, `nodeIntegration: false`, `sandbox: true`
       explicitly, add a `will-navigate` / `setWindowOpenHandler` deny handler,
       and ship a Content-Security-Policy on the renderer.
-- [ ] **Confirm CDP debug port 9222 can never ship.** `src/main.ts:8-10` guards
+- [x] **Confirm CDP debug port 9222 can never ship.** `src/main.ts:8-10` guards
       it behind `!app.isPackaged` (correct) — just verify no build path leaves
       `isPackaged` false in a released artifact.
 

--- a/vite.renderer.config.mjs
+++ b/vite.renderer.config.mjs
@@ -1,11 +1,43 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
 import path from 'path'
+import { defineConfig } from 'vite'
+
+// Applied to packaged builds only: the dev server needs HMR websockets and
+// react-refresh's inline preamble, which a strict policy would block. The
+// policy ships as a meta tag because the packaged renderer loads from
+// file://, where injecting response headers is not an option.
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "connect-src 'self' http://127.0.0.1:7847 http://localhost:7847",
+  "font-src 'self' data:",
+  "img-src 'self' data:",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'"
+].join('; ')
+
+function injectContentSecurityPolicy() {
+  return {
+    apply: 'build',
+    name: 'inject-content-security-policy',
+    transformIndexHtml() {
+      return [
+        {
+          attrs: {
+            content: contentSecurityPolicy,
+            'http-equiv': 'Content-Security-Policy'
+          },
+          injectTo: 'head-prepend',
+          tag: 'meta'
+        }
+      ]
+    }
+  }
+}
 
 // https://vitejs.dev/config
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [injectContentSecurityPolicy(), react(), tailwindcss()],
   resolve: {
     alias: {
       '@': path.resolve(import.meta.dirname, './src')


### PR DESCRIPTION
## Security: pin renderer isolation, deny navigation, and ship a CSP

`webPreferences` set only `preload`, relying on Electron defaults for isolation; nothing restricted navigation or child windows; and no Content-Security-Policy existed anywhere.

### Changes

- **Explicit isolation:** `contextIsolation: true`, `nodeIntegration: false`, `sandbox: true`. The preload only uses `contextBridge`/`ipcRenderer.invoke`, which are sandbox-safe.
- **Navigation guards:** `will-navigate` blocks any navigation off the app origin (dev-server origin in dev, `file://` when packaged); `setWindowOpenHandler` denies all child windows, forwarding `https:` URLs to the system browser.
- **CSP:** `default-src 'self'; connect-src 'self' http://127.0.0.1:7847 http://localhost:7847; font-src 'self' data:; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'` (both API hosts listed so this is merge-order-independent with #14). Shipped as a **build-time meta tag** via a small Vite plugin (`apply: 'build'`) rather than the `webRequest.onHeadersReceived` header injection originally sketched: the packaged renderer loads from `file://`, where response-header injection doesn't reliably apply, while a meta tag in the built HTML always does. Dev builds get no CSP, so HMR websockets and the react-refresh inline preamble keep working.
- **Theme bootstrap moved** from an inline `<script>` in `index.html` (which `script-src 'self'` would block) to `src/theme-bootstrap.ts`, bundled by Vite as a regular entry.

### Todo item 5: CDP port 9222 cannot ship (verification, no code change)

`src/main.ts:8-10` adds `remote-debugging-port=9222` only when `!app.isPackaged`. All Forge makers (Squirrel, ZIP, RPM, Deb) package the app, so `isPackaged` is true in every released artifact, and the fuses already disable `RunAsNode`, `EnableNodeCliInspectArguments`, and `NODE_OPTIONS`. Empirically, launching the locally packaged binary even with an explicit `--remote-debugging-port` flag did not open a CDP port. Both security todo items are ticked in this PR.

### Verification

- `yarn lint`, `tsc --noEmit`, `yarn vitest run` — clean/passing.
- **Dev (`yarn start` + agent-browser):** app renders with theme applied from the new external script; `typeof require` and `typeof process` are `undefined` in the renderer; `window.electron` bridge intact under sandbox; `location.href = 'https://example.com'` blocked; `window.open('https://…')` opens no in-app window.
- **Packaged build:** extracted the built renderer from `app.asar` — the CSP meta tag is present; served it over HTTP in a browser: React boots, the theme script executes, styles apply, and the console shows **zero CSP violations** (only expected connection-refused errors for the absent API).
- ⚠️ Pre-existing issue found while verifying (not caused by this PR): the locally packaged app hangs before binding the API port — reproduced identically on `main`. It stalls in `initializeDatabase()`, which runs before any code this PR touches. Worth a separate investigation before the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)