### PR TITLE
Encrypt stored connection secrets and stop returning passwords

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,12 @@ Ergonomic SQL Client for Humans. Electron desktop app with React frontend.
 - API base URL in frontend: `http://localhost:7847`
 - Query execution is async: POST creates query, poll GET `/queries/:id` for
   results
+- Database `connectionInfo` is encrypted at rest with Electron `safeStorage`
+  (`enc:v1:` prefix in the `databases` table; see
+  `src/main/databases/secret-storage.ts`). API responses never include
+  passwords — internal callers use `getDatabaseWithSecrets()`, updates with a
+  blank password keep the stored one, and connection tests can pass a
+  `databaseId` to borrow it.
 - Refer to @CODE_STYLE.md
 - Don't include the Claude footer in commits
 

--- a/src/app/api-client.ts
+++ b/src/app/api-client.ts
@@ -1,9 +1,10 @@
 import { CreateConnectionTestResponse } from '@/databases'
 import { SchemaInfo } from '@/databases/adapter'
 import {
-  ConnectionInfo,
   CreateDatabaseRequest,
-  DatabaseType
+  DatabaseType,
+  UpdateConnectionInfo,
+  UpdateDatabaseRequest
 } from '@/databases/schemas'
 import { ApiError } from '@/errors'
 import { DatabaseDto } from '@/glue/databases'
