### PR TITLE
Harden the database layer: security, reliability, and resource bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 seed-sqlite/pagila.sqlite
 squeal.sqlite3
+squeal.sqlite3-shm
+squeal.sqlite3-wal
 typings/
 yarn-debug.log*
 yarn-error.log*

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -36,6 +36,19 @@ describe('authentication', () => {
     })
   })
 
+  it('rejects a wrong token of a different length', async () => {
+    const response = await app.request('/databases', {
+      headers: {
+        Authorization: 'Bearer a-much-longer-token-than-the-configured-one'
+      }
+    })
+
+    expect(response.status).toEqual(401)
+    expect(await response.json()).toEqual({
+      error: { message: 'Unauthorized', status: 401 }
+    })
+  })
+
   it('accepts requests with the correct token', async () => {
     const response = await app.request('/databases', {
       headers: { Authorization: 'Bearer secret-token' }
@@ -49,15 +62,9 @@ describe('authentication', () => {
     const response = await app.request('/health')
 
     expect(response.status).toEqual(200)
-    expect(await response.json()).toEqual({ status: 'ok' })
-  })
-
-  it('does not require a token when none is configured', async () => {
-    const openApp = createApp({ enableLogging: false })
-
-    const response = await openApp.request('/databases')
-
-    expect(response.status).toEqual(200)
-    expect(await response.json()).toEqual({ databases: [] })
+    expect(await response.json()).toEqual({
+      encryptionAvailable: true,
+      status: 'ok'
+    })
   })
 })

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,7 +4,7 @@ import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
 import { prettyJSON } from 'hono/pretty-json'
 import { requestId } from 'hono/request-id'
-import { randomBytes } from 'node:crypto'
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 
 import { connectionTestRouter, databaseRouter } from './databases'
 import { chatRouter } from './main/chat/routes'
@@ -20,17 +20,20 @@ const defaultAllowedOrigins = ['null']
 export interface CreateAppOptions {
   allowedOrigins?: string[]
   enableLogging?: boolean
-  token?: string
+  encryptionAvailable?: boolean
+  token: string
 }
 
 export interface StartServerOptions {
   allowedOrigins?: string[]
+  encryptionAvailable?: boolean
 }
 
-export function createApp(options: CreateAppOptions = {}) {
+export function createApp(options: CreateAppOptions) {
   const {
     allowedOrigins = defaultAllowedOrigins,
     enableLogging = true,
+    encryptionAvailable = true,
     token
   } = options
 
@@ -54,25 +57,25 @@ export function createApp(options: CreateAppOptions = {}) {
     })
   )
 
-  if (token) {
-    app.use('*', async (context, next) => {
-      if (context.req.path === '/health') {
-        return next()
-      }
-
-      if (context.req.header('Authorization') !== `Bearer ${token}`) {
-        return context.json(
-          { error: { message: 'Unauthorized', status: 401 } },
-          401
-        )
-      }
-
+  app.use('*', async (context, next) => {
+    if (context.req.path === '/health') {
       return next()
-    })
-  }
+    }
 
+    if (!isAuthorized(context.req.header('Authorization'), token)) {
+      return context.json(
+        { error: { message: 'Unauthorized', status: 401 } },
+        401
+      )
+    }
+
+    return next()
+  })
+
+  // encryptionAvailable tells the renderer whether the OS keychain can
+  // protect stored connection secrets, so it can warn before saving one.
   app.get('/health', (c) => {
-    return c.json({ status: 'ok' })
+    return c.json({ encryptionAvailable, status: 'ok' })
   })
 
   app.route('/connection-tests', connectionTestRouter)
@@ -86,9 +89,24 @@ export function createApp(options: CreateAppOptions = {}) {
   return app
 }
 
+// Hashing both sides first makes timingSafeEqual usable for tokens of unequal
+// length without leaking the length through an early return.
+function isAuthorized(header: string | undefined, token: string): boolean {
+  const presented = header?.startsWith('Bearer ') ? header.slice(7) : ''
+
+  const presentedDigest = createHash('sha256').update(presented).digest()
+  const tokenDigest = createHash('sha256').update(token).digest()
+
+  return timingSafeEqual(presentedDigest, tokenDigest)
+}
+
 export function startServer(port = 3000, options: StartServerOptions = {}) {
   const token = randomBytes(32).toString('hex')
-  const app = createApp({ allowedOrigins: options.allowedOrigins, token })
+  const app = createApp({
+    allowedOrigins: options.allowedOrigins,
+    encryptionAvailable: options.encryptionAvailable,
+    token
+  })
 
   serve({
     fetch: app.fetch,

--- a/src/app/api-client.test.ts
+++ b/src/app/api-client.test.ts
@@ -237,7 +237,12 @@ describe('apiClient', () => {
         finishedAt: 1704067201000,
         id: request.id,
         queriedAt: request.queriedAt,
-        result: { columns: ['id', 'name'], rows: [[1, 'Alice']] },
+        result: {
+          fields: [{ name: 'id' }, { name: 'name' }],
+          rowCount: 1,
+          rows: [{ id: 1, name: 'Alice' }],
+          truncated: false
+        },
         truncated: false,
         worksheetId: request.worksheetId
       }
@@ -261,7 +266,12 @@ describe('apiClient', () => {
         finishedAt: 1704067201000,
         id: queryId,
         queriedAt: 1704067200000,
-        result: { columns: ['?column?'], rows: [[1]] },
+        result: {
+          fields: [{ name: '?column?' }],
+          rowCount: 1,
+          rows: [{ '?column?': 1 }],
+          truncated: false
+        },
         truncated: false,
         worksheetId: 'ws-123'
       }
@@ -292,7 +302,12 @@ describe('apiClient', () => {
         finishedAt: 1704067201000,
         id: queryId,
         queriedAt: 1704067200000,
-        result: { columns: ['?column?'], rows: [[1]] },
+        result: {
+          fields: [{ name: '?column?' }],
+          rowCount: 1,
+          rows: [{ '?column?': 1 }],
+          truncated: false
+        },
         truncated: false,
         worksheetId: 'ws-123'
       }

--- a/src/app/api-client.ts
+++ b/src/app/api-client.ts
@@ -33,6 +33,11 @@ interface GetDatabasesResponse {
   databases: DatabaseDto[]
 }
 
+interface GetHealthResponse {
+  encryptionAvailable: boolean
+  status: string
+}
+
 interface GetSchemaResponse {
   schema: SchemaInfo
 }
@@ -132,10 +137,20 @@ export const apiClient = {
     })
   },
 
+  async deleteDatabase(databaseId: string): Promise<void> {
+    await apiRequest<{ success: boolean }>(`/databases/${databaseId}`, {
+      method: 'DELETE'
+    })
+  },
+
   async getDatabases(): Promise<DatabaseDto[]> {
     const data = await apiRequest<GetDatabasesResponse>('/databases')
 
     return data.databases
+  },
+
+  async getHealth(): Promise<GetHealthResponse> {
+    return apiRequest<GetHealthResponse>('/health')
   },
 
   async getWorksheets(): Promise<WorksheetDto[]> {

--- a/src/app/components/DatabaseExplorer.test.tsx
+++ b/src/app/components/DatabaseExplorer.test.tsx
@@ -12,6 +12,7 @@ import { DatabaseExplorer } from './DatabaseExplorer'
 vi.mock('../api-client', () => ({
   apiClient: {
     createWorksheet: vi.fn(),
+    deleteDatabase: vi.fn(),
     getDatabases: vi.fn(async () => []),
     getQueries: vi.fn(async () => []),
     getWorksheets: vi.fn(async () => []),
@@ -229,6 +230,43 @@ describe('DatabaseExplorer', () => {
     await waitFor(() => {
       expect(store.getState().editor.openWorksheetId).toEqual('ws-users')
     })
+  })
+
+  it('deletes a database after confirming via the action toast', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.deleteDatabase).mockResolvedValue(undefined)
+
+    renderWithProviders(<DatabaseExplorer />, { databases: [testDatabase] })
+
+    fireEvent.contextMenu(screen.getByText('Test Database'))
+
+    await user.click(await screen.findByRole('menuitem', { name: 'Delete' }))
+
+    // The action toast asks for confirmation before anything is deleted.
+    expect(apiClient.deleteDatabase).not.toHaveBeenCalled()
+    expect(await screen.findByText('Delete "Test Database"?')).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(apiClient.deleteDatabase).toHaveBeenCalledWith('db-123')
+    })
+  })
+
+  it('does not delete when the confirmation toast is ignored', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.deleteDatabase).mockClear()
+
+    renderWithProviders(<DatabaseExplorer />, { databases: [testDatabase] })
+
+    fireEvent.contextMenu(screen.getByText('Test Database'))
+
+    await user.click(await screen.findByRole('menuitem', { name: 'Delete' }))
+
+    expect(await screen.findByText('Delete "Test Database"?')).toBeVisible()
+    expect(apiClient.deleteDatabase).not.toHaveBeenCalled()
   })
 
   it('opens the create database screen from the add button', async () => {

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -15,7 +15,8 @@ import {
   Pencil,
   Plus,
   SearchIcon,
-  Table2Icon
+  Table2Icon,
+  Trash2
 } from 'lucide-react'
 import { ReactElement, useCallback } from 'react'
 import { toast } from 'sonner'
@@ -26,7 +27,11 @@ import {
   useDatabaseSchema,
   useDatabaseSchemas
 } from '../hooks/queries'
-import { useCreateWorksheet, useReorderDatabases } from '../hooks/mutations'
+import {
+  useCreateWorksheet,
+  useDeleteDatabase,
+  useReorderDatabases
+} from '../hooks/mutations'
 import {
   staticListStrategy,
   useDropIndicator,
@@ -103,7 +108,8 @@ export function DatabaseExplorer(): ReactElement {
 
   const renderedRows: RenderedDatabaseRow[] = baseRows.map((row) => ({
     ...row,
-    hasMultipleSchemas: multipleSchemasByDatabaseId.get(row.database.id) ?? false
+    hasMultipleSchemas:
+      multipleSchemasByDatabaseId.get(row.database.id) ?? false
   }))
 
   // While a search is settling, some schemas may still be loading, so hold off
@@ -155,6 +161,38 @@ export function DatabaseExplorer(): ReactElement {
       dispatch(uiActions.openEditDatabase(databaseId))
     },
     [dispatch]
+  )
+
+  const deleteDatabase = useDeleteDatabase()
+
+  const handleDeleteDatabase = useCallback(
+    (database: DatabaseDto) => {
+      // Deleting purges the stored secret, so it asks for confirmation via an
+      // action toast — ignoring it is a safe no.
+      toast(`Delete "${database.name}"?`, {
+        action: {
+          label: 'Delete',
+          onClick: () => {
+            deleteDatabase.mutate(database.id, {
+              onError: (error) => {
+                const message =
+                  error instanceof Error ? error.message : 'Unknown error'
+
+                toast.error('Failed to delete database', {
+                  description: message
+                })
+              },
+              onSuccess: () => {
+                toast.success(`Deleted "${database.name}"`)
+              }
+            })
+          }
+        },
+        description:
+          'The stored connection details, including its password, will be removed. Worksheets and query history are kept.'
+      })
+    },
+    [deleteDatabase]
   )
 
   const handleCreateDatabase = useCallback(() => {
@@ -209,6 +247,7 @@ export function DatabaseExplorer(): ReactElement {
                 isExpanded={Boolean(expandedDatabases[row.database.id])}
                 isSortingDisabled={isSortingDisabled}
                 searchMatch={row.searchMatch}
+                onDelete={handleDeleteDatabase}
                 onEdit={handleEditDatabase}
               />
             ))}
@@ -251,6 +290,7 @@ interface DatabaseRowProps {
   hasMultipleSchemas: boolean
   isExpanded: boolean
   isSortingDisabled: boolean
+  onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
   searchMatch?: DatabaseMatch
 }
@@ -261,6 +301,7 @@ function DatabaseRow({
   hasMultipleSchemas,
   isExpanded,
   isSortingDisabled,
+  onDelete,
   onEdit,
   searchMatch
 }: DatabaseRowProps): ReactElement {
@@ -293,7 +334,7 @@ function DatabaseRow({
 
   const tableEntries = searchMatch
     ? searchMatch.tables
-    : schema.data?.tables ?? []
+    : (schema.data?.tables ?? [])
 
   const handleQueryTable = useCallback(
     (tableName: string) => {
@@ -370,6 +411,14 @@ function DatabaseRow({
           >
             <Pencil className="size-3" />
             Edit
+          </ContextMenuItem>
+
+          <ContextMenuItem
+            className="flex items-center gap-2 min-w-32 text-xs text-destructive focus:text-destructive"
+            onClick={() => onDelete(database)}
+          >
+            <Trash2 className="size-3" />
+            Delete
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -1,13 +1,6 @@
-import {
-  closestCenter,
-  DndContext,
-  DragEndEvent,
-  PointerSensor,
-  useSensor,
-  useSensors
-} from '@dnd-kit/core'
+import { closestCenter, DndContext } from '@dnd-kit/core'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
-import { arrayMove, SortableContext, useSortable } from '@dnd-kit/sortable'
+import { SortableContext, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import {
   ChevronRight,
@@ -37,6 +30,7 @@ import {
   useDropIndicator,
   type DropIndicator
 } from '../hooks/use-drop-indicator'
+import { useReorderDrag } from '../hooks/use-reorder-drag'
 import {
   databaseSearchQueryUpdated,
   worksheetSelected
@@ -54,121 +48,59 @@ import {
   ContextMenuItem,
   ContextMenuTrigger
 } from './ui/context-menu'
+import type { SchemaInfo, TableInfo } from '@/databases/adapter'
 import { DatabaseDto } from '@/glue/databases'
 import { DropIndicatorLine } from './DropIndicatorLine'
 
-export function DatabaseExplorer(): ReactElement {
-  const dispatch = useAppDispatch()
-  const databases = useDatabases()
-  const expandedDatabases = useAppSelector(
-    (state) => state.databaseExplorer.expandedDatabases
-  )
+interface RenderedDatabaseRow {
+  database: DatabaseDto
+  hasMultipleSchemas: boolean
+  searchMatch?: DatabaseMatch
+}
 
-  const databaseSearchQuery = useAppSelector(
-    (state) => state.editor.databaseSearchQuery ?? ''
-  )
+// Builds the rows to render: while searching, only databases with a match
+// (and their matching tables) survive; otherwise every database is shown.
+// Each row notes whether its database spans multiple schemas, so duplicate
+// table names (common across schemas) stay distinguishable without adding
+// noise to single-schema databases.
+function computeRenderedRows(
+  databases: DatabaseDto[],
+  schemas: (SchemaInfo | undefined)[],
+  searchQuery: string
+): RenderedDatabaseRow[] {
+  const isSearching = searchQuery.trim().length > 0
 
-  const isSearching = databaseSearchQuery.trim().length > 0
-
-  // Prefetch every schema in the background so search and expansion are instant,
-  // and reuse those results as the source for matching tables and columns.
-  const schemaResults = useDatabaseSchemas(
-    databases.data.map((database) => database.id)
-  )
-
-  const searchMatches = isSearching
-    ? databases.data
-        .map((database, index) =>
-          computeDatabaseMatch(
-            database,
-            schemaResults[index]?.data,
-            databaseSearchQuery
-          )
-        )
-        .filter((match): match is DatabaseMatch => match !== null)
-    : null
-
-  // A table row shows its schema only when its database spans more than one, so
-  // duplicate table names (common across schemas) stay distinguishable without
-  // adding noise to single-schema databases.
-  const multipleSchemasByDatabaseId = new Map<string, boolean>()
-  databases.data.forEach((database, index) => {
-    const schemaTables = schemaResults[index]?.data?.tables ?? []
-    const schemaNames = new Set(schemaTables.map((table) => table.tableSchema))
-
-    multipleSchemasByDatabaseId.set(database.id, schemaNames.size > 1)
-  })
-
-  const baseRows = searchMatches
-    ? searchMatches.map((match) => ({
-        database: match.database,
-        searchMatch: match
-      }))
-    : databases.data.map((database) => ({ database }))
-
-  const renderedRows: RenderedDatabaseRow[] = baseRows.map((row) => ({
-    ...row,
-    hasMultipleSchemas:
-      multipleSchemasByDatabaseId.get(row.database.id) ?? false
+  const rows = databases.map((database, index) => ({
+    database,
+    hasMultipleSchemas: spansMultipleSchemas(schemas[index]),
+    searchMatch: isSearching
+      ? (computeDatabaseMatch(database, schemas[index], searchQuery) ??
+        undefined)
+      : undefined
   }))
 
-  // While a search is settling, some schemas may still be loading, so hold off
-  // on the "no matches" message until they have resolved.
-  const isLoadingSchemas =
-    isSearching && schemaResults.some((result) => result.isLoading)
+  if (!isSearching) {
+    return rows
+  }
 
-  // Reordering a filtered subset is ambiguous, so dragging only works on the
-  // full list.
-  const isSortingDisabled = isSearching
-  const reorderDatabases = useReorderDatabases()
+  return rows.filter((row) => row.searchMatch !== undefined)
+}
 
-  const renderedDatabaseIds = renderedRows.map((row) => row.database.id)
-  const {
-    dropIndicatorFor,
-    handleDragOver,
-    handleDragStart,
-    resetDropIndicator
-  } = useDropIndicator(renderedDatabaseIds)
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+function spansMultipleSchemas(schema: SchemaInfo | undefined): boolean {
+  const schemaNames = new Set(
+    (schema?.tables ?? []).map((table) => table.tableSchema)
   )
 
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event
+  return schemaNames.size > 1
+}
 
-      resetDropIndicator()
-
-      if (!over || active.id === over.id) {
-        return
-      }
-
-      const databaseIds = databases.data.map((database) => database.id)
-      const orderedIds = arrayMove(
-        databaseIds,
-        databaseIds.indexOf(String(active.id)),
-        databaseIds.indexOf(String(over.id))
-      )
-
-      reorderDatabases.mutate(orderedIds)
-    },
-    [databases.data, reorderDatabases, resetDropIndicator]
-  )
-
-  const handleEditDatabase = useCallback(
-    (databaseId: string) => {
-      dispatch(uiActions.openEditDatabase(databaseId))
-    },
-    [dispatch]
-  )
-
+// Deleting purges the stored secret, so it asks for confirmation via an
+// action toast — ignoring it is a safe no.
+function useConfirmedDatabaseDeletion(): (database: DatabaseDto) => void {
   const deleteDatabase = useDeleteDatabase()
 
-  const handleDeleteDatabase = useCallback(
+  return useCallback(
     (database: DatabaseDto) => {
-      // Deleting purges the stored secret, so it asks for confirmation via an
-      // action toast — ignoring it is a safe no.
       toast(`Delete "${database.name}"?`, {
         action: {
           label: 'Delete',
@@ -194,6 +126,110 @@ export function DatabaseExplorer(): ReactElement {
     },
     [deleteDatabase]
   )
+}
+
+// Opens a fresh worksheet querying the given table and marks it as the open,
+// most recently used one.
+function useQueryTableWorksheet(
+  databaseId: string
+): (tableName: string) => void {
+  const createWorksheet = useCreateWorksheet()
+  const dispatch = useAppDispatch()
+  const { worksheets: worksheetsCollection } = useCollections()
+
+  return useCallback(
+    (tableName: string) => {
+      createWorksheet.mutate(
+        {
+          content: `SELECT * FROM ${tableName} LIMIT 100`,
+          databaseId,
+          name: tableName
+        },
+        {
+          onSuccess: (worksheet) => {
+            dispatch(worksheetSelected(worksheet.id))
+
+            if (worksheetsCollection.status === 'ready') {
+              const transaction = worksheetsCollection.update(
+                worksheet.id,
+                (draft) => {
+                  draft.lastOpenedAt = Date.now()
+                }
+              )
+
+              void transaction.isPersisted.promise.catch((): void => undefined)
+            }
+          },
+          onError: (error) => {
+            const message =
+              error instanceof Error ? error.message : 'Unknown error'
+
+            toast.error('Failed to create worksheet', { description: message })
+          }
+        }
+      )
+    },
+    [createWorksheet, databaseId, dispatch, worksheetsCollection]
+  )
+}
+
+export function DatabaseExplorer(): ReactElement {
+  const dispatch = useAppDispatch()
+  const databases = useDatabases()
+  const expandedDatabases = useAppSelector(
+    (state) => state.databaseExplorer.expandedDatabases
+  )
+
+  const databaseSearchQuery = useAppSelector(
+    (state) => state.editor.databaseSearchQuery ?? ''
+  )
+
+  const isSearching = databaseSearchQuery.trim().length > 0
+
+  // Prefetch every schema in the background so search and expansion are instant,
+  // and reuse those results as the source for matching tables and columns.
+  const schemaResults = useDatabaseSchemas(
+    databases.data.map((database) => database.id)
+  )
+
+  const renderedRows = computeRenderedRows(
+    databases.data,
+    schemaResults.map((result) => result.data),
+    databaseSearchQuery
+  )
+
+  // While a search is settling, some schemas may still be loading, so hold off
+  // on the "no matches" message until they have resolved.
+  const isLoadingSchemas =
+    isSearching && schemaResults.some((result) => result.isLoading)
+
+  // Reordering a filtered subset is ambiguous, so dragging only works on the
+  // full list.
+  const isSortingDisabled = isSearching
+  const reorderDatabases = useReorderDatabases()
+
+  const renderedDatabaseIds = renderedRows.map((row) => row.database.id)
+  const {
+    dropIndicatorFor,
+    handleDragOver,
+    handleDragStart,
+    resetDropIndicator
+  } = useDropIndicator(renderedDatabaseIds)
+
+  const { handleDragEnd, sensors } = useReorderDrag({
+    ids: databases.data.map((database) => database.id),
+    onReorder: reorderDatabases.mutate,
+    resetDropIndicator
+  })
+
+  const handleEditDatabase = useCallback(
+    (databaseId: string) => {
+      dispatch(uiActions.openEditDatabase(databaseId))
+    },
+    [dispatch]
+  )
+
+  const handleDeleteDatabase = useConfirmedDatabaseDeletion()
 
   const handleCreateDatabase = useCallback(() => {
     dispatch(uiActions.openCreateDatabase())
@@ -278,12 +314,6 @@ export function DatabaseExplorer(): ReactElement {
   )
 }
 
-interface RenderedDatabaseRow {
-  database: DatabaseDto
-  hasMultipleSchemas: boolean
-  searchMatch?: DatabaseMatch
-}
-
 interface DatabaseRowProps {
   database: DatabaseDto
   dropIndicator: DropIndicator
@@ -293,6 +323,14 @@ interface DatabaseRowProps {
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
   searchMatch?: DatabaseMatch
+}
+
+// While searching, a matching row is forced open to reveal its tables.
+function isRowExpanded(
+  searchMatch: DatabaseMatch | undefined,
+  isExpanded: boolean
+): boolean {
+  return searchMatch ? searchMatch.expandDatabase || isExpanded : isExpanded
 }
 
 function DatabaseRow({
@@ -305,20 +343,7 @@ function DatabaseRow({
   onEdit,
   searchMatch
 }: DatabaseRowProps): ReactElement {
-  const dispatch = useAppDispatch()
-  const expandedTables = useAppSelector(
-    (state) => state.databaseExplorer.expandedTables
-  )
-
-  // While searching, the tables come from the precomputed match and the row is
-  // forced open to reveal them, so the lazy per-row fetch is skipped.
-  const schema = useDatabaseSchema(
-    searchMatch ? undefined : isExpanded ? database.id : undefined
-  )
-
-  const isDatabaseExpanded = searchMatch
-    ? searchMatch.expandDatabase || isExpanded
-    : isExpanded
+  const isDatabaseExpanded = isRowExpanded(searchMatch, isExpanded)
 
   const {
     attributes,
@@ -328,48 +353,6 @@ function DatabaseRow({
     transform,
     transition
   } = useSortable({ disabled: isSortingDisabled, id: database.id })
-
-  const createWorksheet = useCreateWorksheet()
-  const { worksheets: worksheetsCollection } = useCollections()
-
-  const tableEntries = searchMatch
-    ? searchMatch.tables
-    : (schema.data?.tables ?? [])
-
-  const handleQueryTable = useCallback(
-    (tableName: string) => {
-      createWorksheet.mutate(
-        {
-          content: `SELECT * FROM ${tableName} LIMIT 100`,
-          databaseId: database.id,
-          name: tableName
-        },
-        {
-          onSuccess: (worksheet) => {
-            dispatch(worksheetSelected(worksheet.id))
-
-            if (worksheetsCollection.status === 'ready') {
-              const transaction = worksheetsCollection.update(
-                worksheet.id,
-                (draft) => {
-                  draft.lastOpenedAt = Date.now()
-                }
-              )
-
-              void transaction.isPersisted.promise.catch((): void => undefined)
-            }
-          },
-          onError: (error) => {
-            const message =
-              error instanceof Error ? error.message : 'Unknown error'
-
-            toast.error('Failed to create worksheet', { description: message })
-          }
-        }
-      )
-    },
-    [createWorksheet, database.id, dispatch, worksheetsCollection]
-  )
 
   return (
     // The transform lives on the wrapper so an expanded subtree moves with the
@@ -381,115 +364,200 @@ function DatabaseRow({
     >
       {dropIndicator && <DropIndicatorLine position={dropIndicator} />}
 
+      <DatabaseRowHeader
+        database={database}
+        isExpanded={isDatabaseExpanded}
+        // While filtering only dragging is off, so skip the sortable props
+        // entirely — spreading them would mark the row aria-disabled even
+        // though clicking still works.
+        sortableProps={isSortingDisabled ? {} : { ...attributes, ...listeners }}
+        onDelete={onDelete}
+        onEdit={onEdit}
+      />
+
+      {isDatabaseExpanded && (
+        <DatabaseTableList
+          database={database}
+          hasMultipleSchemas={hasMultipleSchemas}
+          searchMatch={searchMatch}
+        />
+      )}
+    </div>
+  )
+}
+
+interface DatabaseRowHeaderProps {
+  database: DatabaseDto
+  isExpanded: boolean
+  onDelete: (database: DatabaseDto) => void
+  onEdit: (databaseId: string) => void
+  sortableProps: Record<string, unknown>
+}
+
+function DatabaseRowHeader({
+  database,
+  isExpanded,
+  onDelete,
+  onEdit,
+  sortableProps
+}: DatabaseRowHeaderProps): ReactElement {
+  const dispatch = useAppDispatch()
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger>
+        <Button
+          {...sortableProps}
+          className="flex justify-start items-center gap-1 -ml-2 px-0 py-1 cursor-default h-5 font-normal w-full"
+          size="sm"
+          variant="ghost"
+          onClick={() => dispatch(expandDatabase(database.id))}
+        >
+          <ChevronRight
+            className={cn(
+              'size-3 transition-transform duration-150',
+              isExpanded ? 'rotate-90' : ''
+            )}
+          />
+          <Database className="size-3" />
+          <span className="text-xs">{database.name}</span>
+        </Button>
+      </ContextMenuTrigger>
+
+      <ContextMenuContent>
+        <ContextMenuItem
+          className="flex items-center gap-2 min-w-32 text-xs"
+          onClick={() => onEdit(database.id)}
+        >
+          <Pencil className="size-3" />
+          Edit
+        </ContextMenuItem>
+
+        <ContextMenuItem
+          className="flex items-center gap-2 min-w-32 text-xs text-destructive focus:text-destructive"
+          onClick={() => onDelete(database)}
+        >
+          <Trash2 className="size-3" />
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+interface DatabaseTableListProps {
+  database: DatabaseDto
+  hasMultipleSchemas: boolean
+  searchMatch?: DatabaseMatch
+}
+
+function DatabaseTableList({
+  database,
+  hasMultipleSchemas,
+  searchMatch
+}: DatabaseTableListProps): ReactElement {
+  const dispatch = useAppDispatch()
+  const expandedTables = useAppSelector(
+    (state) => state.databaseExplorer.expandedTables
+  )
+
+  // While searching, the tables come from the precomputed match, so the lazy
+  // fetch is skipped; otherwise the list only mounts once the row is
+  // expanded, which is exactly when the schema is needed.
+  const schema = useDatabaseSchema(searchMatch ? undefined : database.id)
+
+  const handleQueryTable = useQueryTableWorksheet(database.id)
+
+  const tables = searchMatch?.tables ?? schema.data?.tables ?? []
+
+  return (
+    <div className="flex flex-col gap-0.5 pl-4 pt-1">
+      {tables.map((table) => {
+        // Table names repeat across schemas, so the key must include the
+        // schema — otherwise same-named tables collide and expanding one
+        // toggles them all.
+        const tableKey = `${database.id}-${table.tableSchema}-${table.tableName}`
+
+        return (
+          <DatabaseTableRow
+            key={tableKey}
+            hasMultipleSchemas={hasMultipleSchemas}
+            isExpanded={Boolean(expandedTables[tableKey])}
+            table={table}
+            onQueryTable={handleQueryTable}
+            onToggle={() => dispatch(expandTable(tableKey))}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+interface DatabaseTableRowProps {
+  hasMultipleSchemas: boolean
+  isExpanded: boolean
+  onQueryTable: (tableName: string) => void
+  onToggle: () => void
+  table: TableInfo
+}
+
+function DatabaseTableRow({
+  hasMultipleSchemas,
+  isExpanded,
+  onQueryTable,
+  onToggle,
+  table
+}: DatabaseTableRowProps): ReactElement {
+  return (
+    <div className="border-l border-surface-0">
       <ContextMenu>
         <ContextMenuTrigger>
           <Button
-            // While filtering only dragging is off, so skip the sortable
-            // props entirely — spreading them would mark the row
-            // aria-disabled even though clicking still works.
-            {...(isSortingDisabled ? {} : { ...attributes, ...listeners })}
-            className="flex justify-start items-center gap-1 -ml-2 px-0 py-1 cursor-default h-5 font-normal w-full"
+            className="flex items-center gap-1 px-0 py-0 cursor-default h-5 font-normal"
             size="sm"
             variant="ghost"
-            onClick={() => dispatch(expandDatabase(database.id))}
+            onClick={onToggle}
           >
             <ChevronRight
               className={cn(
                 'size-3 transition-transform duration-150',
-                isDatabaseExpanded ? 'rotate-90' : ''
+                isExpanded ? 'rotate-90' : ''
               )}
             />
-            <Database className="size-3" />
-            <span className="text-xs">{database.name}</span>
+            <Table2Icon className="size-3 shrink-0" />
+            <span className="truncate">{table.tableName}</span>
+
+            {hasMultipleSchemas && (
+              <span className="text-[10px] text-muted-foreground shrink-0">
+                {table.tableSchema}
+              </span>
+            )}
           </Button>
         </ContextMenuTrigger>
 
         <ContextMenuContent>
           <ContextMenuItem
             className="flex items-center gap-2 min-w-32 text-xs"
-            onClick={() => onEdit(database.id)}
+            onClick={() => onQueryTable(table.tableName)}
           >
-            <Pencil className="size-3" />
-            Edit
-          </ContextMenuItem>
-
-          <ContextMenuItem
-            className="flex items-center gap-2 min-w-32 text-xs text-destructive focus:text-destructive"
-            onClick={() => onDelete(database)}
-          >
-            <Trash2 className="size-3" />
-            Delete
+            <SearchIcon className="size-3" />
+            Query Table
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
 
-      {isDatabaseExpanded && (
-        <div className="flex flex-col gap-0.5 pl-4 pt-1">
-          {tableEntries.map((table) => {
-            // Table names repeat across schemas, so the key must include the
-            // schema — otherwise same-named tables collide and expanding one
-            // toggles them all.
-            const tableKey = `${database.id}-${table.tableSchema}-${table.tableName}`
-            const isTableExpanded = Boolean(expandedTables[tableKey])
-
-            return (
-              <div
-                key={tableKey}
-                className="border-l border-surface-0"
-              >
-                <ContextMenu>
-                  <ContextMenuTrigger>
-                    <Button
-                      className="flex items-center gap-1 px-0 py-0 cursor-default h-5 font-normal"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => dispatch(expandTable(tableKey))}
-                    >
-                      <ChevronRight
-                        className={cn(
-                          'size-3 transition-transform duration-150',
-                          isTableExpanded ? 'rotate-90' : ''
-                        )}
-                      />
-                      <Table2Icon className="size-3 shrink-0" />
-                      <span className="truncate">{table.tableName}</span>
-
-                      {hasMultipleSchemas && (
-                        <span className="text-[10px] text-muted-foreground shrink-0">
-                          {table.tableSchema}
-                        </span>
-                      )}
-                    </Button>
-                  </ContextMenuTrigger>
-
-                  <ContextMenuContent>
-                    <ContextMenuItem
-                      className="flex items-center gap-2 min-w-32 text-xs"
-                      onClick={() => handleQueryTable(table.tableName)}
-                    >
-                      <SearchIcon className="size-3" />
-                      Query Table
-                    </ContextMenuItem>
-                  </ContextMenuContent>
-                </ContextMenu>
-
-                {isTableExpanded && (
-                  <div className="flex flex-col pl-4">
-                    {table.columns.map((column) => (
-                      <div
-                        key={`${tableKey}-${column.columnName}`}
-                        className="flex items-center gap-1 px-3 py-0.5 border-l border-surface-0"
-                      >
-                        <span className="text-xs text-muted-foreground">
-                          {column.columnName} ({column.dataType})
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )
-          })}
+      {isExpanded && (
+        <div className="flex flex-col pl-4">
+          {table.columns.map((column) => (
+            <div
+              key={`${table.tableSchema}-${table.tableName}-${column.columnName}`}
+              className="flex items-center gap-1 px-3 py-0.5 border-l border-surface-0"
+            >
+              <span className="text-xs text-muted-foreground">
+                {column.columnName} ({column.dataType})
+              </span>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -16,6 +16,19 @@ import { createCollections } from '../collections'
 import { CollectionsProvider } from '../collections-context'
 import { DatabaseForm } from './DatabaseForm'
 
+// The form asks the backend whether the OS keychain can encrypt secrets; stub
+// the hook so no test consumes the fetch mocks with a health request.
+let encryptionAvailable = true
+
+vi.mock('../hooks/queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks/queries')>()
+
+  return {
+    ...actual,
+    useEncryptionAvailable: () => encryptionAvailable
+  }
+})
+
 // Radix UI Select uses DOM APIs not available in jsdom
 beforeAll(() => {
   Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false)
@@ -64,11 +77,35 @@ function renderDatabaseForm(props: Parameters<typeof DatabaseForm>[0] = {}) {
 
 describe('DatabaseForm', () => {
   beforeEach(() => {
+    encryptionAvailable = true
+
     vi.stubGlobal('fetch', vi.fn())
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  it('warns when the OS keychain cannot encrypt the password', () => {
+    encryptionAvailable = false
+
+    renderDatabaseForm()
+
+    expect(
+      screen.getByText(
+        'Your OS keychain is unavailable — this password will be stored unencrypted on this computer.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('does not warn when the OS keychain is available', () => {
+    renderDatabaseForm()
+
+    expect(
+      screen.queryByText(
+        'Your OS keychain is unavailable — this password will be stored unencrypted on this computer.'
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('renders all form fields', () => {
@@ -416,6 +453,34 @@ describe('DatabaseForm', () => {
       await user.click(screen.getByRole('option', { name: 'Verify Full' }))
 
       expect(screen.getByLabelText('SSL Root Certificate')).toBeInTheDocument()
+    })
+
+    it('shows SSL Root Certificate field when verify-ca is selected', async () => {
+      const user = userEvent.setup()
+
+      renderDatabaseForm()
+
+      await user.click(screen.getByRole('button', { name: /advanced/i }))
+      await user.click(screen.getByRole('combobox', { name: /ssl mode/i }))
+      await user.click(screen.getByRole('option', { name: 'Verify CA' }))
+
+      expect(screen.getByLabelText('SSL Root Certificate')).toBeInTheDocument()
+    })
+
+    it('explains that require does not verify the server identity', async () => {
+      const user = userEvent.setup()
+
+      renderDatabaseForm()
+
+      await user.click(screen.getByRole('button', { name: /advanced/i }))
+      await user.click(screen.getByRole('combobox', { name: /ssl mode/i }))
+      await user.click(screen.getByRole('option', { name: 'Require' }))
+
+      expect(
+        screen.getByText(
+          "Encrypts traffic but does not verify the server's identity."
+        )
+      ).toBeInTheDocument()
     })
 
     it('hides SSL Root Certificate field when switching away from verify-full', async () => {

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -26,6 +26,7 @@ import { DatabaseDto } from '@/glue/databases'
 import { WorksheetDto } from '@/glue/worksheets'
 import { apiClient } from '../api-client'
 import { useCreateDatabase, useUpdateDatabase } from '../hooks/mutations'
+import { useEncryptionAvailable } from '../hooks/queries'
 import { Button } from './ui/button'
 import {
   Form,
@@ -665,6 +666,8 @@ function AuthenticationSection({
   form: DatabaseFormApi
   isEditMode: boolean
 }): ReactElement {
+  const encryptionAvailable = useEncryptionAvailable()
+
   return (
     <FormSection>
       <FormSectionHeader>
@@ -672,6 +675,13 @@ function AuthenticationSection({
       </FormSectionHeader>
 
       <Separator />
+
+      {!encryptionAvailable && (
+        <p className="rounded-md border border-yellow/40 bg-yellow/10 px-3 py-2 text-xs text-yellow">
+          Your OS keychain is unavailable — this password will be stored
+          unencrypted on this computer.
+        </p>
+      )}
 
       <div className="flex items-start gap-4">
         <FormField
@@ -750,16 +760,25 @@ function SslSection({ form }: { form: DatabaseFormApi }): ReactElement {
                 <SelectContent>
                   <SelectItem value="disable">Disabled</SelectItem>
                   <SelectItem value="require">Require</SelectItem>
+                  <SelectItem value="verify-ca">Verify CA</SelectItem>
                   <SelectItem value="verify-full">Verify Full</SelectItem>
                 </SelectContent>
               </Select>
+              {field.value === 'require' && (
+                <p className="text-xs text-muted-foreground">
+                  Encrypts traffic but does not verify the server&apos;s
+                  identity.
+                </p>
+              )}
               <FormMessage />
             </FormItem>
           )}
         />
       </div>
 
-      {form.watch('connectionInfo.sslMode') === 'verify-full' && (
+      {['verify-ca', 'verify-full'].includes(
+        form.watch('connectionInfo.sslMode') ?? ''
+      ) && (
         <FormField
           control={form.control}
           name="connectionInfo.sslRootCert"
@@ -899,7 +918,12 @@ function parseConnectionString(value: string): ParsedConnectionString | null {
 function parseSslMode(url: URL): SslMode | undefined {
   const value = url.searchParams.get('sslmode') ?? url.searchParams.get('ssl')
 
-  if (value === 'disable' || value === 'require' || value === 'verify-full') {
+  if (
+    value === 'disable' ||
+    value === 'require' ||
+    value === 'verify-ca' ||
+    value === 'verify-full'
+  ) {
     return value
   }
 

--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -1,13 +1,6 @@
-import {
-  closestCenter,
-  DndContext,
-  DragEndEvent,
-  PointerSensor,
-  useSensor,
-  useSensors
-} from '@dnd-kit/core'
+import { closestCenter, DndContext } from '@dnd-kit/core'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
-import { arrayMove, SortableContext, useSortable } from '@dnd-kit/sortable'
+import { SortableContext, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { FileBracesIcon, PlusIcon } from 'lucide-react'
 import {
@@ -28,6 +21,7 @@ import {
   useDropIndicator,
   type DropIndicator
 } from '../hooks/use-drop-indicator'
+import { useReorderDrag } from '../hooks/use-reorder-drag'
 import { cn } from '../lib/utils'
 import { useAppDispatch, useAppSelector } from '../store'
 import {
@@ -178,31 +172,11 @@ export function WorksheetExplorer(): ReactElement {
     resetDropIndicator
   } = useDropIndicator(filteredWorksheetIds)
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
-  )
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event
-
-      resetDropIndicator()
-
-      if (!over || active.id === over.id) {
-        return
-      }
-
-      const worksheetIds = worksheets.data.map((worksheet) => worksheet.id)
-      const orderedIds = arrayMove(
-        worksheetIds,
-        worksheetIds.indexOf(String(active.id)),
-        worksheetIds.indexOf(String(over.id))
-      )
-
-      reorderWorksheets.mutate(orderedIds)
-    },
-    [reorderWorksheets, resetDropIndicator, worksheets.data]
-  )
+  const { handleDragEnd, sensors } = useReorderDrag({
+    ids: worksheets.data.map((worksheet) => worksheet.id),
+    onReorder: reorderWorksheets.mutate,
+    resetDropIndicator
+  })
 
   const touchWorksheet = useCallback(
     (worksheetId: string) => {

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -114,6 +114,25 @@ export function useCreateDatabase() {
   })
 }
 
+export function useDeleteDatabase() {
+  const { databases } = useCollections()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (databaseId: string) => apiClient.deleteDatabase(databaseId),
+    onSuccess: (_, databaseId) => {
+      if (databases.status === 'ready') {
+        databases.utils.writeDelete(databaseId)
+      }
+
+      // The backend detaches worksheets that pointed at the database, and the
+      // cached schema belongs to a connection that no longer exists.
+      queryClient.removeQueries({ queryKey: queryKeys.schema(databaseId) })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.worksheets })
+    }
+  })
+}
+
 export function useReorderDatabases() {
   const { databases } = useCollections()
   const queryClient = useQueryClient()

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -53,6 +53,18 @@ export function useQueriesList() {
   )
 }
 
+// Whether the OS keychain can encrypt stored connection secrets. Fetched once
+// per session — it only changes with the OS environment.
+export function useEncryptionAvailable(): boolean {
+  const health = useQuery({
+    queryKey: queryKeys.health,
+    queryFn: () => apiClient.getHealth(),
+    staleTime: Infinity
+  })
+
+  return health.data?.encryptionAvailable ?? true
+}
+
 export function useDatabaseSchema(databaseId: string | undefined) {
   return useQuery<SchemaInfo>({
     queryKey: databaseId ? queryKeys.schema(databaseId) : ['schema', 'noop'],

--- a/src/app/hooks/use-reorder-drag.ts
+++ b/src/app/hooks/use-reorder-drag.ts
@@ -1,0 +1,48 @@
+import {
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+import { useCallback } from 'react'
+
+interface UseReorderDragOptions {
+  ids: string[]
+  onReorder: (orderedIds: string[]) => void
+  resetDropIndicator: () => void
+}
+
+// Shared dnd-kit wiring for the sortable sidebar lists: a pointer sensor with
+// a small activation distance, and a drag-end handler that resets the drop
+// indicator and maps the drop position to a fully reordered id list.
+export function useReorderDrag(options: UseReorderDragOptions) {
+  const { ids, onReorder, resetDropIndicator } = options
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+
+      resetDropIndicator()
+
+      if (!over || active.id === over.id) {
+        return
+      }
+
+      const orderedIds = arrayMove(
+        ids,
+        ids.indexOf(String(active.id)),
+        ids.indexOf(String(over.id))
+      )
+
+      onReorder(orderedIds)
+    },
+    [ids, onReorder, resetDropIndicator]
+  )
+
+  return { handleDragEnd, sensors }
+}

--- a/src/app/query-keys.ts
+++ b/src/app/query-keys.ts
@@ -1,5 +1,6 @@
 export const queryKeys = {
   databases: ['databases'] as const,
+  health: ['health'] as const,
   queries: ['queries'] as const,
   query: (id: string) => ['query', id] as const,
   schema: (databaseId: string) => ['schema', databaseId] as const,

--- a/src/database/add-column-if-missing.test.ts
+++ b/src/database/add-column-if-missing.test.ts
@@ -1,0 +1,48 @@
+import { sql } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/libsql'
+import { describe, expect, it } from 'vitest'
+
+import { addColumnIfMissing } from './add-column-if-missing'
+
+describe('addColumnIfMissing', () => {
+  it('adds a missing column', async () => {
+    const database = drizzle(':memory:')
+
+    await database.run(sql`CREATE TABLE things (id TEXT PRIMARY KEY)`)
+    await addColumnIfMissing(
+      database,
+      sql`ALTER TABLE things ADD COLUMN name TEXT`
+    )
+
+    const rows = await database.all<{ name: string }>(
+      sql`SELECT name FROM pragma_table_info('things') ORDER BY name`
+    )
+
+    expect(rows).toEqual([{ name: 'id' }, { name: 'name' }])
+  })
+
+  it('swallows the duplicate column error', async () => {
+    const database = drizzle(':memory:')
+
+    await database.run(sql`CREATE TABLE things (id TEXT PRIMARY KEY)`)
+    await addColumnIfMissing(
+      database,
+      sql`ALTER TABLE things ADD COLUMN name TEXT`
+    )
+
+    await expect(
+      addColumnIfMissing(database, sql`ALTER TABLE things ADD COLUMN name TEXT`)
+    ).resolves.toEqual(undefined)
+  })
+
+  it('propagates every other error', async () => {
+    const database = drizzle(':memory:')
+
+    await expect(
+      addColumnIfMissing(
+        database,
+        sql`ALTER TABLE missing_table ADD COLUMN name TEXT`
+      )
+    ).rejects.toThrow(/ALTER TABLE missing_table/)
+  })
+})

--- a/src/database/add-column-if-missing.ts
+++ b/src/database/add-column-if-missing.ts
@@ -1,0 +1,34 @@
+import type { SQL } from 'drizzle-orm'
+import type { LibSQLDatabase } from 'drizzle-orm/libsql'
+
+// Startup schema evolution: adding a column that already exists is the one
+// expected, safe failure. Anything else — a locked file, a corrupt database —
+// must surface instead of being swallowed as if the migration succeeded.
+export async function addColumnIfMissing(
+  database: LibSQLDatabase,
+  statement: SQL
+): Promise<void> {
+  try {
+    await database.run(statement)
+  } catch (error) {
+    if (!isDuplicateColumnError(error)) {
+      throw error
+    }
+  }
+}
+
+// Drizzle wraps the driver error, so the tell-tale message sits somewhere in
+// the cause chain rather than on the thrown error itself.
+function isDuplicateColumnError(error: unknown): boolean {
+  let current: unknown = error
+
+  while (current instanceof Error) {
+    if (current.message.includes('duplicate column name')) {
+      return true
+    }
+
+    current = current.cause
+  }
+
+  return false
+}

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import { sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/libsql'
 
+import { addColumnIfMissing } from './add-column-if-missing'
 import { databaseFilePath } from './path'
 import { createTables } from './tables'
 
@@ -9,49 +10,33 @@ export const database = drizzle(databaseFilePath)
 
 // Create tables if they don't exist.
 export async function initializeDatabase() {
+  // WAL keeps readers and the background query writer from blocking each
+  // other, and the busy timeout retries a momentarily locked file instead of
+  // failing instantly.
+  await database.run(sql`PRAGMA busy_timeout = 5000`)
+  await database.run(sql`PRAGMA journal_mode = WAL`)
+
   await createTables(database)
 
-  // Add content column for existing databases that don't have it.
-  await database
-    .run(
-      sql`
-    ALTER TABLE worksheets ADD COLUMN content TEXT NOT NULL DEFAULT ''
-  `
-    )
-    .catch(() => {
-      // Column already exists, ignore error.
-    })
+  // Add columns that predate their tables' current definition. Each helper
+  // call swallows only the "duplicate column name" error.
+  await addColumnIfMissing(
+    database,
+    sql`ALTER TABLE worksheets ADD COLUMN content TEXT NOT NULL DEFAULT ''`
+  )
 
-  // Add lastOpenedAt column for existing databases that don't have it.
-  await database
-    .run(
-      sql`
-    ALTER TABLE worksheets ADD COLUMN lastOpenedAt INTEGER
-  `
-    )
-    .catch(() => {
-      // Column already exists, ignore error.
-    })
+  await addColumnIfMissing(
+    database,
+    sql`ALTER TABLE worksheets ADD COLUMN lastOpenedAt INTEGER`
+  )
 
-  // Add sortOrder column for existing databases that don't have it.
-  await database
-    .run(
-      sql`
-    ALTER TABLE databases ADD COLUMN sortOrder INTEGER
-  `
-    )
-    .catch(() => {
-      // Column already exists, ignore error.
-    })
+  await addColumnIfMissing(
+    database,
+    sql`ALTER TABLE databases ADD COLUMN sortOrder INTEGER`
+  )
 
-  // Add sortOrder column for existing worksheets that don't have it.
-  await database
-    .run(
-      sql`
-    ALTER TABLE worksheets ADD COLUMN sortOrder INTEGER
-  `
-    )
-    .catch(() => {
-      // Column already exists, ignore error.
-    })
+  await addColumnIfMissing(
+    database,
+    sql`ALTER TABLE worksheets ADD COLUMN sortOrder INTEGER`
+  )
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 export const chatsTable = sqliteTable('chats', {
   id: text()
@@ -39,18 +39,30 @@ export const messagesTable = sqliteTable('messages', {
   toolInvocations: text()
 })
 
-export const queriesTable = sqliteTable('queries', {
-  id: text()
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  content: text().notNull(),
-  databaseId: text().notNull(),
-  error: text(),
-  finishedAt: integer(),
-  queriedAt: integer().notNull(),
-  result: text(),
-  worksheetId: text().notNull()
-})
+export const queriesTable = sqliteTable(
+  'queries',
+  {
+    id: text()
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    content: text().notNull(),
+    databaseId: text().notNull(),
+    error: text(),
+    finishedAt: integer(),
+    queriedAt: integer().notNull(),
+    result: text(),
+    worksheetId: text().notNull()
+  },
+  (table) => [
+    // The history list sorts by queriedAt, and retention keeps the newest
+    // query per worksheet — both scan the whole table without these.
+    index('queries_queried_at_index').on(table.queriedAt),
+    index('queries_worksheet_id_queried_at_index').on(
+      table.worksheetId,
+      table.queriedAt
+    )
+  ]
+)
 
 export const worksheetsTable = sqliteTable('worksheets', {
   id: text()

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -49,6 +49,16 @@ export async function createTables(database: LibSQLDatabase): Promise<void> {
   `)
 
   await database.run(sql`
+    CREATE INDEX IF NOT EXISTS queries_queried_at_index
+    ON queries (queriedAt)
+  `)
+
+  await database.run(sql`
+    CREATE INDEX IF NOT EXISTS queries_worksheet_id_queried_at_index
+    ON queries (worksheetId, queriedAt)
+  `)
+
+  await database.run(sql`
     CREATE TABLE IF NOT EXISTS worksheets (
       id TEXT PRIMARY KEY NOT NULL,
       content TEXT NOT NULL DEFAULT '',

--- a/src/databases/adapter.ts
+++ b/src/databases/adapter.ts
@@ -2,6 +2,16 @@
 // off at the driver and flagged as truncated.
 export const maxResultRows = 10_000
 
+// Thrown by adapters when a query is canceled before it ever reaches the
+// server — for example while the connection is still being established.
+export class QueryCanceledError extends Error {
+  constructor() {
+    super('Query canceled.')
+
+    this.name = 'QueryCanceledError'
+  }
+}
+
 export interface QueryResult {
   fields: { name: string }[]
 

--- a/src/databases/databases.test.ts
+++ b/src/databases/databases.test.ts
@@ -3,10 +3,12 @@ import { sql } from 'drizzle-orm'
 import type { Hono } from 'hono'
 
 import {
+  authorizeApp,
   getTestDatabase,
   mockAdapterConfig,
   resetTestDatabase,
   setupApiMocks,
+  testApiToken,
   testEncryptionPrefix
 } from '@/test/api-test-helper'
 
@@ -19,7 +21,7 @@ describe('POST /connection-tests', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should return success when connection succeeds', async () => {
@@ -87,7 +89,7 @@ describe('POST /databases', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should create a database and return it', async () => {
@@ -221,7 +223,7 @@ describe('GET /databases/:id/schema', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should return the schema for a database', async () => {
@@ -327,7 +329,7 @@ describe('PATCH /databases/:id', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should update a database', async () => {
@@ -524,7 +526,7 @@ describe('GET /databases', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should order databases by sortOrder', async () => {
@@ -582,7 +584,7 @@ describe('PUT /databases/order', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should reorder databases and return the full list in the new order', async () => {
@@ -689,7 +691,7 @@ describe('POST /connection-tests with a stored password', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should merge the stored password when the request omits it', async () => {

--- a/src/databases/databases.test.ts
+++ b/src/databases/databases.test.ts
@@ -763,3 +763,112 @@ describe('POST /connection-tests with a stored password', () => {
     })
   })
 })
+
+describe('DELETE /databases/:id', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
+  })
+
+  async function insertDatabase(databaseId: string): Promise<void> {
+    const database = getTestDatabase()
+
+    await database.run(sql`
+      INSERT INTO databases (id, name, type, connectionInfo, createdAt)
+      VALUES (
+        ${databaseId},
+        'Doomed DB',
+        'postgres',
+        ${`enc:v1:test:${JSON.stringify({
+          database: 'doomed',
+          host: 'localhost',
+          password: 'super-secret',
+          port: 5432,
+          username: 'user'
+        })}`},
+        ${Date.now()}
+      )
+    `)
+  }
+
+  it('soft deletes the database and purges the stored secret', async () => {
+    const database = getTestDatabase()
+    const databaseId = crypto.randomUUID()
+
+    await insertDatabase(databaseId)
+
+    const response = await app.request(`/databases/${databaseId}`, {
+      method: 'DELETE'
+    })
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ success: true })
+
+    const rows = await database.all<{
+      connectionInfo: string
+      deletedAt: number | null
+    }>(
+      sql`SELECT connectionInfo, deletedAt FROM databases WHERE id = ${databaseId}`
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].connectionInfo).toEqual('enc:v1:test:{}')
+    expect(rows[0].deletedAt).not.toBeNull()
+  })
+
+  it('removes the database from the list', async () => {
+    const databaseId = crypto.randomUUID()
+
+    await insertDatabase(databaseId)
+    await app.request(`/databases/${databaseId}`, { method: 'DELETE' })
+
+    const response = await app.request('/databases')
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ databases: [] })
+  })
+
+  it('detaches worksheets that pointed at the database', async () => {
+    const database = getTestDatabase()
+    const databaseId = crypto.randomUUID()
+    const worksheetId = crypto.randomUUID()
+
+    await insertDatabase(databaseId)
+
+    await database.run(sql`
+      INSERT INTO worksheets (id, content, createdAt, databaseId, name)
+      VALUES (${worksheetId}, '', ${Date.now()}, ${databaseId}, 'Sheet')
+    `)
+
+    await app.request(`/databases/${databaseId}`, { method: 'DELETE' })
+
+    const rows = await database.all<{ databaseId: string | null }>(
+      sql`SELECT databaseId FROM worksheets WHERE id = ${worksheetId}`
+    )
+
+    expect(rows).toEqual([{ databaseId: null }])
+  })
+
+  it('returns 404 for an unknown database', async () => {
+    const response = await app.request(`/databases/${crypto.randomUUID()}`, {
+      method: 'DELETE'
+    })
+
+    expect(response.status).toEqual(404)
+  })
+
+  it('returns 404 for an already deleted database', async () => {
+    const databaseId = crypto.randomUUID()
+
+    await insertDatabase(databaseId)
+    await app.request(`/databases/${databaseId}`, { method: 'DELETE' })
+
+    const response = await app.request(`/databases/${databaseId}`, {
+      method: 'DELETE'
+    })
+
+    expect(response.status).toEqual(404)
+  })
+})

--- a/src/databases/index.ts
+++ b/src/databases/index.ts
@@ -80,7 +80,11 @@ connectionTestRouter.post('/', async (context) => {
   try {
     await adapter.testConnection()
   } catch (error) {
-    log.error('Connection test failed:', error)
+    // Log only the message — the full driver error object embeds the
+    // connection config (host, user).
+    log.error(
+      `Connection test failed: ${error instanceof Error ? error.message : String(error)}`
+    )
 
     return context.json(
       {
@@ -163,6 +167,18 @@ databaseRouter.get('/:id/schema', async (context) => {
       `Failed to load schema for "${databaseRecord.name}": ${reason}`
     )
   }
+})
+
+databaseRouter.delete('/:id', async (context) => {
+  const { id } = context.req.param()
+
+  invariant(id, 'Database ID is required')
+
+  const service = new DatabaseService()
+
+  await service.deleteDatabase(id)
+
+  return context.json({ success: true })
 })
 
 databaseRouter.patch('/:id', async (context) => {

--- a/src/databases/mysql-adapter.test.ts
+++ b/src/databases/mysql-adapter.test.ts
@@ -165,6 +165,7 @@ describe('MysqlAdapter', () => {
       const result = await adapter.runQuery('SELECT * FROM users')
 
       expect(createConnection).toHaveBeenCalledWith({
+        connectTimeout: 5000,
         database: 'testdb',
         host: 'localhost',
         password: 'secret',

--- a/src/databases/mysql-adapter.ts
+++ b/src/databases/mysql-adapter.ts
@@ -44,8 +44,6 @@ export class MysqlAdapter implements DatabaseAdapter {
     const connection = createConnection(this.getConnectionConfig())
     let destroyed = false
 
-    console.log(`Running query:\n${query}\n`)
-
     try {
       return await new Promise<QueryResult>((resolve, reject) => {
         const rows: Record<string, unknown>[] = []
@@ -81,8 +79,6 @@ export class MysqlAdapter implements DatabaseAdapter {
             // to this query and never pooled.
             connection.destroy()
 
-            console.log(`  ✓ Query executed successfully\n`)
-
             resolve({ fields, rowCount: rows.length, rows, truncated: true })
 
             return
@@ -110,8 +106,6 @@ export class MysqlAdapter implements DatabaseAdapter {
 
           settled = true
 
-          console.log(`  ✓ Query executed successfully\n`)
-
           resolve({
             fields,
             rowCount: affectedRows ?? rows.length,
@@ -128,15 +122,10 @@ export class MysqlAdapter implements DatabaseAdapter {
   }
 
   async testConnection(): Promise<void> {
-    const connection = await mysql.createConnection({
-      ...this.getConnectionConfig(),
-      connectTimeout: 5000
-    })
+    const connection = await mysql.createConnection(this.getConnectionConfig())
 
     try {
       await connection.ping()
-
-      console.log('Connected to database successfully')
     } finally {
       await connection.end()
     }
@@ -148,6 +137,9 @@ export class MysqlAdapter implements DatabaseAdapter {
     const ssl = createSslOptions(this.connectionInfo)
 
     return {
+      // Every connection — queries and schema loads included, not just the
+      // connection test — should give up instead of hanging forever.
+      connectTimeout: 5000,
       database,
       host,
       password,

--- a/src/databases/postgres-adapter.test.ts
+++ b/src/databases/postgres-adapter.test.ts
@@ -107,6 +107,7 @@ vi.mock('pg-cursor', () => {
 
 import { Client } from 'pg'
 
+import { QueryCanceledError } from './adapter'
 import {
   connectWithRetry,
   isTooManyClientsError,
@@ -444,6 +445,7 @@ describe('PostgresAdapter', () => {
       await adapter.runQuery('SELECT 1')
 
       expect(Client).toHaveBeenCalledWith({
+        connectionTimeoutMillis: 10000,
         database: 'testdb',
         host: 'localhost',
         password: 'secret',
@@ -463,6 +465,7 @@ describe('PostgresAdapter', () => {
       await adapter.runQuery('SELECT 1')
 
       expect(Client).toHaveBeenCalledWith({
+        connectionTimeoutMillis: 10000,
         database: 'testdb',
         host: 'localhost',
         password: 'p@ss:w/rd#?',
@@ -482,6 +485,7 @@ describe('PostgresAdapter', () => {
       await adapter.runQuery('SELECT 1')
 
       expect(Client).toHaveBeenCalledWith({
+        connectionTimeoutMillis: 10000,
         database: 'testdb',
         host: 'localhost',
         password: 'secret',
@@ -501,6 +505,7 @@ describe('PostgresAdapter', () => {
       await adapter.runQuery('SELECT 1')
 
       expect(Client).toHaveBeenCalledWith({
+        connectionTimeoutMillis: 10000,
         database: 'testdb',
         host: 'localhost',
         password: 'secret',
@@ -595,5 +600,66 @@ describe('connectWithRetry', () => {
     ).rejects.toThrow('out of slots')
     expect(connect).toHaveBeenCalledTimes(4)
     expect(sleep).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('PostgresAdapter cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    cursorState.closeCount = 0
+    cursorState.createdWith.length = 0
+    cursorState.fixtures.length = 0
+    cursorState.readRequests.length = 0
+
+    mockQuery.mockImplementation((input: unknown) => input)
+  })
+
+  it('fails fast when canceled before connecting', async () => {
+    const adapter = new PostgresAdapter(connectionInfo)
+
+    await adapter.cancel()
+
+    await expect(adapter.runQuery('SELECT 1')).rejects.toEqual(
+      new QueryCanceledError()
+    )
+    expect(mockConnect).not.toHaveBeenCalled()
+  })
+
+  it('aborts a connect in flight and reports the query as canceled', async () => {
+    let rejectConnect: ((error: Error) => void) | undefined
+
+    mockConnect.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectConnect = reject
+        })
+    )
+
+    const adapter = new PostgresAdapter(connectionInfo)
+    const runPromise = adapter.runQuery('SELECT pg_sleep(60)')
+
+    // Give the connect a beat to start so cancel sees the in-flight client.
+    await vi.waitFor(() => {
+      expect(mockConnect).toHaveBeenCalled()
+    })
+
+    await adapter.cancel()
+
+    // Ending the client makes the pending connect reject.
+    expect(mockEnd).toHaveBeenCalled()
+
+    rejectConnect?.(new Error('Connection terminated'))
+
+    await expect(runPromise).rejects.toEqual(new QueryCanceledError())
+  })
+
+  it('does nothing when no query is running', async () => {
+    const adapter = new PostgresAdapter(connectionInfo)
+
+    await adapter.cancel()
+
+    expect(mockConnect).not.toHaveBeenCalled()
+    expect(mockQuery).not.toHaveBeenCalled()
   })
 })

--- a/src/databases/postgres-adapter.ts
+++ b/src/databases/postgres-adapter.ts
@@ -4,8 +4,9 @@ import {
   type QueryResult as DriverQueryResult
 } from 'pg'
 import Cursor from 'pg-cursor'
+import { log } from 'tiny-typescript-logger'
 
-import { maxResultRows } from './adapter'
+import { maxResultRows, QueryCanceledError } from './adapter'
 import type { DatabaseAdapter, QueryResult, SchemaInfo } from './adapter'
 import {
   extractMissingColumn,
@@ -26,17 +27,32 @@ export class PostgresAdapter implements DatabaseAdapter {
 
   private activeClient: Client | null = null
 
+  private canceled = false
+
+  private connectingClient: Client | null = null
+
   constructor(connectionInfo: PostgresConnectionInfo) {
     this.connectionInfo = connectionInfo
   }
 
   async cancel(): Promise<void> {
-    // node-postgres exposes the backend process id at runtime, but it is not
-    // present on the published Client type.
-    const backendProcessId = this.activeClient
-      ? (this.activeClient as unknown as { processID?: number | null })
-          .processID
-      : undefined
+    this.canceled = true
+
+    // A connect still in flight can simply be aborted — ending the client
+    // tears down the socket and the pending connect rejects.
+    const connectingClient = this.connectingClient
+
+    if (connectingClient) {
+      try {
+        await connectingClient.end()
+      } catch {
+        // Aborting is best-effort; the connect rejecting is what matters.
+      }
+
+      return
+    }
+
+    const backendProcessId = getBackendProcessId(this.activeClient)
 
     if (!backendProcessId) {
       return
@@ -44,7 +60,9 @@ export class PostgresAdapter implements DatabaseAdapter {
 
     // Postgres cancellation must be issued over a separate connection — the
     // one running the query is busy — so we open a throwaway client and ask
-    // the server to cancel the running backend.
+    // the server to cancel the running backend. A failed cancel must not
+    // reject the cancel route: the query keeps running and can be canceled
+    // again.
     const cancelClient = new Client(createClientConfig(this.connectionInfo))
 
     try {
@@ -53,17 +71,27 @@ export class PostgresAdapter implements DatabaseAdapter {
       await cancelClient.query('SELECT pg_cancel_backend($1)', [
         backendProcessId
       ])
+    } catch (error) {
+      log.warn(
+        `Could not cancel the running query: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
     } finally {
-      await cancelClient.end()
+      try {
+        await cancelClient.end()
+      } catch {
+        // Cleanup is best-effort.
+      }
     }
   }
 
   async getSchema(): Promise<SchemaInfo> {
-    const client = new Client(createClientConfig(this.connectionInfo))
+    // Introspection goes through the same retrying connect as queries, and is
+    // bounded — a hung catalog scan should never hold a connection forever.
+    const client = await this.acquireConnection({ statement_timeout: 30_000 })
 
     try {
-      await client.connect()
-
       return await this.getSchemaWithClient(client)
     } finally {
       await client.end()
@@ -74,8 +102,6 @@ export class PostgresAdapter implements DatabaseAdapter {
     const client = await this.acquireConnection()
 
     this.activeClient = client
-
-    console.log('Connected to database')
 
     try {
       // Postgres folds unquoted identifiers to lowercase, so a query written
@@ -127,7 +153,7 @@ export class PostgresAdapter implements DatabaseAdapter {
             throw error
           }
 
-          console.log(`  ↻ Retrying with quoted identifiers:\n${rewritten}\n`)
+          log.debug('Retrying with quoted identifiers')
 
           attempted.add(rewritten)
           currentQuery = rewritten
@@ -144,10 +170,23 @@ export class PostgresAdapter implements DatabaseAdapter {
   // server is momentarily at its connection cap (a busy neighbour, a spike of
   // background jobs). Retry a few times with backoff before surfacing a clear,
   // actionable error instead of the raw driver message.
-  private async acquireConnection(): Promise<Client> {
+  private async acquireConnection(
+    configOverrides?: Partial<ClientConfig>
+  ): Promise<Client> {
     return connectWithRetry(
       async () => {
-        const client = new Client(createClientConfig(this.connectionInfo))
+        if (this.canceled) {
+          throw new QueryCanceledError()
+        }
+
+        const client = new Client({
+          ...createClientConfig(this.connectionInfo),
+          ...configOverrides
+        })
+
+        // Exposed so cancel() can abort a connect still in flight instead of
+        // silently doing nothing before the query reaches the server.
+        this.connectingClient = client
 
         try {
           await client.connect()
@@ -162,7 +201,13 @@ export class PostgresAdapter implements DatabaseAdapter {
             // Cleanup is best-effort; the original error matters more.
           }
 
+          if (this.canceled) {
+            throw new QueryCanceledError()
+          }
+
           throw error
+        } finally {
+          this.connectingClient = null
         }
       },
       {
@@ -180,8 +225,6 @@ export class PostgresAdapter implements DatabaseAdapter {
     client: Client,
     query: string
   ): Promise<QueryResult> {
-    console.log(`Running query:\n${query}\n`)
-
     const cursor = client.query(new Cursor<Record<string, unknown>>(query))
     const rows: Record<string, unknown>[] = []
     let lastResult: DriverQueryResult | undefined
@@ -215,8 +258,6 @@ export class PostgresAdapter implements DatabaseAdapter {
         // Closing is best-effort; the original error matters more.
       }
     }
-
-    console.log(`  ✓ Query executed successfully\n`)
 
     const truncated = rows.length > maxResultRows
     const returnedRows = truncated ? rows.slice(0, maxResultRows) : rows
@@ -252,8 +293,6 @@ export class PostgresAdapter implements DatabaseAdapter {
 
     try {
       await client.connect()
-
-      console.log('Connected to database successfully')
     } finally {
       await client.end()
     }
@@ -322,6 +361,18 @@ export async function connectWithRetry<Connection>(
   }
 }
 
+// node-postgres exposes the backend process id at runtime, but it is not
+// present on the published Client type.
+function getBackendProcessId(client: Client | null): number | undefined {
+  if (!client || !('processID' in client)) {
+    return undefined
+  }
+
+  const processId = (client as Client & { processID?: unknown }).processID
+
+  return typeof processId === 'number' ? processId : undefined
+}
+
 export function isTooManyClientsError(error: unknown): boolean {
   const messages =
     error instanceof AggregateError
@@ -341,6 +392,9 @@ function createClientConfig(info: PostgresConnectionInfo): ClientConfig {
   const ssl = createSslOptions(info)
 
   return {
+    // A connect attempt that can hang forever holds the query, the Explorer,
+    // or a cancel hostage; pg's default is no timeout.
+    connectionTimeoutMillis: 10_000,
     database,
     host,
     password,

--- a/src/databases/postgres-adapter.ts
+++ b/src/databases/postgres-adapter.ts
@@ -118,36 +118,17 @@ export class PostgresAdapter implements DatabaseAdapter {
         try {
           return await this.executeQuery(client, currentQuery)
         } catch (error) {
-          const message = error instanceof Error ? error.message : String(error)
-
-          // Columns first: "column "x" of relation "y" does not exist" is a
-          // column problem, yet its message also matches the relation pattern.
-          const missingColumn = extractMissingColumn(message)
-          const missingRelation = missingColumn
-            ? null
-            : extractMissingRelation(message)
-
-          if (!missingColumn && !missingRelation) {
+          if (!isMissingIdentifierError(error)) {
             throw error
           }
 
           schema ??= await this.getSchemaWithClient(client)
 
-          let rewritten: string | null = null
-
-          if (missingColumn) {
-            rewritten = rewriteWithQuotedColumns(
-              currentQuery,
-              schema,
-              missingColumn
-            )
-          } else if (missingRelation) {
-            rewritten = rewriteWithQuotedIdentifiers(
-              currentQuery,
-              schema,
-              missingRelation
-            )
-          }
+          const rewritten = rewriteForMissingIdentifier(
+            currentQuery,
+            schema,
+            error
+          )
 
           if (!rewritten || attempted.has(rewritten)) {
             throw error
@@ -259,17 +240,7 @@ export class PostgresAdapter implements DatabaseAdapter {
       }
     }
 
-    const truncated = rows.length > maxResultRows
-    const returnedRows = truncated ? rows.slice(0, maxResultRows) : rows
-
-    return {
-      fields: (lastResult?.fields ?? []).map((field) => ({ name: field.name })),
-      // When truncated, the statement never completes, so the driver has no
-      // total and we report the number of rows returned instead.
-      rowCount: lastResult?.rowCount ?? returnedRows.length,
-      rows: returnedRows,
-      truncated
-    }
+    return toQueryResult(rows, lastResult)
   }
 
   private async getSchemaWithClient(client: Client): Promise<SchemaInfo> {
@@ -358,6 +329,58 @@ export async function connectWithRetry<Connection>(
 
       await sleep(options.delays[attempt])
     }
+  }
+}
+
+function isMissingIdentifierError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return Boolean(
+    extractMissingColumn(message) ?? extractMissingRelation(message)
+  )
+}
+
+// Columns are checked first: "column "x" of relation "y" does not exist" is a
+// column problem, yet its message also matches the relation pattern. Returns
+// the corrected SQL, or null when no unambiguous rewrite exists.
+function rewriteForMissingIdentifier(
+  query: string,
+  schema: SchemaInfo,
+  error: unknown
+): string | null {
+  const message = error instanceof Error ? error.message : String(error)
+
+  const missingColumn = extractMissingColumn(message)
+
+  if (missingColumn) {
+    return rewriteWithQuotedColumns(query, schema, missingColumn)
+  }
+
+  const missingRelation = extractMissingRelation(message)
+
+  if (missingRelation) {
+    return rewriteWithQuotedIdentifiers(query, schema, missingRelation)
+  }
+
+  return null
+}
+
+// Shapes the buffered driver rows into the adapter result, dropping the extra
+// row read past the cap.
+function toQueryResult(
+  rows: Record<string, unknown>[],
+  lastResult: DriverQueryResult | undefined
+): QueryResult {
+  const truncated = rows.length > maxResultRows
+  const returnedRows = truncated ? rows.slice(0, maxResultRows) : rows
+
+  return {
+    fields: (lastResult?.fields ?? []).map((field) => ({ name: field.name })),
+    // When truncated, the statement never completes, so the driver has no
+    // total and we report the number of rows returned instead.
+    rowCount: lastResult?.rowCount ?? returnedRows.length,
+    rows: returnedRows,
+    truncated
   }
 }
 

--- a/src/databases/postgres-identifier-fixer.test.ts
+++ b/src/databases/postgres-identifier-fixer.test.ts
@@ -155,9 +155,9 @@ describe('rewriteWithQuotedIdentifiers', () => {
 
 describe('extractMissingColumn', () => {
   it('extracts the column name from a standard error', () => {
-    expect(
-      extractMissingColumn('column "platformid" does not exist')
-    ).toEqual('platformid')
+    expect(extractMissingColumn('column "platformid" does not exist')).toEqual(
+      'platformid'
+    )
   })
 
   it('extracts the column from a column-of-relation error', () => {
@@ -173,9 +173,9 @@ describe('extractMissingColumn', () => {
   })
 
   it('returns null for relation errors', () => {
-    expect(
-      extractMissingColumn('relation "employees" does not exist')
-    ).toEqual(null)
+    expect(extractMissingColumn('relation "employees" does not exist')).toEqual(
+      null
+    )
   })
 })
 
@@ -234,7 +234,9 @@ describe('rewriteWithQuotedColumns', () => {
         columnSchema,
         'platformid'
       )
-    ).toEqual('SELECT Id, "PlatformId" FROM Employees WHERE "PlatformId" = \'x\'')
+    ).toEqual(
+      'SELECT Id, "PlatformId" FROM Employees WHERE "PlatformId" = \'x\''
+    )
   })
 
   it('rewrites a lowercase reference to its mixed-case column', () => {

--- a/src/databases/schema-provider.test.ts
+++ b/src/databases/schema-provider.test.ts
@@ -188,9 +188,9 @@ describe('transformToSchemaInfo', () => {
 
     // 'banana' lives in another schema but still slots alphabetically by name
     // instead of being grouped after its schema.
-    expect(result.tables.map((table) => `${table.tableSchema}.${table.tableName}`)).toEqual(
-      ['public.apple', 'admin.banana', 'public.zebra']
-    )
+    expect(
+      result.tables.map((table) => `${table.tableSchema}.${table.tableName}`)
+    ).toEqual(['public.apple', 'admin.banana', 'public.zebra'])
   })
 
   it('falls back to schema order for identically named tables', () => {
@@ -219,9 +219,9 @@ describe('transformToSchemaInfo', () => {
 
     const result = transformToSchemaInfo('testdb', columnRows, [])
 
-    expect(result.tables.map((table) => `${table.tableSchema}.${table.tableName}`)).toEqual(
-      ['archive.orders', 'public.orders']
-    )
+    expect(
+      result.tables.map((table) => `${table.tableSchema}.${table.tableName}`)
+    ).toEqual(['archive.orders', 'public.orders'])
   })
 
   it('ignores foreign keys for tables not in columns', () => {

--- a/src/databases/schemas.ts
+++ b/src/databases/schemas.ts
@@ -85,8 +85,6 @@ export const reorderDatabasesSchema = z.object({
     )
 })
 
-export type ReorderDatabasesRequest = z.infer<typeof reorderDatabasesSchema>
-
 export const updateDatabaseSchema = z.object({
   connectionInfo: updateConnectionInfoSchema,
   name: z.string().min(1, 'Name is required.'),

--- a/src/databases/schemas.ts
+++ b/src/databases/schemas.ts
@@ -14,7 +14,7 @@ const portSchema = z
     return typeof value === 'number' ? value : Number(value)
   })
 
-const sslModeSchema = z.enum(['disable', 'require', 'verify-full'])
+const sslModeSchema = z.enum(['disable', 'require', 'verify-ca', 'verify-full'])
 
 export type SslMode = z.infer<typeof sslModeSchema>
 

--- a/src/databases/sqlite-adapter.ts
+++ b/src/databases/sqlite-adapter.ts
@@ -59,15 +59,10 @@ export class SqliteAdapter implements DatabaseAdapter {
     const database = new Database(this.connectionInfo.path)
 
     try {
-      console.log('Connected to SQLite database')
-      console.log(`Running query:\n${query}\n`)
-
       const statement = database.prepare(query)
 
       if (!statement.reader) {
         const info = statement.run()
-
-        console.log(`  ✓ Query executed successfully\n`)
 
         return {
           fields: [],
@@ -95,8 +90,6 @@ export class SqliteAdapter implements DatabaseAdapter {
         rows.push(row as Record<string, unknown>)
       }
 
-      console.log(`  ✓ Query executed successfully\n`)
-
       return { fields, rowCount: rows.length, rows, truncated }
     } finally {
       database.close()
@@ -108,8 +101,6 @@ export class SqliteAdapter implements DatabaseAdapter {
 
     try {
       await client.execute('SELECT 1')
-
-      console.log('Connected to SQLite database successfully')
     } finally {
       client.close()
     }

--- a/src/databases/ssl-options.test.ts
+++ b/src/databases/ssl-options.test.ts
@@ -1,0 +1,105 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { createSslOptions } from './ssl-options'
+
+describe('createSslOptions', () => {
+  let temporaryDirectory: string
+  let certificatePath: string
+
+  beforeAll(() => {
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'ssl-options-'))
+    certificatePath = path.join(temporaryDirectory, 'root.crt')
+
+    fs.writeFileSync(certificatePath, 'fake certificate')
+  })
+
+  afterAll(() => {
+    fs.rmSync(temporaryDirectory, { force: true, recursive: true })
+  })
+
+  it('returns undefined when ssl is disabled', () => {
+    expect(createSslOptions({ sslMode: 'disable' })).toEqual(undefined)
+    expect(createSslOptions({})).toEqual(undefined)
+  })
+
+  it('encrypts without verification for require', () => {
+    expect(createSslOptions({ sslMode: 'require' })).toEqual({
+      rejectUnauthorized: false
+    })
+  })
+
+  it('verifies the chain but not the hostname for verify-ca', () => {
+    const options = createSslOptions({ sslMode: 'verify-ca' })
+
+    expect(options).toEqual({
+      checkServerIdentity: expect.any(Function),
+      rejectUnauthorized: true
+    })
+    expect(options?.checkServerIdentity?.()).toEqual(undefined)
+  })
+
+  it('verifies fully with the system trust store by default', () => {
+    expect(createSslOptions({ sslMode: 'verify-full' })).toEqual({
+      rejectUnauthorized: true
+    })
+
+    expect(
+      createSslOptions({ sslMode: 'verify-full', sslRootCert: 'system' })
+    ).toEqual({ rejectUnauthorized: true })
+  })
+
+  it('loads a custom root certificate for verify-full', () => {
+    expect(
+      createSslOptions({
+        sslMode: 'verify-full',
+        sslRootCert: certificatePath
+      })
+    ).toEqual({ ca: 'fake certificate', rejectUnauthorized: true })
+  })
+
+  it('loads a custom root certificate for verify-ca', () => {
+    expect(
+      createSslOptions({ sslMode: 'verify-ca', sslRootCert: certificatePath })
+    ).toEqual({
+      ca: 'fake certificate',
+      checkServerIdentity: expect.any(Function),
+      rejectUnauthorized: true
+    })
+  })
+
+  it('reports a missing certificate file clearly', () => {
+    const missingPath = path.join(temporaryDirectory, 'missing.crt')
+
+    expect(() =>
+      createSslOptions({ sslMode: 'verify-full', sslRootCert: missingPath })
+    ).toThrow(
+      `Could not read CA certificate at ${missingPath}: the file does not exist.`
+    )
+  })
+
+  it('rejects a directory as a certificate path', () => {
+    expect(() =>
+      createSslOptions({
+        sslMode: 'verify-full',
+        sslRootCert: temporaryDirectory
+      })
+    ).toThrow(
+      `Could not read CA certificate at ${temporaryDirectory}: the path is not a file.`
+    )
+  })
+
+  it('rejects an oversized certificate file', () => {
+    const oversizedPath = path.join(temporaryDirectory, 'oversized.crt')
+
+    fs.writeFileSync(oversizedPath, Buffer.alloc(1024 * 1024 + 1))
+
+    expect(() =>
+      createSslOptions({ sslMode: 'verify-full', sslRootCert: oversizedPath })
+    ).toThrow(
+      `Could not read CA certificate at ${oversizedPath}: the file is larger than 1 MB.`
+    )
+  })
+})

--- a/src/databases/ssl-options.ts
+++ b/src/databases/ssl-options.ts
@@ -4,6 +4,7 @@ import type { SslMode } from './schemas'
 
 export interface SslOptions {
   ca?: string
+  checkServerIdentity?: () => undefined
   rejectUnauthorized: boolean
 }
 
@@ -11,6 +12,10 @@ interface SslConnectionInfo {
   sslMode?: SslMode
   sslRootCert?: string
 }
+
+// Largest realistic corporate CA bundle; anything bigger is a mistake (or a
+// device file) and would otherwise be slurped into memory.
+const maxRootCertificateBytes = 1024 * 1024
 
 // Maps the shared sslMode/sslRootCert connection fields to the ssl options
 // both pg and mysql2 accept. Returns undefined when TLS is disabled.
@@ -23,17 +28,57 @@ export function createSslOptions(
     return undefined
   }
 
+  // libpq parity: 'require' encrypts but does not verify the server's
+  // identity. Users who want verification pick verify-ca or verify-full.
   if (sslMode === 'require') {
     return { rejectUnauthorized: false }
   }
 
-  // verify-full
-  if (sslRootCert && sslRootCert !== 'system') {
+  const ca =
+    sslRootCert && sslRootCert !== 'system'
+      ? readRootCertificate(sslRootCert)
+      : undefined
+
+  // verify-ca validates the certificate chain but not the hostname. Both pg
+  // and mysql2 hand these options to tls.connect, where a checkServerIdentity
+  // returning undefined skips the hostname check.
+  if (sslMode === 'verify-ca') {
     return {
-      ca: fs.readFileSync(sslRootCert).toString(),
+      ...(ca === undefined ? {} : { ca }),
+      checkServerIdentity: () => undefined,
       rejectUnauthorized: true
     }
   }
 
-  return { rejectUnauthorized: true }
+  // verify-full
+  return {
+    ...(ca === undefined ? {} : { ca }),
+    rejectUnauthorized: true
+  }
+}
+
+function readRootCertificate(filePath: string): string {
+  let stats: fs.Stats
+
+  try {
+    stats = fs.statSync(filePath)
+  } catch {
+    throw new Error(
+      `Could not read CA certificate at ${filePath}: the file does not exist.`
+    )
+  }
+
+  if (!stats.isFile()) {
+    throw new Error(
+      `Could not read CA certificate at ${filePath}: the path is not a file.`
+    )
+  }
+
+  if (stats.size > maxRootCertificateBytes) {
+    throw new Error(
+      `Could not read CA certificate at ${filePath}: the file is larger than 1 MB.`
+    )
+  }
+
+  return fs.readFileSync(filePath).toString()
 }

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { Hono } from 'hono'
 
-import { resetTestDatabase, setupApiMocks } from '@/test/api-test-helper'
+import {
+  resetTestDatabase,
+  setupApiMocks,
+  testApiToken
+} from '@/test/api-test-helper'
 
 setupApiMocks()
 
@@ -12,13 +16,32 @@ describe('GET /health', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = createApp({ enableLogging: false, token: testApiToken })
   })
 
-  it('should return status ok', async () => {
+  it('should return status ok without a token', async () => {
     const response = await app.request('/health')
 
     expect(response.status).toEqual(200)
-    expect(await response.json()).toEqual({ status: 'ok' })
+    expect(await response.json()).toEqual({
+      encryptionAvailable: true,
+      status: 'ok'
+    })
+  })
+
+  it('reports when secret encryption is unavailable', async () => {
+    const unavailableApp = createApp({
+      enableLogging: false,
+      encryptionAvailable: false,
+      token: testApiToken
+    })
+
+    const response = await unavailableApp.request('/health')
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({
+      encryptionAvailable: false,
+      status: 'ok'
+    })
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,9 @@ import started from 'electron-squirrel-startup'
 import { apiPort, startServer } from './api'
 import { initializeDatabase } from './database'
 import { migrateConnectionInfoEncryption } from './main/databases/connection-info-migration'
+import { isEncryptionAvailable } from './main/databases/secret-storage'
+import { startQueryRetentionSchedule } from './main/queries/query-retention'
+import { markInterruptedQueries } from './main/queries/reconcile-queries'
 
 if (!app.isPackaged) {
   app.commandLine.appendSwitch('remote-debugging-port', '9222')
@@ -107,6 +110,12 @@ app.on('ready', async () => {
 
   await initializeDatabase()
 
+  // Runs before the server accepts requests so the renderer never sees a
+  // stale "running" query from a previous process.
+  await markInterruptedQueries()
+
+  startQueryRetentionSchedule()
+
   // safeStorage is only reliable once the app is ready.
   await migrateConnectionInfoEncryption()
 
@@ -116,13 +125,12 @@ app.on('ready', async () => {
     allowedOrigins.push(new URL(MAIN_WINDOW_VITE_DEV_SERVER_URL).origin)
   }
 
-  const { token } = startServer(apiPort, { allowedOrigins })
+  const { token } = startServer(apiPort, {
+    allowedOrigins,
+    encryptionAvailable: isEncryptionAvailable()
+  })
 
   apiToken = token
-
-  if (!app.isPackaged) {
-    console.log(`API token: ${apiToken}`)
-  }
 
   createWindow()
 })

--- a/src/main/databases/connection-info-migration.ts
+++ b/src/main/databases/connection-info-migration.ts
@@ -26,13 +26,13 @@ export async function migrateConnectionInfoEncryption(
   const migrationResults = await Promise.all(
     records.map(async (record) => {
       if (isEncrypted(record.connectionInfo)) {
-        return false
+        return 'encrypted'
       }
 
       const encrypted = secretStorage.encrypt(record.connectionInfo)
 
       if (encrypted === record.connectionInfo) {
-        return false
+        return 'plaintext'
       }
 
       await database
@@ -40,13 +40,24 @@ export async function migrateConnectionInfoEncryption(
         .set({ connectionInfo: encrypted })
         .where(eq(databasesTable.id, record.id))
 
-      return true
+      return 'migrated'
     })
   )
 
-  const migratedCount = migrationResults.filter(Boolean).length
+  const migratedCount = migrationResults.filter(
+    (result) => result === 'migrated'
+  ).length
+  const plaintextCount = migrationResults.filter(
+    (result) => result === 'plaintext'
+  ).length
 
   if (migratedCount > 0) {
     log.info(`Encrypted connection info for ${migratedCount} database(s).`)
+  }
+
+  if (plaintextCount > 0) {
+    log.warn(
+      `${plaintextCount} database connection(s) remain unencrypted because OS keychain encryption is unavailable.`
+    )
   }
 }

--- a/src/main/databases/database-service.ts
+++ b/src/main/databases/database-service.ts
@@ -91,6 +91,34 @@ export class DatabaseService {
     return { database: databaseDto, updatedWorksheet }
   }
 
+  async deleteDatabase(id: string): Promise<void> {
+    const record = await this.findActiveRecord(id)
+
+    if (!record) {
+      throw new ApiError(404, 'Database not found')
+    }
+
+    // The secret purge and the soft delete are one write, so a deleted row
+    // never retains a password.
+    await database
+      .update(databasesTable)
+      .set({
+        connectionInfo: this.secretStorage.encrypt('{}'),
+        deletedAt: Date.now()
+      })
+      .where(eq(databasesTable.id, id))
+
+    await database
+      .update(worksheetsTable)
+      .set({ databaseId: null })
+      .where(
+        and(
+          eq(worksheetsTable.databaseId, id),
+          isNull(worksheetsTable.deletedAt)
+        )
+      )
+  }
+
   async getDatabase(id: string): Promise<DatabaseDto | null> {
     const record = await this.findActiveRecord(id)
 

--- a/src/main/databases/secret-storage.ts
+++ b/src/main/databases/secret-storage.ts
@@ -14,6 +14,12 @@ export function isEncrypted(value: string): boolean {
   return value.startsWith(encryptedPrefix)
 }
 
+// Whether the OS keychain can protect stored secrets. Exposed so the renderer
+// can warn the user before a password is saved unencrypted.
+export function isEncryptionAvailable(): boolean {
+  return safeStorage.isEncryptionAvailable()
+}
+
 // Encrypts values with the OS keychain via Electron's safeStorage. Values are
 // stored as `enc:v1:<base64>`; anything without that prefix is treated as
 // legacy plaintext and passed through so existing rows keep working until the

--- a/src/main/queries/index.ts
+++ b/src/main/queries/index.ts
@@ -1,9 +1,11 @@
 import { desc, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import invariant from 'tiny-invariant'
+import { log } from 'tiny-typescript-logger'
 
 import { database } from '@/database'
 import { queriesTable } from '@/database/schema'
+import type { QueryResult } from '@/databases/adapter'
 import { ApiError, ValidationError } from '@/errors'
 import { createQuerySchema, queryRunner } from './query-runner'
 
@@ -18,7 +20,7 @@ export interface QueryDto {
   finishedAt?: number | null
   id: string
   queriedAt: number
-  result: any | null
+  result: QueryResult | null
   truncated: boolean
   worksheetId: string
 }
@@ -97,13 +99,25 @@ queryRouter.post('/:id/cancel', async (context) => {
   return context.json({ success: true })
 })
 
-function transformQuery(query: any): QueryDto {
-  const parsed = query.result ? JSON.parse(query.result) : null
+function transformQuery(query: typeof queriesTable.$inferSelect): QueryDto {
+  let parsed: QueryResult | null = null
+  let parseError: string | null = null
+
+  // One unreadable stored result must not take down the whole history list.
+  if (query.result) {
+    try {
+      parsed = JSON.parse(query.result) as QueryResult
+    } catch {
+      parseError = 'Stored result could not be read.'
+
+      log.error(`Could not parse the stored result for query ${query.id}.`)
+    }
+  }
 
   return {
     content: query.content,
     databaseId: query.databaseId,
-    error: query.error ?? null,
+    error: query.error ?? parseError,
     finishedAt: query.finishedAt ?? null,
     id: query.id,
     queriedAt: query.queriedAt,

--- a/src/main/queries/queries.test.ts
+++ b/src/main/queries/queries.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { sql } from 'drizzle-orm'
 import type { Hono } from 'hono'
 
 import {
   authorizeApp,
   getTestDatabase,
+  mockAdapterConfig,
   resetTestDatabase,
   setupApiMocks,
   testApiToken
@@ -314,5 +315,165 @@ describe('POST /queries', () => {
     })
 
     expect(response.status).toEqual(400)
+  })
+})
+
+describe('GET /queries/:id with a corrupt stored result', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
+  })
+
+  it('returns an error-shaped query instead of failing', async () => {
+    const database = getTestDatabase()
+    const databaseId = crypto.randomUUID()
+    const worksheetId = crypto.randomUUID()
+    const queryId = crypto.randomUUID()
+    const queriedAt = Date.now()
+    const finishedAt = queriedAt + 100
+
+    await database.run(sql`
+      INSERT INTO queries (id, content, databaseId, worksheetId, queriedAt, result, finishedAt)
+      VALUES (
+        ${queryId},
+        'SELECT 1',
+        ${databaseId},
+        ${worksheetId},
+        ${queriedAt},
+        'not json',
+        ${finishedAt}
+      )
+    `)
+
+    const response = await app.request(`/queries/${queryId}`)
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({
+      query: {
+        content: 'SELECT 1',
+        databaseId,
+        error: 'Stored result could not be read.',
+        finishedAt,
+        id: queryId,
+        queriedAt,
+        result: null,
+        truncated: false,
+        worksheetId
+      }
+    })
+  })
+
+  it('keeps the rest of the history list readable', async () => {
+    const database = getTestDatabase()
+    const databaseId = crypto.randomUUID()
+    const worksheetId = crypto.randomUUID()
+    const corruptId = crypto.randomUUID()
+    const healthyId = crypto.randomUUID()
+
+    await database.run(sql`
+      INSERT INTO queries (id, content, databaseId, worksheetId, queriedAt, result, finishedAt)
+      VALUES
+        (${corruptId}, 'SELECT 1', ${databaseId}, ${worksheetId}, ${Date.now()}, 'not json', ${Date.now()}),
+        (${healthyId}, 'SELECT 2', ${databaseId}, ${worksheetId}, ${Date.now()}, ${JSON.stringify(
+          { fields: [], rowCount: 0, rows: [], truncated: false }
+        )}, ${Date.now()})
+    `)
+
+    const response = await app.request('/queries')
+
+    expect(response.status).toEqual(200)
+
+    const data = await response.json()
+
+    expect(data.queries).toHaveLength(2)
+  })
+})
+
+describe('POST /queries/:id/cancel', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    await resetTestDatabase()
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
+  })
+
+  it('cancels a running query and stores the canceled state', async () => {
+    const database = getTestDatabase()
+    const databaseId = crypto.randomUUID()
+
+    await database.run(sql`
+      INSERT INTO databases (id, name, type, connectionInfo, createdAt)
+      VALUES (
+        ${databaseId},
+        'Cancel DB',
+        'postgres',
+        ${JSON.stringify({
+          database: 'canceldb',
+          host: 'localhost',
+          password: 'pass',
+          port: 5432,
+          username: 'user'
+        })},
+        ${Date.now()}
+      )
+    `)
+
+    // The mock query hangs until cancel() rejects it with the message the
+    // Postgres server sends for a canceled statement.
+    let rejectRunningQuery: ((error: Error) => void) | undefined
+
+    mockAdapterConfig.runQuery = () =>
+      new Promise((_resolve, reject) => {
+        rejectRunningQuery = reject
+      })
+
+    mockAdapterConfig.cancel = async () => {
+      rejectRunningQuery?.(new Error('canceling statement due to user request'))
+    }
+
+    const queryId = crypto.randomUUID()
+
+    const createResponse = await app.request('/queries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: 'SELECT pg_sleep(60)',
+        databaseId,
+        id: queryId,
+        queriedAt: Date.now(),
+        worksheetId: crypto.randomUUID()
+      })
+    })
+
+    expect(createResponse.status).toEqual(200)
+
+    const cancelResponse = await app.request(`/queries/${queryId}/cancel`, {
+      method: 'POST'
+    })
+
+    expect(cancelResponse.status).toEqual(200)
+    expect(await cancelResponse.json()).toEqual({ success: true })
+
+    await vi.waitFor(async () => {
+      const rows = await database.all<{
+        error: string | null
+        finishedAt: number | null
+      }>(sql`SELECT error, finishedAt FROM queries WHERE id = ${queryId}`)
+
+      expect(rows[0].error).toEqual('Query canceled.')
+      expect(rows[0].finishedAt).not.toBeNull()
+    })
+  })
+
+  it('succeeds for a query that is no longer running', async () => {
+    const response = await app.request(
+      `/queries/${crypto.randomUUID()}/cancel`,
+      { method: 'POST' }
+    )
+
+    expect(response.status).toEqual(200)
+    expect(await response.json()).toEqual({ success: true })
   })
 })

--- a/src/main/queries/queries.test.ts
+++ b/src/main/queries/queries.test.ts
@@ -3,9 +3,11 @@ import { sql } from 'drizzle-orm'
 import type { Hono } from 'hono'
 
 import {
+  authorizeApp,
   getTestDatabase,
   resetTestDatabase,
-  setupApiMocks
+  setupApiMocks,
+  testApiToken
 } from '@/test/api-test-helper'
 
 setupApiMocks()
@@ -17,7 +19,7 @@ describe('GET /queries', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should return an empty list when no queries exist', async () => {
@@ -56,7 +58,7 @@ describe('GET /queries/:id', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should return a specific query', async () => {
@@ -141,7 +143,7 @@ describe('POST /queries', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should create a query and return it', async () => {

--- a/src/main/queries/query-retention.test.ts
+++ b/src/main/queries/query-retention.test.ts
@@ -1,0 +1,111 @@
+import { sql } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  getTestDatabase,
+  resetTestDatabase,
+  setupApiMocks
+} from '@/test/api-test-helper'
+
+setupApiMocks()
+
+import { deleteExpiredQueries } from './query-retention'
+
+const dayInMilliseconds = 24 * 60 * 60 * 1000
+
+async function insertQuery(options: {
+  id: string
+  queriedAt: number
+  worksheetId: string
+}): Promise<void> {
+  const database = getTestDatabase()
+
+  await database.run(sql`
+    INSERT INTO queries (
+      id, content, databaseId, finishedAt, queriedAt, worksheetId
+    )
+    VALUES (
+      ${options.id},
+      'SELECT 1',
+      'database-1',
+      ${options.queriedAt},
+      ${options.queriedAt},
+      ${options.worksheetId}
+    )
+  `)
+}
+
+async function remainingQueryIds(): Promise<string[]> {
+  const database = getTestDatabase()
+  const rows = await database.all<{ id: string }>(
+    sql`SELECT id FROM queries ORDER BY id`
+  )
+
+  return rows.map((row) => row.id)
+}
+
+describe('deleteExpiredQueries', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  it('deletes queries older than the retention window', async () => {
+    const now = Date.now()
+
+    await insertQuery({
+      id: 'old',
+      queriedAt: now - 31 * dayInMilliseconds,
+      worksheetId: 'worksheet-1'
+    })
+    await insertQuery({
+      id: 'recent',
+      queriedAt: now,
+      worksheetId: 'worksheet-1'
+    })
+
+    const deletedCount = await deleteExpiredQueries(30)
+
+    expect(deletedCount).toEqual(1)
+    expect(await remainingQueryIds()).toEqual(['recent'])
+  })
+
+  it('keeps an expired query that is the newest for its worksheet', async () => {
+    const now = Date.now()
+
+    await insertQuery({
+      id: 'old-but-latest',
+      queriedAt: now - 90 * dayInMilliseconds,
+      worksheetId: 'worksheet-1'
+    })
+    await insertQuery({
+      id: 'older-sibling',
+      queriedAt: now - 120 * dayInMilliseconds,
+      worksheetId: 'worksheet-1'
+    })
+
+    const deletedCount = await deleteExpiredQueries(30)
+
+    expect(deletedCount).toEqual(1)
+    expect(await remainingQueryIds()).toEqual(['old-but-latest'])
+  })
+
+  it('keeps everything inside the retention window', async () => {
+    const now = Date.now()
+
+    await insertQuery({
+      id: 'first',
+      queriedAt: now - 5 * dayInMilliseconds,
+      worksheetId: 'worksheet-1'
+    })
+    await insertQuery({
+      id: 'second',
+      queriedAt: now - 1 * dayInMilliseconds,
+      worksheetId: 'worksheet-1'
+    })
+
+    const deletedCount = await deleteExpiredQueries(30)
+
+    expect(deletedCount).toEqual(0)
+    expect(await remainingQueryIds()).toEqual(['first', 'second'])
+  })
+})

--- a/src/main/queries/query-retention.ts
+++ b/src/main/queries/query-retention.ts
@@ -1,0 +1,55 @@
+import { sql } from 'drizzle-orm'
+import { log } from 'tiny-typescript-logger'
+
+import { database } from '@/database'
+
+const dayInMilliseconds = 24 * 60 * 60 * 1000
+
+export const defaultRetentionDays = 30
+
+// Query history grows without bound otherwise — every run stores its full
+// result (up to 10,000 rows of JSON) in the app database. Each worksheet's
+// newest query is always kept regardless of age because the result panel
+// shows it.
+export async function deleteExpiredQueries(
+  retentionDays = defaultRetentionDays
+): Promise<number> {
+  const cutoff = Date.now() - retentionDays * dayInMilliseconds
+
+  const result = await database.run(sql`
+    DELETE FROM queries
+    WHERE queriedAt < ${cutoff}
+      AND queriedAt < (
+        SELECT MAX(newer.queriedAt)
+        FROM queries AS newer
+        WHERE newer.worksheetId = queries.worksheetId
+      )
+  `)
+
+  const deletedCount = Number(result.rowsAffected ?? 0)
+
+  if (deletedCount > 0) {
+    log.info(
+      `Deleted ${deletedCount} query history entry(ies) older than ${retentionDays} days.`
+    )
+  }
+
+  return deletedCount
+}
+
+// Desktop apps can stay open for weeks, so a boot-only sweep is not enough.
+export function startQueryRetentionSchedule(): void {
+  const sweep = () => {
+    void deleteExpiredQueries().catch((error: unknown) => {
+      log.error(
+        `Query history cleanup failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    })
+  }
+
+  sweep()
+
+  setInterval(sweep, dayInMilliseconds)
+}

--- a/src/main/queries/query-runner.ts
+++ b/src/main/queries/query-runner.ts
@@ -1,10 +1,11 @@
 import { eq, isNull } from 'drizzle-orm'
+import { log } from 'tiny-typescript-logger'
 import { z } from 'zod'
 
 import { database } from '@/database'
 import { databasesTable, queriesTable } from '@/database/schema'
 import { canceledQueryMessage } from '@/glue/queries'
-import type { DatabaseAdapter } from '@/databases/adapter'
+import { QueryCanceledError, type DatabaseAdapter } from '@/databases/adapter'
 import { createAdapter } from '@/databases/create-adapter'
 import { DatabaseService } from '@/main/databases/database-service'
 
@@ -71,7 +72,9 @@ class QueryRunner {
     return insertedQueryRow
   }
 
-  private async runQueryInBackground(query: any): Promise<void> {
+  private async runQueryInBackground(
+    query: typeof queriesTable.$inferSelect
+  ): Promise<void> {
     try {
       const service = new DatabaseService()
       const databaseRecord = await service.getDatabaseWithSecrets(
@@ -107,15 +110,32 @@ class QueryRunner {
         ? canceledQueryMessage
         : extractErrorMessage(error)
 
-      await database
-        .update(queriesTable)
-        .set({ error: errorMessage, finishedAt: Date.now() })
-        .where(eq(queriesTable.id, query.id))
+      // This promise is fire-and-forget, so a failed write must be contained
+      // here — an unhandled rejection would take down the main process while
+      // the row silently stayed "running".
+      try {
+        await database
+          .update(queriesTable)
+          .set({ error: errorMessage, finishedAt: Date.now() })
+          .where(eq(queriesTable.id, query.id))
+      } catch (updateError) {
+        log.error(
+          `Could not mark query ${query.id} as failed: ${
+            updateError instanceof Error
+              ? updateError.message
+              : String(updateError)
+          }`
+        )
+      }
     }
   }
 }
 
 function isCancellationError(error: unknown): boolean {
+  if (error instanceof QueryCanceledError) {
+    return true
+  }
+
   const message = error instanceof Error ? error.message : String(error)
 
   return message

--- a/src/main/queries/reconcile-queries.test.ts
+++ b/src/main/queries/reconcile-queries.test.ts
@@ -1,0 +1,98 @@
+import { sql } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  getTestDatabase,
+  resetTestDatabase,
+  setupApiMocks
+} from '@/test/api-test-helper'
+
+setupApiMocks()
+
+import {
+  interruptedQueryMessage,
+  markInterruptedQueries
+} from './reconcile-queries'
+
+async function insertQuery(options: {
+  error?: string
+  finishedAt?: number
+  id: string
+  result?: string
+}): Promise<void> {
+  const database = getTestDatabase()
+
+  await database.run(sql`
+    INSERT INTO queries (
+      id, content, databaseId, error, finishedAt, queriedAt, result, worksheetId
+    )
+    VALUES (
+      ${options.id},
+      'SELECT 1',
+      'database-1',
+      ${options.error ?? null},
+      ${options.finishedAt ?? null},
+      ${Date.now()},
+      ${options.result ?? null},
+      'worksheet-1'
+    )
+  `)
+}
+
+describe('markInterruptedQueries', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  it('marks unfinished queries as interrupted', async () => {
+    await insertQuery({ id: 'orphaned' })
+
+    const count = await markInterruptedQueries()
+
+    expect(count).toEqual(1)
+
+    const database = getTestDatabase()
+    const rows = await database.all<{
+      error: string | null
+      finishedAt: number | null
+    }>(sql`SELECT error, finishedAt FROM queries WHERE id = 'orphaned'`)
+
+    expect(rows[0].error).toEqual(interruptedQueryMessage)
+    expect(rows[0].finishedAt).not.toBeNull()
+  })
+
+  it('leaves finished queries untouched', async () => {
+    await insertQuery({
+      finishedAt: 1704067200000,
+      id: 'completed',
+      result: '{"fields":[],"rowCount":0,"rows":[],"truncated":false}'
+    })
+    await insertQuery({
+      error: 'Boom',
+      finishedAt: 1704067200000,
+      id: 'failed'
+    })
+
+    const count = await markInterruptedQueries()
+
+    expect(count).toEqual(0)
+
+    const database = getTestDatabase()
+    const rows = await database.all<{
+      error: string | null
+      finishedAt: number | null
+      id: string
+    }>(sql`SELECT id, error, finishedAt FROM queries ORDER BY id`)
+
+    expect(rows).toEqual([
+      { error: null, finishedAt: 1704067200000, id: 'completed' },
+      { error: 'Boom', finishedAt: 1704067200000, id: 'failed' }
+    ])
+  })
+
+  it('does nothing when there are no queries', async () => {
+    const count = await markInterruptedQueries()
+
+    expect(count).toEqual(0)
+  })
+})

--- a/src/main/queries/reconcile-queries.ts
+++ b/src/main/queries/reconcile-queries.ts
@@ -1,0 +1,26 @@
+import { isNull } from 'drizzle-orm'
+import { log } from 'tiny-typescript-logger'
+
+import { database } from '@/database'
+import { queriesTable } from '@/database/schema'
+
+export const interruptedQueryMessage =
+  'Query was interrupted because the app restarted.'
+
+// Queries run in the background of the previous process, so any row still
+// unfinished at boot was cut off by a crash or quit and can never complete.
+// Marking them failed stops the renderer from showing an eternal spinner and
+// polling for a result that will never arrive.
+export async function markInterruptedQueries(): Promise<number> {
+  const interrupted = await database
+    .update(queriesTable)
+    .set({ error: interruptedQueryMessage, finishedAt: Date.now() })
+    .where(isNull(queriesTable.finishedAt))
+    .returning({ id: queriesTable.id })
+
+  if (interrupted.length > 0) {
+    log.info(`Marked ${interrupted.length} interrupted query(ies) as failed.`)
+  }
+
+  return interrupted.length
+}

--- a/src/main/worksheets/worksheets.test.ts
+++ b/src/main/worksheets/worksheets.test.ts
@@ -3,9 +3,11 @@ import { sql } from 'drizzle-orm'
 import type { Hono } from 'hono'
 
 import {
+  authorizeApp,
   getTestDatabase,
   resetTestDatabase,
-  setupApiMocks
+  setupApiMocks,
+  testApiToken
 } from '@/test/api-test-helper'
 
 setupApiMocks()
@@ -17,7 +19,7 @@ describe('POST /worksheets', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should create a worksheet with the given name', async () => {
@@ -105,7 +107,7 @@ describe('GET /worksheets', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should order worksheets by sortOrder', async () => {
@@ -163,7 +165,7 @@ describe('PUT /worksheets/order', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should reorder worksheets and return the full list in the new order', async () => {
@@ -270,7 +272,7 @@ describe('PATCH /worksheets/:id', () => {
 
   beforeEach(async () => {
     await resetTestDatabase()
-    app = createApp({ enableLogging: false })
+    app = authorizeApp(createApp({ enableLogging: false, token: testApiToken }))
   })
 
   it('should update worksheet name', async () => {

--- a/src/test/api-test-helper.ts
+++ b/src/test/api-test-helper.ts
@@ -33,6 +33,7 @@ export function authorizeApp(app: Hono): Hono {
 
 // Mock adapter configuration that can be changed per test.
 export const mockAdapterConfig = {
+  cancel: undefined as (() => Promise<void>) | undefined,
   getSchema: async (): Promise<SchemaInfo> => ({
     databaseName: 'test_db',
     tables: []
@@ -103,6 +104,10 @@ function createMockAdapterClass() {
       mockAdapterConfig.lastConnectionInfo = connectionInfo
     }
 
+    async cancel() {
+      await mockAdapterConfig.cancel?.()
+    }
+
     async getSchema() {
       return mockAdapterConfig.getSchema()
     }
@@ -125,6 +130,7 @@ export async function resetTestDatabase(): Promise<void> {
   testDatabase = await createTestDatabase()
 
   // Reset mock adapter config to defaults.
+  mockAdapterConfig.cancel = undefined
   mockAdapterConfig.lastConnectionInfo = undefined
   mockAdapterConfig.getSchema = async () => ({
     databaseName: 'test_db',

--- a/src/test/api-test-helper.ts
+++ b/src/test/api-test-helper.ts
@@ -1,4 +1,5 @@
 import { drizzle, LibSQLDatabase } from 'drizzle-orm/libsql'
+import type { Hono } from 'hono'
 import { vi } from 'vitest'
 
 import { createTables } from '@/database/tables'
@@ -6,6 +7,29 @@ import type { QueryResult, SchemaInfo } from '@/databases/adapter'
 
 // The test database instance that will be used by tests.
 let testDatabase: LibSQLDatabase
+
+// The bearer token test apps are created with.
+export const testApiToken = 'test-api-token'
+
+/**
+ * Wraps app.request so every test request carries the bearer token, keeping
+ * route tests focused on behavior rather than auth plumbing. Requests that
+ * pass their own Authorization header keep it.
+ */
+export function authorizeApp(app: Hono): Hono {
+  const request = app.request.bind(app)
+
+  app.request = ((input: Parameters<Hono['request']>[0], init?: RequestInit) =>
+    request(input, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${testApiToken}`,
+        ...(init?.headers as Record<string, string> | undefined)
+      }
+    })) as Hono['request']
+
+  return app
+}
 
 // Mock adapter configuration that can be changed per test.
 export const mockAdapterConfig = {


### PR DESCRIPTION
A full hardening pass over the database layer (adapters, query runner, secret storage, API auth, app-state SQLite), from a review that covered security, reliability, performance, and stability.

### Security
- Bearer-token comparison is timing-safe (hash then `timingSafeEqual`) and `createApp` now requires a token — an unauthenticated app can no longer be constructed by omission.
- The dev-only `console.log` of the API token is gone, adapters no longer print SQL text to stdout, and connection-test logging is reduced to the error message (the full driver error embeds host/user).
- New `DELETE /databases/:id`: soft delete and secret purge in one write (stored blob overwritten with encrypted `{}`), worksheets detached, Explorer context-menu action behind an action-toast confirmation.
- When the OS keychain is unavailable, `/health` reports `encryptionAvailable: false`, the connection form warns that the password will be stored unencrypted, and the boot migration logs how many rows remain plaintext.

### TLS
- New `verify-ca` mode (chain validation without hostname pinning) in the schema, ssl-options, and the form; `require` keeps libpq parity but the form now says it does not verify server identity.
- The CA-file read validates existence/regular-file/≤1 MB and returns a friendly error instead of a raw `ENOENT` stack.

### Reliability
- Queries orphaned by a crash are marked "interrupted" at boot, ending the renderer's previously infinite 250 ms polling.
- Postgres cancel works during connect (tracked connecting client is aborted), fails fast when already canceled, and a failed cancel logs instead of rejecting the route.
- A corrupt stored result returns an error-shaped row instead of a 500 for the whole history; the query DTO and background runner drop their `any` types.
- Startup `ALTER TABLE` migrations only swallow duplicate-column errors instead of every failure.

### Performance / resource bounds
- Connect timeouts on every Postgres (10 s) and MySQL (5 s) connection; a 30 s statement timeout on schema introspection only — user queries stay unbounded and cancellable.
- Query history retention: rows older than 30 days deleted at boot and daily, always keeping each worksheet's newest query; new indexes on `queriedAt` and `(worksheetId, queriedAt)`.
- App database runs WAL with a 5 s busy timeout.