@@ -161,11 +162,12 @@ export const apiClient = {
   },
 
   async testConnection(
-    connectionInfo: ConnectionInfo,
-    type: DatabaseType
+    connectionInfo: UpdateConnectionInfo,
+    type: DatabaseType,
+    databaseId?: string
   ): Promise<CreateConnectionTestResponse> {
     const response = await fetch(`${baseUrl}/connection-tests`, {
-      body: JSON.stringify({ connectionInfo, type }),
+      body: JSON.stringify({ connectionInfo, databaseId, type }),
       headers: { 'Content-Type': 'application/json' },
       method: 'POST'
     })
@@ -175,7 +177,7 @@ export const apiClient = {
 
   async updateDatabase(
     databaseId: string,
-    request: CreateDatabaseRequest
+    request: UpdateDatabaseRequest
   ): Promise<UpdateDatabaseResponse> {
     const response = await fetch(`${baseUrl}/databases/${databaseId}`, {
       body: JSON.stringify(request),

--- a/src/app/components/DatabaseExplorer.test.tsx
+++ b/src/app/components/DatabaseExplorer.test.tsx
@@ -38,7 +38,6 @@ const testDatabase: DatabaseDto = {
   connectionInfo: {
     database: 'testdb',
     host: 'localhost',
-    password: 'secret',
     port: 5432,
     username: 'admin'
   },

--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -169,6 +169,78 @@ describe('DatabaseForm', () => {
     })
   })
 
+  describe('edit mode', () => {
+    const editProps = {
+      databaseId: 'db-123',
+      defaultValues: {
+        connectionInfo: {
+          database: 'mydb',
+          host: 'localhost',
+          port: 5432,
+          username: 'postgres'
+        },
+        name: 'My Database',
+        type: 'postgres' as const
+      }
+    }
+
+    it('sends the databaseId when testing a connection without a password', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        json: () => Promise.resolve({ success: true }),
+        ok: true
+      } as Response)
+
+      renderDatabaseForm(editProps)
+
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('connection-success-icon')
+        ).toBeInTheDocument()
+      })
+
+      const [, requestOptions] = vi.mocked(fetch).mock.calls[0]
+      const body = JSON.parse(String(requestOptions?.body))
+
+      expect(body.databaseId).toEqual('db-123')
+      expect(body.connectionInfo.password).toEqual('')
+    })
+
+    it('submits without a password', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            database: {
+              connectionInfo: editProps.defaultValues.connectionInfo,
+              createdAt: 1704067200000,
+              id: 'db-123',
+              name: 'My Database',
+              type: 'postgres'
+            }
+          }),
+        ok: true
+      } as Response)
+
+      renderDatabaseForm(editProps)
+
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalled()
+      })
+
+      const [url, requestOptions] = vi.mocked(fetch).mock.calls[0]
+
+      expect(String(url)).toContain('/databases/db-123')
+      expect(requestOptions?.method).toEqual('PATCH')
+    })
+  })
+
   it('calls onSuccess with database and worksheet when save succeeds', async () => {
     const user = userEvent.setup()
     const onSuccess = vi.fn()

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -7,17 +7,19 @@ import {
   XCircleIcon
 } from 'lucide-react'
 import { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react'
-import { useForm, type UseFormReturn } from 'react-hook-form'
+import { useForm, type Resolver, type UseFormReturn } from 'react-hook-form'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
 import { CreateConnectionTestResponse } from '@/databases'
 import {
-  ConnectionInfo,
+  CreateDatabaseRequest,
   createDatabaseSchema,
   DatabaseType,
   databaseTypeSchema,
-  SslMode
+  SslMode,
+  UpdateConnectionInfo,
+  updateDatabaseSchema
 } from '@/databases/schemas'
 import { ApiError } from '@/errors'
 import { DatabaseDto } from '@/glue/databases'
@@ -43,8 +45,10 @@ import {
 } from './ui/select'
 import { Separator } from './ui/separator'
 
-type FormInput = z.input<typeof createDatabaseSchema>
-type FormOutput = z.output<typeof createDatabaseSchema>
+// The form is typed off the update schema (optional password); create mode
+// swaps in the create resolver so the password is still required there.
+type FormInput = z.input<typeof updateDatabaseSchema>
+type FormOutput = z.output<typeof updateDatabaseSchema>
 
 export interface DatabaseFormResult {
   database: DatabaseDto
@@ -97,7 +101,9 @@ export function DatabaseForm({
       name: defaultValues?.name ?? '',
       type: defaultType
     },
-    resolver: zodResolver(createDatabaseSchema)
+    resolver: zodResolver(
+      isEditMode ? updateDatabaseSchema : createDatabaseSchema
+    ) as Resolver<FormInput, unknown, FormOutput>
   })
 
   const createDatabase = useCreateDatabase()
@@ -230,7 +236,8 @@ export function DatabaseForm({
           }
         )
       } else {
-        createDatabase.mutate(values, {
+        // The create resolver validated the password, so the cast is safe.
+        createDatabase.mutate(values as CreateDatabaseRequest, {
           onSuccess: handleSuccess,
           onError: handleFailure
         })
@@ -264,8 +271,9 @@ export function DatabaseForm({
 
       Promise.all([
         apiClient.testConnection(
-          normalizedConnectionInfo as ConnectionInfo,
-          databaseType
+          normalizedConnectionInfo as UpdateConnectionInfo,
+          databaseType,
+          databaseId
         ),
         minDelay
       ])
@@ -384,7 +392,12 @@ export function DatabaseForm({
           onTypeChange={handleTypeChange}
         />
 
-        {databaseType !== 'sqlite' && <AuthenticationSection form={form} />}
+        {databaseType !== 'sqlite' && (
+          <AuthenticationSection
+            form={form}
+            isEditMode={isEditMode}
+          />
+        )}
 
         {databaseType !== 'sqlite' &&
           (showAdvanced ? (
@@ -584,9 +597,11 @@ function ConnectionDetailsSection({
 }
 
 function AuthenticationSection({
-  form
+  form,
+  isEditMode
 }: {
   form: DatabaseFormApi
+  isEditMode: boolean
 }): ReactElement {
   return (
     <FormSection>
@@ -624,7 +639,11 @@ function AuthenticationSection({
               <FormLabel>Password</FormLabel>
               <FormControl>
                 <Input
-                  placeholder="password"
+                  placeholder={
+                    isEditMode
+                      ? 'Leave blank to keep current password'
+                      : 'password'
+                  }
                   type="password"
                   {...field}
                   value={field.value ?? ''}

--- a/src/app/components/DatabaseSelector.test.tsx
+++ b/src/app/components/DatabaseSelector.test.tsx
@@ -33,7 +33,6 @@ const testDatabase: DatabaseDto = {
   connectionInfo: {
     database: 'testdb',
     host: 'localhost',
-    password: 'secret',
     port: 5432,
     username: 'admin'
   },

--- a/src/app/components/EditorScreen.test.tsx
+++ b/src/app/components/EditorScreen.test.tsx
@@ -24,7 +24,6 @@ const testDatabase: DatabaseDto = {
   connectionInfo: {
     database: 'testdb',
     host: 'localhost',
-    password: 'secret',
     port: 5432,
     username: 'admin'
   },
@@ -61,8 +60,15 @@ describe('EditorScreen', () => {
       expect(screen.getByLabelText('Host')).toHaveValue('localhost')
       expect(screen.getByLabelText('Port')).toHaveValue(5432)
       expect(screen.getByLabelText('Username')).toHaveValue('admin')
-      expect(screen.getByLabelText('Password')).toHaveValue('secret')
       expect(screen.getByLabelText('Database')).toHaveValue('testdb')
+
+      // Passwords are never returned to the renderer — the field starts
+      // empty and hints that leaving it blank keeps the stored one.
+      expect(screen.getByLabelText('Password')).toHaveValue('')
+      expect(screen.getByLabelText('Password')).toHaveAttribute(
+        'placeholder',
+        'Leave blank to keep current password'
+      )
     })
 
     it('shows a not-found message for an unknown database id', () => {

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -6,7 +6,10 @@ import { apiClient } from '../api-client'
 import { useCollections } from '../collections-context'
 import { queryPollInterval } from './queries'
 import { queryKeys } from '../query-keys'
-import { CreateDatabaseRequest } from '@/databases/schemas'
+import {
+  CreateDatabaseRequest,
+  UpdateDatabaseRequest
+} from '@/databases/schemas'
 import { canceledQueryMessage } from '@/glue/queries'
 import { CreateWorksheetRequest } from '@/glue/worksheets'
 import { QueryDto } from '@/main/queries'
@@ -121,7 +124,7 @@ export function useUpdateDatabase() {
       request
     }: {
       id: string
-      request: CreateDatabaseRequest
+      request: UpdateDatabaseRequest
     }) => apiClient.updateDatabase(id, request),
     onSuccess: (response) => {
       if (databases.status === 'ready') {

--- a/src/databases/databases.test.ts
+++ b/src/databases/databases.test.ts
@@ -6,7 +6,8 @@ import {
   getTestDatabase,
   mockAdapterConfig,
   resetTestDatabase,
-  setupApiMocks
+  setupApiMocks,
+  testEncryptionPrefix
 } from '@/test/api-test-helper'
 
 setupApiMocks()
@@ -117,10 +118,10 @@ describe('POST /databases', () => {
         host: 'localhost',
         port: 5432,
         database: 'production',
-        username: 'admin',
-        password: 'secret'
+        username: 'admin'
       }
     })
+    expect(data.database.connectionInfo.password).toBeUndefined()
     expect(data.database.id).toBeDefined()
     expect(data.database.createdAt).toBeDefined()
   })
@@ -151,6 +152,20 @@ describe('POST /databases', () => {
     expect(rows[0]).toMatchObject({
       name: 'Test DB',
       type: 'mysql'
+    })
+
+    const storedConnectionInfo = (rows[0] as { connectionInfo: string })
+      .connectionInfo
+
+    expect(storedConnectionInfo.startsWith(testEncryptionPrefix)).toEqual(true)
+    expect(
+      JSON.parse(storedConnectionInfo.slice(testEncryptionPrefix.length))
+    ).toEqual({
+      host: 'localhost',
+      port: 3306,
+      database: 'test',
+      username: 'root',
+      password: 'password'
     })
   })
 
@@ -364,10 +379,10 @@ describe('PATCH /databases/:id', () => {
         host: 'newhost.example.com',
         port: 5433,
         database: 'updated',
-        username: 'newuser',
-        password: 'newpass'
+        username: 'newuser'
       }
     })
+    expect(data.database.connectionInfo.password).toBeUndefined()
   })
 
   it('should persist updates to storage', async () => {
@@ -415,6 +430,138 @@ describe('PATCH /databases/:id', () => {
     expect(rows[0]).toMatchObject({
       name: 'After Update',
       type: 'postgres'
+    })
+  })
+
+  it('should keep the stored password when the update omits it', async () => {
+    const database = getTestDatabase()
+    const databaseId = crypto.randomUUID()
+
+    await database.run(sql`
+      INSERT INTO databases (id, name, type, connectionInfo, createdAt)
+      VALUES (
+        ${databaseId},
+        'Keep Password',
+        'postgres',
+        ${JSON.stringify({
+          host: 'localhost',
+          port: 5432,
+          database: 'original',
+          username: 'user',
+          password: 'stored-secret'
+        })},
+        ${Date.now()}
+      )
+    `)
+
+    const response = await app.request(`/databases/${databaseId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Keep Password',
+        type: 'postgres',
+        connectionInfo: {
+          host: 'newhost.example.com',
+          port: 5432,
+          database: 'original',
+          username: 'user'
+        }
+      })
+    })
+
+    expect(response.status).toEqual(200)
+
+    const rows = await database.all<{ connectionInfo: string }>(
+      sql`SELECT connectionInfo FROM databases WHERE id = ${databaseId}`
+    )
+    const storedConnectionInfo = JSON.parse(
+      rows[0].connectionInfo.slice(testEncryptionPrefix.length)
+    )
+
+    expect(storedConnectionInfo).toEqual({
+      database: 'original',
+      host: 'newhost.example.com',
+      password: 'stored-secret',
+      port: 5432,
+      username: 'user'
+    })
+  })
+})
+
+describe('POST /connection-tests with a stored password', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    app = createApp({ enableLogging: false })
+  })
+
+  it('should merge the stored password when the request omits it', async () => {
+    const database = getTestDatabase()
+    const databaseId = crypto.randomUUID()
+
+    await database.run(sql`
+      INSERT INTO databases (id, name, type, connectionInfo, createdAt)
+      VALUES (
+        ${databaseId},
+        'Existing DB',
+        'postgres',
+        ${JSON.stringify({
+          host: 'localhost',
+          port: 5432,
+          database: 'testdb',
+          username: 'user',
+          password: 'stored-secret'
+        })},
+        ${Date.now()}
+      )
+    `)
+
+    const response = await app.request('/connection-tests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        databaseId,
+        type: 'postgres',
+        connectionInfo: {
+          host: 'localhost',
+          port: 5432,
+          database: 'testdb',
+          username: 'user'
+        }
+      })
+    })
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ success: true })
+    expect(mockAdapterConfig.lastConnectionInfo).toEqual({
+      database: 'testdb',
+      host: 'localhost',
+      password: 'stored-secret',
+      port: 5432,
+      username: 'user'
+    })
+  })
+
+  it('should fail when the password is omitted without a databaseId', async () => {
+    const response = await app.request('/connection-tests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'postgres',
+        connectionInfo: {
+          host: 'localhost',
+          port: 5432,
+          database: 'testdb',
+          username: 'user'
+        }
+      })
+    })
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({
+      message: 'Password is required.',
+      success: false
     })
   })
 })

--- a/src/databases/index.ts
+++ b/src/databases/index.ts
@@ -8,11 +8,13 @@ import { SqliteAdapter } from './sqlite-adapter'
 import {
   connectionTestSchema,
   createDatabaseSchema,
+  updateDatabaseSchema,
   type ConnectionInfo,
   type DatabaseType,
   type MysqlConnectionInfo,
   type PostgresConnectionInfo,
-  type SqliteConnectionInfo
+  type SqliteConnectionInfo,
+  type UpdateConnectionInfo
 } from './schemas'
 import { ApiError, ValidationError } from '@/errors'
 import { DatabaseService } from '@/main/databases/database-service'
@@ -40,6 +42,37 @@ function createAdapter(type: DatabaseType, connectionInfo: ConnectionInfo) {
   }
 }
 
+// A test without a password uses the stored one — the renderer never sees
+// passwords, so testing an existing connection sends its databaseId instead.
+async function resolveTestConnectionInfo(
+  connectionInfo: UpdateConnectionInfo,
+  type: DatabaseType,
+  databaseId?: string
+): Promise<ConnectionInfo | null> {
+  const hasPassword = !('username' in connectionInfo) || connectionInfo.password
+
+  if (hasPassword) {
+    return connectionInfo as ConnectionInfo
+  }
+
+  if (!databaseId) {
+    return null
+  }
+
+  const service = new DatabaseService()
+  const stored = await service.getDatabaseWithSecrets(databaseId)
+
+  if (
+    !stored ||
+    stored.type !== type ||
+    !('password' in stored.connectionInfo)
+  ) {
+    return null
+  }
+
+  return { ...connectionInfo, password: stored.connectionInfo.password }
+}
+
 connectionTestRouter.post('/', async (context) => {
   const body = await context.req.json()
   const result = await connectionTestSchema.safeParseAsync(body)
@@ -48,7 +81,20 @@ connectionTestRouter.post('/', async (context) => {
     throw new ValidationError(result.error)
   }
 
-  const adapter = createAdapter(result.data.type, result.data.connectionInfo)
+  const connectionInfo = await resolveTestConnectionInfo(
+    result.data.connectionInfo,
+    result.data.type,
+    result.data.databaseId
+  )
+
+  if (!connectionInfo) {
+    return context.json(
+      { message: 'Password is required.', success: false },
+      200
+    )
+  }
+
+  const adapter = createAdapter(result.data.type, connectionInfo)
 
   try {
     await adapter.testConnection()
@@ -98,7 +144,7 @@ databaseRouter.get('/:id/schema', async (context) => {
   invariant(id, 'Database ID is required')
 
   const service = new DatabaseService()
-  const databaseRecord = await service.getDatabase(id)
+  const databaseRecord = await service.getDatabaseWithSecrets(id)
 
   if (!databaseRecord) {
     throw new ApiError(404, 'Database not found')
@@ -127,7 +173,7 @@ databaseRouter.get('/:id/schema', async (context) => {
 databaseRouter.patch('/:id', async (context) => {
   const { id } = context.req.param()
   const body = await context.req.json()
-  const result = await createDatabaseSchema.safeParseAsync(body)
+  const result = await updateDatabaseSchema.safeParseAsync(body)
 
   if (!result.success) {
     throw new ValidationError(result.error)

--- a/src/databases/schemas.ts
+++ b/src/databases/schemas.ts
@@ -55,11 +55,38 @@ export type ConnectionInfo =
   | PostgresConnectionInfo
   | SqliteConnectionInfo
 
+// The renderer never receives stored passwords — API responses use this shape.
+export type PublicConnectionInfo =
+  | Omit<MysqlConnectionInfo, 'password'>
+  | Omit<PostgresConnectionInfo, 'password'>
+  | SqliteConnectionInfo
+
 export const connectionInfoSchema = z.union([
   mysqlConnectionInfoSchema,
   postgresConnectionInfoSchema,
   sqliteConnectionInfoSchema
 ])
+
+// Updates and connection tests may omit the password to mean "use the stored
+// one" — the main process merges it back in server-side.
+export const updateMysqlConnectionInfoSchema = mysqlConnectionInfoSchema.extend(
+  {
+    password: z.string().optional()
+  }
+)
+
+export const updatePostgresConnectionInfoSchema =
+  postgresConnectionInfoSchema.extend({
+    password: z.string().optional()
+  })
+
+export const updateConnectionInfoSchema = z.union([
+  updateMysqlConnectionInfoSchema,
+  updatePostgresConnectionInfoSchema,
+  sqliteConnectionInfoSchema
+])
+
+export type UpdateConnectionInfo = z.infer<typeof updateConnectionInfoSchema>
 
 export const createDatabaseSchema = z.object({
   connectionInfo: connectionInfoSchema,
@@ -69,7 +96,16 @@ export const createDatabaseSchema = z.object({
 
 export type CreateDatabaseRequest = z.infer<typeof createDatabaseSchema>
 
+export const updateDatabaseSchema = z.object({
+  connectionInfo: updateConnectionInfoSchema,
+  name: z.string().min(1, 'Name is required.'),
+  type: databaseTypeSchema
+})
+
+export type UpdateDatabaseRequest = z.infer<typeof updateDatabaseSchema>
+
 export const connectionTestSchema = z.object({
-  connectionInfo: connectionInfoSchema,
+  connectionInfo: updateConnectionInfoSchema,
+  databaseId: z.string().optional(),
   type: databaseTypeSchema
 })

--- a/src/glue/databases.ts
+++ b/src/glue/databases.ts
@@ -1,7 +1,7 @@
-import { ConnectionInfo, DatabaseType } from '@/databases/schemas'
+import { DatabaseType, PublicConnectionInfo } from '@/databases/schemas'
 
 export interface DatabaseDto {
-  connectionInfo: ConnectionInfo
+  connectionInfo: PublicConnectionInfo
   createdAt: number
   id: string
   name: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import started from 'electron-squirrel-startup'
 
 import { apiPort, startServer } from './api'
 import { initializeDatabase } from './database'
+import { migrateConnectionInfoEncryption } from './main/databases/connection-info-migration'
 
 if (!app.isPackaged) {
   app.commandLine.appendSwitch('remote-debugging-port', '9222')
@@ -70,6 +71,9 @@ const createWindow = async () => {
 
 app.on('ready', async () => {
   await initializeDatabase()
+
+  // safeStorage is only reliable once the app is ready.
+  await migrateConnectionInfoEncryption()
 
   startServer(apiPort)
 

--- a/src/main/databases/connection-info-migration.test.ts
+++ b/src/main/databases/connection-info-migration.test.ts
@@ -1,0 +1,60 @@
+import { sql } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  getTestDatabase,
+  resetTestDatabase,
+  setupApiMocks,
+  testEncryptionPrefix
+} from '@/test/api-test-helper'
+
+setupApiMocks()
+
+import { migrateConnectionInfoEncryption } from './connection-info-migration'
+
+describe('migrateConnectionInfoEncryption', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  it('encrypts legacy plaintext rows', async () => {
+    const database = getTestDatabase()
+    const plaintext = JSON.stringify({ path: '/tmp/test.sqlite3' })
+
+    await database.run(sql`
+      INSERT INTO databases (id, name, type, connectionInfo, createdAt)
+      VALUES ('db-1', 'Legacy', 'sqlite', ${plaintext}, ${1704067200000})
+    `)
+
+    await migrateConnectionInfoEncryption()
+
+    const rows = await database.all<{ connectionInfo: string }>(
+      sql`SELECT connectionInfo FROM databases WHERE id = 'db-1'`
+    )
+
+    expect(rows).toEqual([
+      { connectionInfo: `${testEncryptionPrefix}${plaintext}` }
+    ])
+  })
+
+  it('leaves already-encrypted rows unchanged', async () => {
+    const database = getTestDatabase()
+    const plaintext = JSON.stringify({ path: '/tmp/test.sqlite3' })
+
+    await database.run(sql`
+      INSERT INTO databases (id, name, type, connectionInfo, createdAt)
+      VALUES ('db-1', 'Legacy', 'sqlite', ${plaintext}, ${1704067200000})
+    `)
+
+    await migrateConnectionInfoEncryption()
+    await migrateConnectionInfoEncryption()
+
+    const rows = await database.all<{ connectionInfo: string }>(
+      sql`SELECT connectionInfo FROM databases WHERE id = 'db-1'`
+    )
+
+    expect(rows).toEqual([
+      { connectionInfo: `${testEncryptionPrefix}${plaintext}` }
+    ])
+  })
+})

--- a/src/main/databases/connection-info-migration.ts
+++ b/src/main/databases/connection-info-migration.ts
@@ -1,0 +1,50 @@
+import { eq } from 'drizzle-orm'
+import { log } from 'tiny-typescript-logger'
+
+import { database } from '@/database'
+import { databasesTable } from '@/database/schema'
+import {
+  isEncrypted,
+  safeStorageSecretStorage,
+  type SecretStorage
+} from './secret-storage'
+
+// One-time, idempotent re-encryption of legacy plaintext connectionInfo rows.
+// Rows that are already encrypted carry the enc:v1: prefix and are skipped;
+// when OS encryption is unavailable, encrypt() returns its input and the rows
+// are left as plaintext for a later run.
+export async function migrateConnectionInfoEncryption(
+  secretStorage: SecretStorage = safeStorageSecretStorage
+): Promise<void> {
+  const records = await database
+    .select({
+      connectionInfo: databasesTable.connectionInfo,
+      id: databasesTable.id
+    })
+    .from(databasesTable)
+
+  let migratedCount = 0
+
+  for (const record of records) {
+    if (isEncrypted(record.connectionInfo)) {
+      continue
+    }
+
+    const encrypted = secretStorage.encrypt(record.connectionInfo)
+
+    if (encrypted === record.connectionInfo) {
+      continue
+    }
+
+    await database
+      .update(databasesTable)
+      .set({ connectionInfo: encrypted })
+      .where(eq(databasesTable.id, record.id))
+
+    migratedCount += 1
+  }
+
+  if (migratedCount > 0) {
+    log.info(`Encrypted connection info for ${migratedCount} database(s).`)
+  }
+}

--- a/src/main/databases/database-service.test.ts
+++ b/src/main/databases/database-service.test.ts
@@ -66,6 +66,17 @@ vi.mock('drizzle-orm', () => ({
   isNull: vi.fn((column) => ({ type: 'isNull', column }))
 }))
 
+vi.mock('./secret-storage', () => ({
+  isEncrypted: (value: string) => value.startsWith('enc:v1:test:'),
+  safeStorageSecretStorage: {
+    decrypt: (value: string) =>
+      value.startsWith('enc:v1:test:')
+        ? value.slice('enc:v1:test:'.length)
+        : value,
+    encrypt: (value: string) => `enc:v1:test:${value}`
+  }
+}))
+
 import { DatabaseService } from './database-service'
 
 describe('DatabaseService', () => {
@@ -74,7 +85,7 @@ describe('DatabaseService', () => {
   })
 
   describe('createDatabase', () => {
-    it('should insert a database with serialized connection info', async () => {
+    it('should insert a database with encrypted connection info', async () => {
       const service = new DatabaseService()
       const connectionInfo = {
         database: 'mydb',
@@ -88,14 +99,14 @@ describe('DatabaseService', () => {
 
       expect(mockInsert).toHaveBeenCalled()
       expect(mockValues).toHaveBeenCalledWith({
-        connectionInfo: JSON.stringify(connectionInfo),
+        connectionInfo: `enc:v1:test:${JSON.stringify(connectionInfo)}`,
         name: 'My Database',
         type: 'postgres'
       })
       expect(mockReturning).toHaveBeenCalled()
     })
 
-    it('should return a transformed DatabaseDto', async () => {
+    it('should return a DatabaseDto without the password', async () => {
       const service = new DatabaseService()
       const connectionInfo = {
         database: 'mydb',
@@ -116,7 +127,6 @@ describe('DatabaseService', () => {
           connectionInfo: {
             database: 'testdb',
             host: 'localhost',
-            password: 'secret',
             port: 5432,
             username: 'user'
           },

--- a/src/main/databases/database-service.ts
+++ b/src/main/databases/database-service.ts
@@ -1,16 +1,36 @@
+import { and, eq, isNull } from 'drizzle-orm'
+
 import { database } from '@/database'
 import { databasesTable, worksheetsTable } from '@/database/schema'
-import type { ConnectionInfo, DatabaseType } from '@/databases/schemas'
+import type {
+  ConnectionInfo,
+  DatabaseType,
+  PublicConnectionInfo,
+  UpdateConnectionInfo
+} from '@/databases/schemas'
 import { DatabaseDto } from '@/glue/databases'
 import { WorksheetDto } from '@/glue/worksheets'
-import { and, eq, isNull } from 'drizzle-orm'
+import { safeStorageSecretStorage, type SecretStorage } from './secret-storage'
 
 export interface CreateDatabaseResult {
   database: DatabaseDto
   updatedWorksheet?: WorksheetDto
 }
 
+export interface DatabaseWithSecrets {
+  connectionInfo: ConnectionInfo
+  id: string
+  name: string
+  type: DatabaseType
+}
+
 export class DatabaseService {
+  private readonly secretStorage: SecretStorage
+
+  constructor(secretStorage: SecretStorage = safeStorageSecretStorage) {
+    this.secretStorage = secretStorage
+  }
+
   async createDatabase(
     name: string,
     connectionInfo: ConnectionInfo,
@@ -19,13 +39,15 @@ export class DatabaseService {
     const [record] = await database
       .insert(databasesTable)
       .values({
-        connectionInfo: JSON.stringify(connectionInfo),
+        connectionInfo: this.secretStorage.encrypt(
+          JSON.stringify(connectionInfo)
+        ),
         name,
         type
       })
       .returning()
 
-    const databaseDto = transformDatabase(record)
+    const databaseDto = this.transformDatabase(record)
 
     // If this is the first database and there's a worksheet without a database, connect it.
     const existingDatabases = await database
@@ -78,7 +100,30 @@ export class DatabaseService {
       return null
     }
 
-    return transformDatabase(record)
+    return this.transformDatabase(record)
+  }
+
+  // Returns the decrypted connection info, password included. Main-process
+  // use only (adapter construction) — never send this to the renderer.
+  async getDatabaseWithSecrets(
+    id: string
+  ): Promise<DatabaseWithSecrets | null> {
+    const [record] = await database
+      .select()
+      .from(databasesTable)
+      .where(and(eq(databasesTable.id, id), isNull(databasesTable.deletedAt)))
+      .limit(1)
+
+    if (!record) {
+      return null
+    }
+
+    return {
+      connectionInfo: this.parseConnectionInfo(record.connectionInfo),
+      id: record.id,
+      name: record.name,
+      type: record.type as DatabaseType
+    }
   }
 
   async listDatabases(): Promise<DatabaseDto[]> {
@@ -87,37 +132,87 @@ export class DatabaseService {
       .from(databasesTable)
       .where(isNull(databasesTable.deletedAt))
 
-    return records.map(transformDatabase)
+    return records.map((record) => this.transformDatabase(record))
   }
 
   async updateDatabase(
     id: string,
     name: string,
-    connectionInfo: ConnectionInfo,
+    connectionInfo: UpdateConnectionInfo,
     type: DatabaseType
   ): Promise<DatabaseDto> {
+    const resolvedConnectionInfo = await this.resolveConnectionInfo(
+      id,
+      connectionInfo,
+      type
+    )
+
     const [record] = await database
       .update(databasesTable)
       .set({
-        connectionInfo: JSON.stringify(connectionInfo),
+        connectionInfo: this.secretStorage.encrypt(
+          JSON.stringify(resolvedConnectionInfo)
+        ),
         name,
         type
       })
       .where(eq(databasesTable.id, id))
       .returning()
 
-    return transformDatabase(record)
+    return this.transformDatabase(record)
+  }
+
+  private parseConnectionInfo(value: string): ConnectionInfo {
+    return JSON.parse(this.secretStorage.decrypt(value)) as ConnectionInfo
+  }
+
+  // An update without a password means "keep the stored one" — the renderer
+  // never sees passwords, so edits can't send them back.
+  private async resolveConnectionInfo(
+    id: string,
+    connectionInfo: UpdateConnectionInfo,
+    type: DatabaseType
+  ): Promise<ConnectionInfo> {
+    if (!('username' in connectionInfo) || connectionInfo.password) {
+      return connectionInfo as ConnectionInfo
+    }
+
+    const existing = await this.getDatabaseWithSecrets(id)
+    const storedPassword =
+      existing &&
+      existing.type === type &&
+      'password' in existing.connectionInfo
+        ? existing.connectionInfo.password
+        : ''
+
+    return { ...connectionInfo, password: storedPassword }
+  }
+
+  private transformDatabase(
+    record: typeof databasesTable.$inferSelect
+  ): DatabaseDto {
+    return {
+      connectionInfo: toPublicConnectionInfo(
+        this.parseConnectionInfo(record.connectionInfo)
+      ),
+      createdAt: record.createdAt,
+      id: record.id,
+      name: record.name,
+      type: record.type as DatabaseType
+    }
   }
 }
 
-function transformDatabase(
-  record: typeof databasesTable.$inferSelect
-): DatabaseDto {
-  return {
-    connectionInfo: JSON.parse(record.connectionInfo),
-    createdAt: record.createdAt,
-    id: record.id,
-    name: record.name,
-    type: record.type as DatabaseType
+function toPublicConnectionInfo(
+  connectionInfo: ConnectionInfo
+): PublicConnectionInfo {
+  if (!('password' in connectionInfo)) {
+    return connectionInfo
   }
+
+  const publicInfo: Partial<typeof connectionInfo> = { ...connectionInfo }
+
+  delete publicInfo.password
+
+  return publicInfo as PublicConnectionInfo
 }

--- a/src/main/databases/secret-storage.test.ts
+++ b/src/main/databases/secret-storage.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockDecryptString, mockEncryptString, mockIsEncryptionAvailable } =
+  vi.hoisted(() => ({
+    mockDecryptString: vi.fn(),
+    mockEncryptString: vi.fn(),
+    mockIsEncryptionAvailable: vi.fn()
+  }))
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    decryptString: mockDecryptString,
+    encryptString: mockEncryptString,
+    isEncryptionAvailable: mockIsEncryptionAvailable
+  }
+}))
+
+import { isEncrypted, safeStorageSecretStorage } from './secret-storage'
+
+describe('secretStorage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockIsEncryptionAvailable.mockReturnValue(true)
+    mockEncryptString.mockImplementation((value: string) =>
+      Buffer.from(`sealed(${value})`)
+    )
+    mockDecryptString.mockImplementation((value: Buffer) => {
+      const match = /^sealed\((.*)\)$/.exec(value.toString())
+
+      if (!match) {
+        throw new Error('Not encrypted with this key.')
+      }
+
+      return match[1]
+    })
+  })
+
+  describe('encrypt', () => {
+    it('prefixes encrypted values with enc:v1:', () => {
+      const encrypted = safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(encrypted).toEqual(
+        `enc:v1:${Buffer.from('sealed({"password":"x"})').toString('base64')}`
+      )
+    })
+
+    it('falls back to plaintext when encryption is unavailable', () => {
+      mockIsEncryptionAvailable.mockReturnValue(false)
+
+      const encrypted = safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(encrypted).toEqual('{"password":"x"}')
+      expect(mockEncryptString).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('decrypt', () => {
+    it('round-trips an encrypted value', () => {
+      const encrypted = safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(safeStorageSecretStorage.decrypt(encrypted)).toEqual(
+        '{"password":"x"}'
+      )
+    })
+
+    it('passes legacy plaintext values through unchanged', () => {
+      expect(safeStorageSecretStorage.decrypt('{"password":"x"}')).toEqual(
+        '{"password":"x"}'
+      )
+      expect(mockDecryptString).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isEncrypted', () => {
+    it('detects the encrypted prefix', () => {
+      expect(isEncrypted('enc:v1:abc')).toEqual(true)
+      expect(isEncrypted('{"password":"x"}')).toEqual(false)
+    })
+  })
+})

--- a/src/main/databases/secret-storage.ts
+++ b/src/main/databases/secret-storage.ts
@@ -1,0 +1,47 @@
+import { safeStorage } from 'electron'
+import { log } from 'tiny-typescript-logger'
+
+export interface SecretStorage {
+  decrypt(value: string): string
+  encrypt(value: string): string
+}
+
+const encryptedPrefix = 'enc:v1:'
+
+let warnedAboutUnavailableEncryption = false
+
+export function isEncrypted(value: string): boolean {
+  return value.startsWith(encryptedPrefix)
+}
+
+// Encrypts values with the OS keychain via Electron's safeStorage. Values are
+// stored as `enc:v1:<base64>`; anything without that prefix is treated as
+// legacy plaintext and passed through so existing rows keep working until the
+// boot-time migration re-encrypts them.
+export const safeStorageSecretStorage: SecretStorage = {
+  decrypt(value: string): string {
+    if (!isEncrypted(value)) {
+      return value
+    }
+
+    const encrypted = Buffer.from(value.slice(encryptedPrefix.length), 'base64')
+
+    return safeStorage.decryptString(encrypted)
+  },
+
+  encrypt(value: string): string {
+    if (!safeStorage.isEncryptionAvailable()) {
+      if (!warnedAboutUnavailableEncryption) {
+        warnedAboutUnavailableEncryption = true
+
+        log.warn(
+          'OS keychain encryption is unavailable — storing connection secrets as plaintext.'
+        )
+      }
+
+      return value
+    }
+
+    return `${encryptedPrefix}${safeStorage.encryptString(value).toString('base64')}`
+  }
+}

--- a/src/main/queries/query-runner.ts
+++ b/src/main/queries/query-runner.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm'
+import { eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 
 import { database } from '@/database'
@@ -15,6 +15,7 @@ import type {
   PostgresConnectionInfo,
   SqliteConnectionInfo
 } from '@/databases/schemas'
+import { DatabaseService } from '@/main/databases/database-service'
 
 export const createQuerySchema = z.object({
   content: z.string(),
@@ -81,28 +82,18 @@ class QueryRunner {
 
   private async runQueryInBackground(query: any): Promise<void> {
     try {
-      const [databaseRecord] = await database
-        .select()
-        .from(databasesTable)
-        .where(
-          and(
-            eq(databasesTable.id, query.databaseId),
-            isNull(databasesTable.deletedAt)
-          )
-        )
-        .limit(1)
+      const service = new DatabaseService()
+      const databaseRecord = await service.getDatabaseWithSecrets(
+        query.databaseId
+      )
 
       if (!databaseRecord) {
         throw new Error(`Database not found: ${query.databaseId}`)
       }
 
-      const connectionInfo: ConnectionInfo = JSON.parse(
-        databaseRecord.connectionInfo
-      )
-
       const adapter = createAdapter(
-        databaseRecord.type as DatabaseType,
-        connectionInfo
+        databaseRecord.type,
+        databaseRecord.connectionInfo
       )
 
       this.runningAdapters.set(query.id, adapter)

--- a/src/test/api-test-helper.ts
+++ b/src/test/api-test-helper.ts
@@ -13,6 +13,9 @@ export const mockAdapterConfig = {
     databaseName: 'test_db',
     tables: []
   }),
+  // The connectionInfo the most recently constructed adapter received —
+  // lets tests assert on server-side password merging.
+  lastConnectionInfo: undefined as unknown,
   runQuery: async (): Promise<QueryResult> => ({
     fields: [{ name: 'id' }, { name: 'name' }],
     rowCount: 2,
@@ -27,6 +30,8 @@ export const mockAdapterConfig = {
   }
 }
 
+export const testEncryptionPrefix = 'enc:v1:test:'
+
 /**
  * Sets up the test environment with mocks.
  * Call this at the top of your test file, before any imports that use the database.
@@ -39,9 +44,25 @@ export function setupApiMocks() {
     }
   }))
 
+  // Electron's safeStorage is unavailable in vitest — use a transparent
+  // stand-in with a recognizable prefix so tests can assert on stored values.
+  vi.mock('@/main/databases/secret-storage', () => ({
+    isEncrypted: (value: string) => value.startsWith('enc:v1:test:'),
+    safeStorageSecretStorage: {
+      decrypt: (value: string) =>
+        value.startsWith('enc:v1:test:')
+          ? value.slice('enc:v1:test:'.length)
+          : value,
+      encrypt: (value: string) => `enc:v1:test:${value}`
+    }
+  }))
+
   // Mock the database adapters.
   vi.mock('@/databases/postgres-adapter', () => ({
     PostgresAdapter: class {
+      constructor(connectionInfo: unknown) {
+        mockAdapterConfig.lastConnectionInfo = connectionInfo
+      }
       async getSchema() {
         return mockAdapterConfig.getSchema()
       }
@@ -56,6 +77,9 @@ export function setupApiMocks() {
 
   vi.mock('@/databases/mysql-adapter', () => ({
     MysqlAdapter: class {
+      constructor(connectionInfo: unknown) {
+        mockAdapterConfig.lastConnectionInfo = connectionInfo
+      }
       async getSchema() {
         return mockAdapterConfig.getSchema()
       }
@@ -70,6 +94,9 @@ export function setupApiMocks() {
 
   vi.mock('@/databases/sqlite-adapter', () => ({
     SqliteAdapter: class {
+      constructor(connectionInfo: unknown) {
+        mockAdapterConfig.lastConnectionInfo = connectionInfo
+      }
       async getSchema() {
         return mockAdapterConfig.getSchema()
       }
@@ -91,6 +118,7 @@ export async function resetTestDatabase(): Promise<void> {
   testDatabase = await createTestDatabase()
 
   // Reset mock adapter config to defaults.
+  mockAdapterConfig.lastConnectionInfo = undefined
   mockAdapterConfig.getSchema = async () => ({
     databaseName: 'test_db',
     tables: []

--- a/todo.md
+++ b/todo.md
@@ -25,7 +25,7 @@ at the code to change.
       the app origin, add an `Origin`/`Host` allow-list (DNS-rebinding defense),
       bind explicitly to `127.0.0.1`, and require a per-session token handed to
       the renderer via `preload.ts`.
-- [ ] **Stop storing database passwords in plaintext.**
+- [x] **Stop storing database passwords in plaintext.**
       `src/main/databases/database-service.ts:22,102` writes the full
       `connectionInfo` (including `password`) as plaintext JSON into
       `~/.../squeal.sqlite3`. Encrypt secrets with Electron `safeStorage`


### PR DESCRIPTION
## Security: passwords were stored as plaintext and returned to the renderer

`database-service.ts` wrote the full `connectionInfo` (password included) as plaintext JSON into `squeal.sqlite3`, and every GET/POST/PATCH response handed it straight back to the renderer.

### Changes

**At rest** — the whole `connectionInfo` JSON string is encrypted with Electron `safeStorage` (OS-keychain backed) as `enc:v1:<base64>` via a small `SecretStorage` module. Values without the prefix are treated as legacy plaintext and pass through on decrypt, so nothing breaks mid-transition. When the OS keychain is unavailable (keyring-less Linux), storage falls back to plaintext with a one-time warning — the status quo, never worse. A boot-time, idempotent migration re-encrypts existing rows (runs after `ready`, when safeStorage is reliable).

**Over the wire** — DTOs now use a `PublicConnectionInfo` type with the password omitted; `transformDatabase` strips it. Internal consumers (query runner, schema route, connection tests) use a new `getDatabaseWithSecrets()` so decryption lives in one place. The PATCH route also stops reusing the create schema (it previously *required* a password on every update).

**Edit flow** — since the renderer never sees passwords anymore:
- Updates may omit the password; the server merges the stored one back in (`resolveConnectionInfo`). The edit form's password field starts empty with a "Leave blank to keep current password" placeholder.
- Connection tests accept an optional `databaseId` and borrow the stored password when the field is blank, so "Test Connection" works during edits. A blank password with no `databaseId` fails with a clear message.

### Verification

- `yarn vitest run` — 288/288 (new: secret-storage unit tests, migration tests, PATCH-keeps-password, connection-test-by-id, edit-mode form tests), `yarn lint`, `tsc --noEmit` clean.
- Manual against the real dev app (macOS keychain): booted with an existing plaintext `squeal.sqlite3` → all rows re-encrypted to `enc:v1:`; `GET /databases` returns no password field for any database; schema fetch over a real Postgres connection works (decryption → adapter path); connection test with `databaseId` and no password succeeds; PATCH without a password preserves the stored one (verified by a subsequent successful schema fetch); renderer lists and renders everything normally.

Merge note: lands cleanest after #14 (both touch `api-client.ts`; this side is a trivial rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)