### PR TITLE
fix: make failures visible and survivable

### DIFF
--- a/src/app/api-client.test.ts
+++ b/src/app/api-client.test.ts
@@ -7,8 +7,17 @@ import type {
   SchemaInfoDto,
   WorksheetDto
 } from '@/glue/api/schemas'
+import type { SpanRecord } from '@/glue/tracing/spans'
 
 const mockFetch = vi.fn()
+
+// Finished spans are observed at the exporter boundary so the assertions read
+// the record the renderer would actually ship.
+const { enqueueSpan } = vi.hoisted(() => ({
+  enqueueSpan: vi.fn<(record: SpanRecord) => void>()
+}))
+
+vi.mock('./tracing/exporter', () => ({ enqueueSpan }))
 
 vi.stubGlobal('fetch', mockFetch)
 
@@ -346,6 +355,107 @@ describe('apiClient', () => {
       mockFetch.mockRejectedValueOnce(new Error('Failed to fetch'))
 
       await expect(apiClient.getDatabases()).rejects.toBeInstanceOf(ApiError)
+    })
+
+    it('reports an unreachable backend without leaking the fetch message', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Failed to fetch'))
+
+      try {
+        await apiClient.getDatabases()
+        expect.fail('Expected the request to reject')
+      } catch (error) {
+        expect(error).toEqual(
+          expect.objectContaining({
+            message:
+              "Could not reach Squeal's backend. Restart Squeal and try again.",
+            statusCode: 503
+          })
+        )
+      }
+    })
+
+    it('reports a 500 without leaking the platform status message', async () => {
+      mockFetch.mockResolvedValueOnce(respondWith({}, { status: 500 }))
+
+      try {
+        await apiClient.getDatabases()
+        expect.fail('Expected the request to reject')
+      } catch (error) {
+        expect(error).toEqual(
+          expect.objectContaining({
+            message:
+              "Squeal's backend reported an error. Restart Squeal and try again.",
+            statusCode: 500
+          })
+        )
+      }
+    })
+
+    // An invalid payload never leaves the machine: the client encodes against
+    // the contract first. The failure has to arrive as field errors, not as the
+    // schema tree ParseError.message renders.
+    it('maps an encode failure to field errors and sends nothing', async () => {
+      try {
+        await apiClient.testConnection(
+          { database: 'testdb', host: '', username: 'admin' },
+          'postgres'
+        )
+        expect.fail('Expected the request to reject')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).statusCode).toEqual(400)
+        expect((error as ApiError).details?.['connectionInfo.host']).toEqual(
+          'Host is required.'
+        )
+        expect((error as ApiError).message).toEqual(
+          'Please correct the highlighted fields.'
+        )
+      }
+
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('reports a response that does not match the contract as a bug', async () => {
+      mockFetch.mockResolvedValueOnce(
+        respondWith({ databases: [{ id: 123 }] }, { status: 200 })
+      )
+
+      try {
+        await apiClient.getDatabases()
+        expect.fail('Expected the request to reject')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).message).toEqual(
+          'Squeal could not read the response from its backend. Please report this.'
+        )
+        expect((error as ApiError).details).toBeUndefined()
+      }
+    })
+  })
+
+  describe('spans', () => {
+    it('records the response status code on the client span', async () => {
+      mockFetch.mockResolvedValueOnce(respondWith({ databases: [] }))
+
+      await apiClient.getDatabases()
+
+      const spans = enqueueSpan.mock.calls.map(([record]) => record)
+      const request = spans.find((span) => span.name === 'HTTP GET /databases')
+
+      expect(request?.attributes['http.status_code']).toEqual(200)
+      expect(request?.status).toEqual('ok')
+    })
+
+    it('marks the span as errored when the request fails', async () => {
+      mockFetch.mockResolvedValueOnce(respondWith({}, { status: 500 }))
+
+      await expect(apiClient.getDatabases()).rejects.toBeInstanceOf(ApiError)
+
+      const spans = enqueueSpan.mock.calls.map(([record]) => record)
+      const request = spans.find((span) => span.name === 'HTTP GET /databases')
+
+      expect(request?.attributes['http.status_code']).toEqual(500)
+      expect(request?.status).toEqual('error')
     })
   })
 })

--- a/src/app/api-client.ts
+++ b/src/app/api-client.ts
@@ -9,7 +9,15 @@ import {
   HttpClientRequest
 } from '@effect/platform'
 import { HttpApiDecodeError } from '@effect/platform/HttpApiError'
-import { Cause, Effect, Exit, FiberRef, ManagedRuntime, Option } from 'effect'
+import {
+  Cause,
+  Effect,
+  Exit,
+  FiberRef,
+  ManagedRuntime,
+  Option,
+  ParseResult
+} from 'effect'
 
 import { SquealApi } from '@/glue/api/api'
 import type {
@@ -37,7 +45,8 @@ import { ApiError } from '@/errors'
 import { SpanContext, SpanRecord } from '@/glue/tracing/spans'
 import { formatTraceparent } from '@/glue/tracing/traceparent'
 
-import { startSpan } from './tracing/tracer'
+import { memoizePromise } from './memoize-promise'
+import { Span, startSpan } from './tracing/tracer'
 
 const baseUrl = 'http://127.0.0.1:7847'
 
@@ -46,52 +55,86 @@ interface GetHealthResponse {
   status: string
 }
 
-let apiTokenPromise: Promise<string> | undefined
-
-function getApiToken(): Promise<string> {
-  apiTokenPromise ??= window.electron.getApiToken()
-
-  return apiTokenPromise
-}
+const getApiToken = memoizePromise(() => window.electron.getApiToken())
 
 // The renderer's tracer is hand-rolled (no fiber context to inherit), so the
 // traceparent for the current call travels through a FiberRef that the
 // request transform reads.
 const currentTraceparent = FiberRef.unsafeMake<string | undefined>(undefined)
 
+// Payload encoding happens strictly before the request is executed, so a
+// ParseError raised while `sent` is still false means the payload was invalid
+// and nothing left the machine, while one raised afterwards means the response
+// did not match the contract. `run` gives every call its own marker, so
+// concurrent requests never read each other's state.
+interface RequestPhase {
+  sent: boolean
+  status?: number
+}
+
+const currentRequestPhase = FiberRef.unsafeMake<RequestPhase | undefined>(
+  undefined
+)
+
 const runtime = ManagedRuntime.make(FetchHttpClient.layer)
 
-const client = HttpApiClient.make(SquealApi, {
-  baseUrl,
-  transformClient: (httpClient) =>
-    httpClient.pipe(
-      HttpClient.mapRequestEffect((request) =>
-        Effect.gen(function* () {
-          const token = yield* Effect.promise(getApiToken)
-          const traceparent = yield* FiberRef.get(currentTraceparent)
+// HttpApiClient.make reflects over every group and endpoint and builds a fresh
+// schema union, so it is resolved once rather than per call — the 250ms result
+// poller would otherwise rebuild the entire client four times a second.
+const getClient = memoizePromise(() =>
+  runtime.runPromise(
+    HttpApiClient.make(SquealApi, {
+      baseUrl,
+      transformClient: (httpClient) =>
+        httpClient.pipe(
+          HttpClient.mapRequestEffect((request) =>
+            Effect.gen(function* () {
+              const token = yield* Effect.promise(getApiToken)
+              const traceparent = yield* FiberRef.get(currentTraceparent)
+              const phase = yield* FiberRef.get(currentRequestPhase)
 
-          const authorized = HttpClientRequest.setHeader(
-            request,
-            'Authorization',
-            `Bearer ${token}`
-          )
+              if (phase !== undefined) {
+                phase.sent = true
+              }
 
-          if (traceparent === undefined) {
-            return authorized
-          }
+              const authorized = HttpClientRequest.setHeader(
+                request,
+                'Authorization',
+                `Bearer ${token}`
+              )
 
-          return HttpClientRequest.setHeader(
-            authorized,
-            'traceparent',
-            traceparent
-          )
-        })
-      ),
-      // The spans below carry the traceparent explicitly; the client's own
-      // propagation would inject a competing one.
-      HttpClient.withTracerPropagation(false)
-    )
-})
+              if (traceparent === undefined) {
+                return authorized
+              }
+
+              return HttpClientRequest.setHeader(
+                authorized,
+                'traceparent',
+                traceparent
+              )
+            })
+          ),
+          // Runs for every response the client receives, including non-2xx
+          // ones, so both the span attribute and the error message get the
+          // real status code.
+          HttpClient.tap((response) =>
+            Effect.gen(function* () {
+              const phase = yield* FiberRef.get(currentRequestPhase)
+
+              if (phase !== undefined) {
+                phase.status = response.status
+              }
+            })
+          ),
+          // The spans below carry the traceparent explicitly; the client's own
+          // propagation would inject a competing one.
+          HttpClient.withTracerPropagation(false)
+        )
+    })
+  )
+)
+
+const client = Effect.promise(getClient)
 
 // Infrastructure failures the API contract does not describe. They carry
 // `_tag` like domain errors but reference the whole request/response, so they
@@ -102,6 +145,11 @@ const infrastructureTags = new Set([
   'ResponseError'
 ])
 
+const validationMessage = 'Please correct the highlighted fields.'
+
+// Both the server's decode errors and the client's own encode errors carry
+// their issues in this shape, so the database form's field mapping consumes
+// either one unchanged.
 function toFieldDetails(
   issues: ReadonlyArray<{ message: string; path: ReadonlyArray<PropertyKey> }>
 ): Record<string, string> {
@@ -126,49 +174,85 @@ function isDomainError(error: unknown): boolean {
   )
 }
 
-function responseStatus(error: unknown): number | undefined {
-  if (typeof error !== 'object' || error === null || !('response' in error)) {
-    return undefined
-  }
-
-  const status = (error as { response?: { status?: number } }).response?.status
-
-  return typeof status === 'number' ? status : undefined
-}
-
 // Domain errors reach the caller as themselves so hooks can discriminate on
-// `_tag`; decode and transport failures become ApiError, which existing
-// catch-alls and the database form's field mapping already understand.
-function toThrowable(cause: Cause.Cause<unknown>): unknown {
+// `_tag`. Everything else becomes an ApiError carrying copy the user can act
+// on: the underlying ParseError/ResponseError/RequestError messages are
+// developer-facing (a schema tree, or `StatusCode: non 2xx status code …`) and
+// must never reach a toast. They go to the console instead.
+function toThrowable(
+  cause: Cause.Cause<unknown>,
+  phase: RequestPhase
+): unknown {
   const failure = Cause.failureOption(cause)
   const error = Option.isSome(failure) ? failure.value : Cause.squash(cause)
 
+  // The server rejected the payload and said which fields were wrong.
   if (error instanceof HttpApiDecodeError) {
-    return new ApiError(400, 'Validation error', toFieldDetails(error.issues))
+    return new ApiError(400, validationMessage, toFieldDetails(error.issues))
+  }
+
+  if (ParseResult.isParseError(error)) {
+    // Nothing was sent: the payload failed to encode against the contract, so
+    // this is invalid user input and the issues map onto form fields.
+    if (!phase.sent) {
+      return new ApiError(
+        400,
+        validationMessage,
+        toFieldDetails(ParseResult.ArrayFormatter.formatErrorSync(error))
+      )
+    }
+
+    console.error('The API response did not match the contract:', error.message)
+
+    return new ApiError(
+      phase.status ?? 500,
+      'Squeal could not read the response from its backend. Please report this.'
+    )
   }
 
   if (isDomainError(error)) {
     return error
   }
 
+  if (error instanceof Error) {
+    console.error('Squeal API request failed:', error)
+  }
+
+  // No response ever arrived, so the backend is unreachable rather than broken.
+  if (phase.status === undefined) {
+    return new ApiError(
+      503,
+      "Could not reach Squeal's backend. Restart Squeal and try again."
+    )
+  }
+
   return new ApiError(
-    responseStatus(error) ?? 500,
-    error instanceof Error
-      ? error.message
-      : 'The request could not be completed. Please try again.'
+    phase.status,
+    "Squeal's backend reported an error. Restart Squeal and try again."
   )
 }
 
 function run<A, E>(
-  effect: Effect.Effect<A, E, HttpClient.HttpClient>
+  effect: Effect.Effect<A, E, HttpClient.HttpClient>,
+  phase: RequestPhase = { sent: false }
 ): Promise<A> {
-  return runtime.runPromiseExit(effect).then((exit) => {
-    if (Exit.isSuccess(exit)) {
-      return exit.value
-    }
+  return runtime
+    .runPromiseExit(Effect.locally(effect, currentRequestPhase, phase))
+    .then((exit) => {
+      if (Exit.isSuccess(exit)) {
+        return exit.value
+      }
 
-    throw toThrowable(exit.cause)
-  })
+      throw toThrowable(exit.cause, phase)
+    })
+}
+
+function recordStatusCode(span: Span, status: number | undefined): void {
+  if (status === undefined) {
+    return
+  }
+
+  span.setAttribute('http.status_code', status)
 }
 
 // Requests the renderer traces get a client span whose context is sent as the
@@ -188,17 +272,29 @@ function traced<A, E>(
     kind: 'client',
     ...(parent === undefined ? {} : { parent })
   })
+  const phase: RequestPhase = { sent: false }
 
   return run(
-    Effect.locally(effect, currentTraceparent, formatTraceparent(span.context))
+    Effect.locally(effect, currentTraceparent, formatTraceparent(span.context)),
+    phase
   ).then(
     (value) => {
+      recordStatusCode(span, phase.status)
       span.setStatus('ok')
       span.end()
 
       return value
     },
     (error: unknown) => {
+      recordStatusCode(
+        span,
+        phase.status ??
+          (error instanceof ApiError ? error.statusCode : undefined)
+      )
+      span.setStatus(
+        'error',
+        error instanceof Error ? error.message : String(error)
+      )
       span.recordException(error)
       span.end()
 

--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -409,6 +409,28 @@ describe('DatabaseForm', () => {
     })
   })
 
+  // Testing a connection skips the form's own validation, so the contract
+  // rejects the payload client-side. That has to surface as an inline field
+  // error rather than the schema tree ParseError.message renders.
+  it('shows an inline field error when testing an incomplete connection', async () => {
+    const user = userEvent.setup()
+
+    renderDatabaseForm()
+
+    await user.type(screen.getByLabelText('Name'), 'My Database')
+    await user.type(screen.getByLabelText('Username'), 'postgres')
+    await user.type(screen.getByLabelText('Password'), 'password')
+    await user.type(screen.getByLabelText('Database'), 'mydb')
+
+    await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Host is required.')).toBeInTheDocument()
+    })
+
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   it('disables buttons while testing connection', async () => {
     const user = userEvent.setup()
 

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -166,12 +166,27 @@ export function DatabaseForm({
 
   const isLoading = isSaving || isTestingConnection
 
+  // The row exists but its stored secret could not be decrypted — most often
+  // because the OS keychain was reset. Saving the form re-encrypts and repairs
+  // it, so say that rather than silently showing blank fields.
+  const connectionInfoUnreadable =
+    isEditMode &&
+    defaultValues !== undefined &&
+    defaultValues.connectionInfo === undefined
+
   return (
     <Form {...form}>
       <form
         className="flex flex-col gap-8"
         onSubmit={form.handleSubmit(handleSubmit)}
       >
+        {connectionInfoUnreadable && (
+          <p className="rounded-md border border-yellow/40 bg-yellow/10 px-3 py-2 text-xs text-yellow">
+            Squeal could not read this connection&apos;s stored details. Enter
+            them again and save to repair it.
+          </p>
+        )}
+
         {databaseType !== 'sqlite' && (
           <ConnectionStringSection
             form={form}

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -95,6 +95,33 @@ function getDefaultConnectionInfo(
   }
 }
 
+// The row exists but its stored secret could not be decrypted — most often
+// because the OS keychain was reset. Saving the form re-encrypts and repairs it,
+// so say that rather than silently showing blank fields.
+function UnreadableConnectionNotice({
+  defaultValues,
+  isEditMode
+}: {
+  defaultValues: DatabaseFormProps['defaultValues']
+  isEditMode: boolean
+}): ReactElement | null {
+  const unreadable =
+    isEditMode &&
+    defaultValues !== undefined &&
+    defaultValues.connectionInfo === undefined
+
+  if (!unreadable) {
+    return null
+  }
+
+  return (
+    <p className="rounded-md border border-yellow/40 bg-yellow/10 px-3 py-2 text-xs text-yellow">
+      Squeal could not read this connection&apos;s stored details. Enter them
+      again and save to repair it.
+    </p>
+  )
+}
+
 export function DatabaseForm({
   databaseId,
   defaultValues,
@@ -166,26 +193,16 @@ export function DatabaseForm({
 
   const isLoading = isSaving || isTestingConnection
 
-  // The row exists but its stored secret could not be decrypted — most often
-  // because the OS keychain was reset. Saving the form re-encrypts and repairs
-  // it, so say that rather than silently showing blank fields.
-  const connectionInfoUnreadable =
-    isEditMode &&
-    defaultValues !== undefined &&
-    defaultValues.connectionInfo === undefined
-
   return (
     <Form {...form}>
       <form
         className="flex flex-col gap-8"
         onSubmit={form.handleSubmit(handleSubmit)}
       >
-        {connectionInfoUnreadable && (
-          <p className="rounded-md border border-yellow/40 bg-yellow/10 px-3 py-2 text-xs text-yellow">
-            Squeal could not read this connection&apos;s stored details. Enter
-            them again and save to repair it.
-          </p>
-        )}
+        <UnreadableConnectionNotice
+          defaultValues={defaultValues}
+          isEditMode={isEditMode}
+        />
 
         {databaseType !== 'sqlite' && (
           <ConnectionStringSection

--- a/src/app/components/EditorScreen.tsx
+++ b/src/app/components/EditorScreen.tsx
@@ -44,7 +44,9 @@ export function EditorScreen({
 
   const defaultValues = database
     ? {
-        connectionInfo: database.connectionInfo,
+        // Null when the stored secret could not be decrypted; the form opens
+        // with empty connection fields so saving repairs the row.
+        connectionInfo: database.connectionInfo ?? undefined,
         name: database.name,
         type: database.type
       }

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -8,11 +8,11 @@ import { queryPollInterval } from './queries'
 import { queryKeys } from '../query-keys'
 import {
   CreateDatabaseRequest,
+  type CreateWorksheetRequest,
+  type QueryDto,
   UpdateDatabaseRequest
 } from '@/glue/api/schemas'
 import { canceledQueryMessage } from '@/glue/queries'
-import type { CreateWorksheetRequest } from '@/glue/api/schemas'
-import type { QueryDto } from '@/glue/api/schemas'
 
 const cancelPollAttempts = 20
 

--- a/src/app/memoize-promise.test.ts
+++ b/src/app/memoize-promise.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { memoizePromise } from './memoize-promise'
+
+describe('memoizePromise', () => {
+  it('creates the value once and reuses it', async () => {
+    const create = vi.fn(() => Promise.resolve('token'))
+    const get = memoizePromise(create)
+
+    expect([await get(), await get(), await get()]).toEqual([
+      'token',
+      'token',
+      'token'
+    ])
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares one in-flight promise between concurrent callers', async () => {
+    const create = vi.fn(() => Promise.resolve('token'))
+    const get = memoizePromise(create)
+
+    expect(await Promise.all([get(), get()])).toEqual(['token', 'token'])
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries after a rejection instead of caching the failure', async () => {
+    const create = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('IPC unavailable'))
+      .mockResolvedValueOnce('token')
+    const get = memoizePromise(create)
+
+    await expect(get()).rejects.toThrow('IPC unavailable')
+
+    expect(await get()).toEqual('token')
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/app/memoize-promise.ts
+++ b/src/app/memoize-promise.ts
@@ -1,0 +1,17 @@
+// Caches the promise for a value that should only ever be created once per
+// renderer session. A rejected promise is deliberately not kept: caching one
+// would wedge every later caller until the window reloads, so the next call
+// gets a fresh attempt instead.
+export function memoizePromise<A>(create: () => Promise<A>): () => Promise<A> {
+  let pending: Promise<A> | undefined
+
+  return () => {
+    pending ??= create().catch((error: unknown) => {
+      pending = undefined
+
+      throw error
+    })
+
+    return pending
+  }
+}

--- a/src/glue/api/schemas.ts
+++ b/src/glue/api/schemas.ts
@@ -110,7 +110,10 @@ export type PublicConnectionInfo = Schema.Schema.Type<
 // --- Databases ---------------------------------------------------------------
 
 export const DatabaseDto = Schema.Struct({
-  connectionInfo: PublicConnectionInfo,
+  // Null when the stored secret could not be decrypted — for example after the
+  // OS keychain was reset. The row still has to be listed so the user can see
+  // it, repair it, or delete it.
+  connectionInfo: Schema.NullOr(PublicConnectionInfo),
   createdAt: Schema.Number,
   id: Schema.String,
   name: Schema.String,

--- a/src/server/services/app-database.ts
+++ b/src/server/services/app-database.ts
@@ -16,6 +16,19 @@ export interface AppDatabaseService {
   ) => Effect.Effect<T, AppDatabaseError>
 }
 
+// A rejected write is not automatically a broken database: a constraint
+// violation is the database working correctly and refusing bad data. Reporting
+// both the same way made a duplicate primary key read as "restart Squeal".
+function isConstraintViolation(cause: unknown): boolean {
+  const message = cause instanceof Error ? cause.message : String(cause)
+
+  return (
+    message.includes('SQLITE_CONSTRAINT') ||
+    message.includes('UNIQUE constraint failed') ||
+    message.includes('No values to set')
+  )
+}
+
 export function makeAppDatabaseService(
   client: AppDatabaseClient
 ): AppDatabaseService {
@@ -26,8 +39,9 @@ export function makeAppDatabaseService(
         catch: (cause) =>
           new AppDatabaseError({
             cause: cause instanceof Error ? cause.message : String(cause),
-            message:
-              'The app database is unavailable. Restart Squeal and try again.'
+            message: isConstraintViolation(cause)
+              ? 'The app database rejected this change.'
+              : 'The app database is unavailable. Restart Squeal and try again.'
           }),
         try: () => run(client)
       })
@@ -49,12 +63,17 @@ export class AppDatabase extends Effect.Service<AppDatabase>()('AppDatabase', {
       try: () => initializeDatabase()
     })
 
+    // Closes the client this service was built over, not the module singleton:
+    // building the service across a different client would otherwise close the
+    // wrong handle.
+    const client = database
+
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
-        database.$client.close()
+        client.$client.close()
       })
     )
 
-    return makeAppDatabaseService(database)
+    return makeAppDatabaseService(client)
   })
 }) {}

--- a/src/server/services/database-service.test.ts
+++ b/src/server/services/database-service.test.ts
@@ -246,18 +246,99 @@ describe('DatabaseService', () => {
     ])
   })
 
+  // A keychain reset makes every stored secret unreadable. Failing the whole
+  // list would leave the user unable to see, repair, or delete anything.
+  it('lists a database whose stored connection info cannot be read', async () => {
+    const databases = await run(
+      Effect.gen(function* () {
+        const service = yield* DatabaseService
+        const appDatabase = yield* AppDatabase
+
+        yield* service.create('Readable', connectionInfo, 'postgres')
+
+        yield* appDatabase.execute((client) =>
+          client.insert(databasesTable).values({
+            connectionInfo: 'not-decryptable',
+            name: 'Unreadable',
+            type: 'postgres'
+          })
+        )
+
+        return yield* service.list()
+      })
+    )
+
+    expect(
+      databases
+        .map((database) => ({
+          connectionInfo: database.connectionInfo,
+          name: database.name
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name))
+    ).toEqual([
+      {
+        connectionInfo: {
+          database: 'pagila',
+          host: 'localhost',
+          username: 'postgres'
+        },
+        name: 'Readable'
+      },
+      { connectionInfo: null, name: 'Unreadable' }
+    ])
+  })
+
+  it('refuses to update a deleted database', async () => {
+    const outcome = await run(
+      Effect.gen(function* () {
+        const service = yield* DatabaseService
+
+        const created = yield* service.create(
+          'Pagila',
+          connectionInfo,
+          'postgres'
+        )
+
+        yield* service.remove(created.database.id)
+
+        const result = yield* Effect.either(
+          service.update(
+            created.database.id,
+            'Renamed',
+            { ...connectionInfo, password: 'new-secret' },
+            'postgres'
+          )
+        )
+
+        const [row] = yield* (yield* AppDatabase).execute((client) =>
+          client
+            .select()
+            .from(databasesTable)
+            .where(eq(databasesTable.id, created.database.id))
+        )
+
+        return { connectionInfo: row.connectionInfo, result }
+      })
+    )
+
+    expect(outcome.result._tag).toEqual('Left')
+
+    // The purged secret must stay purged.
+    expect(outcome.connectionInfo).toEqual(`${testEncryptionPrefix}{}`)
+  })
+
   it('returns none for a missing or deleted database', async () => {
     const { missing, deleted } = await run(
       Effect.gen(function* () {
         const service = yield* DatabaseService
 
-        const missing = yield* service.get('missing')
+        const missing = yield* service.getWithSecrets('missing')
 
         const created = yield* service.create('Pagila', connectionInfo, 'postgres')
 
         yield* service.remove(created.database.id)
 
-        const deleted = yield* service.get(created.database.id)
+        const deleted = yield* service.getWithSecrets(created.database.id)
 
         return { deleted, missing }
       })

--- a/src/server/services/database-service.ts
+++ b/src/server/services/database-service.ts
@@ -66,6 +66,15 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
           )
         )
 
+      const toUnreadableDatabase = (record: DatabaseRow): DatabaseDto => ({
+        connectionInfo: null,
+        createdAt: record.createdAt,
+        id: record.id,
+        name: record.name,
+        sortOrder: record.sortOrder ?? null,
+        type: record.type as DatabaseType
+      })
+
       const findActiveRecord = (id: string) =>
         appDatabase
           .execute((client) =>
@@ -92,7 +101,19 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
             )
         )
 
-        return yield* Effect.forEach(records, transformDatabase)
+        // Per row, not fail-fast: one unreadable secret must not take down the
+        // whole list, or a keychain reset would leave the user unable to see,
+        // repair, or delete any connection at all. Mirrors the same treatment
+        // stored query results already get in transformQueryRow.
+        return yield* Effect.forEach(records, (record) =>
+          transformDatabase(record).pipe(
+            Effect.catchTag('SecretDecryptError', (error) =>
+              Effect.logWarning(
+                `Could not read connection info for database ${record.id}: ${error.message}`
+              ).pipe(Effect.as(toUnreadableDatabase(record)))
+            )
+          )
+        )
       })
 
       const create = Effect.fn('DatabaseService.create')(function* (
@@ -162,16 +183,6 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
         }
 
         return result
-      })
-
-      const get = Effect.fn('DatabaseService.get')(function* (id: string) {
-        const record = yield* findActiveRecord(id)
-
-        if (Option.isNone(record)) {
-          return Option.none<DatabaseDto>()
-        }
-
-        return Option.some(yield* transformDatabase(record.value))
       })
 
       // Returns the decrypted connection info, password included. Main-
@@ -308,7 +319,13 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
           client
             .update(databasesTable)
             .set({ connectionInfo: encrypted, name, type })
-            .where(eq(databasesTable.id, id))
+            // Soft-deleted rows are excluded like everywhere else: without this
+            // a PATCH would re-encrypt a password onto a row whose secret
+            // remove() deliberately purged, and answer 200 for a database that
+            // appears in no list.
+            .where(
+              and(eq(databasesTable.id, id), isNull(databasesTable.deletedAt))
+            )
             .returning()
         )
 
@@ -324,7 +341,6 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
 
       return {
         create,
-        get,
         getWithSecrets,
         list,
         remove,

--- a/src/server/services/query-runner.test.ts
+++ b/src/server/services/query-runner.test.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import { queriesTable } from '@/database/schema'
 import { QueryCanceledError, type QueryResult } from '@/databases/adapter'
 import type { ConnectionInfo } from '@/glue/api/schemas'
 import { canceledQueryMessage } from '@/glue/queries'
@@ -252,5 +253,75 @@ describe('QueryRunner', () => {
     // AsyncLocalStorage capture this replaces.
     expect(executeSpan?.parentSpanId).toEqual(createSpan?.id)
     expect(executeSpan?.traceId).toEqual(createSpan?.traceId)
+  })
+
+  // Results stored by earlier versions predate `truncated`. These used to be
+  // cast blindly, so a single legacy row failed *response* encoding and took
+  // down the whole history list with a 400.
+  it('reads a stored result written before truncated existed', async () => {
+    const queries = await run(
+      Effect.gen(function* () {
+        const appDatabase = yield* AppDatabase
+        const runner = yield* QueryRunner
+        const database = yield* createDatabase
+
+        yield* appDatabase.execute((client) =>
+          client.insert(queriesTable).values({
+            content: 'select 1',
+            databaseId: database.id,
+            finishedAt: 2_000,
+            id: 'legacy-query',
+            queriedAt: 1_000,
+            result: JSON.stringify({
+              fields: [{ name: 'value' }],
+              rowCount: 1,
+              rows: [{ value: 1 }]
+            }),
+            worksheetId: 'worksheet-1'
+          })
+        )
+
+        return yield* runner.list()
+      })
+    )
+
+    const legacy = queries.find((query) => query.id === 'legacy-query')
+
+    expect(legacy?.result).toEqual({
+      fields: [{ name: 'value' }],
+      rowCount: 1,
+      rows: [{ value: 1 }],
+      truncated: false
+    })
+    expect(legacy?.error).toEqual(null)
+  })
+
+  it('reports a structurally unusable stored result without failing the list', async () => {
+    const queries = await run(
+      Effect.gen(function* () {
+        const appDatabase = yield* AppDatabase
+        const runner = yield* QueryRunner
+        const database = yield* createDatabase
+
+        yield* appDatabase.execute((client) =>
+          client.insert(queriesTable).values({
+            content: 'select 1',
+            databaseId: database.id,
+            finishedAt: 2_000,
+            id: 'broken-query',
+            queriedAt: 1_000,
+            result: JSON.stringify({ unexpected: true }),
+            worksheetId: 'worksheet-1'
+          })
+        )
+
+        return yield* runner.list()
+      })
+    )
+
+    const broken = queries.find((query) => query.id === 'broken-query')
+
+    expect(broken?.result).toEqual(null)
+    expect(broken?.error).toEqual('Stored result could not be read.')
   })
 })

--- a/src/server/services/query-runner.ts
+++ b/src/server/services/query-runner.ts
@@ -13,6 +13,11 @@ import { DatabaseService } from './database-service'
 
 type QueryRow = typeof queriesTable.$inferSelect
 
+// Canceling opens a fresh connection to the user's database, which can hang on
+// an unreachable host. There is deliberately no timeout on running a user
+// query, but shutdown must not wait on one.
+const cancelTimeout = '5 seconds'
+
 // Carries the raw adapter rejection so cancellation can be classified before
 // the error is flattened into a message. Never leaves this module.
 class AdapterQueryError {
@@ -103,10 +108,19 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
             })
         ),
         // Scope teardown (app quit) best-effort cancels the server-side
-        // statement before the fiber dies.
+        // statement before the fiber dies. Effect.ignore alone would not
+        // contain a rejecting cancel(), because Effect.promise turns a
+        // rejection into a defect; and cancel() opens a *new* connection, so it
+        // needs a timeout or a slow one would stall shutdown.
         Effect.onInterrupt(() =>
           Effect.promise(() => adapter.cancel?.() ?? Promise.resolve()).pipe(
-            Effect.ignore
+            Effect.timeout(cancelTimeout),
+            Effect.catchAllCause((cause) =>
+              Effect.logError(
+                `Could not cancel query ${query.id} during shutdown`,
+                cause
+              )
+            )
           )
         ),
         Effect.withSpan('db.query', {

--- a/src/server/services/query-runner.ts
+++ b/src/server/services/query-runner.ts
@@ -351,6 +351,41 @@ function messageFromCause(cause: Cause.Cause<{ message: string }>): string {
   return extractErrorMessage(Cause.squash(cause))
 }
 
+// Stored results are historical data: rows written by earlier versions predate
+// fields the response schema now requires — `truncated` arrived later — and a
+// blind cast let one such row fail response *encoding*, which took down the
+// entire history list with a 400. Normalize to the contract shape rather than
+// asserting it.
+function toStoredQueryResult(value: unknown): QueryResult | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
+  }
+
+  const candidate = value as Partial<QueryResult>
+
+  if (!Array.isArray(candidate.fields) || !Array.isArray(candidate.rows)) {
+    return null
+  }
+
+  if (
+    !candidate.rows.every((row) => typeof row === 'object' && row !== null)
+  ) {
+    return null
+  }
+
+  return {
+    fields: candidate.fields.map((field) => ({
+      name: String((field as { name?: unknown } | null)?.name ?? '')
+    })),
+    rowCount:
+      typeof candidate.rowCount === 'number'
+        ? candidate.rowCount
+        : candidate.rows.length,
+    rows: candidate.rows,
+    truncated: candidate.truncated === true
+  }
+}
+
 function transformQueryRow(row: QueryRow): QueryDto {
   let parsed: QueryResult | null = null
   let parseError: string | null = null
@@ -358,7 +393,11 @@ function transformQueryRow(row: QueryRow): QueryDto {
   // One unreadable stored result must not take down the whole history list.
   if (row.result) {
     try {
-      parsed = JSON.parse(row.result) as QueryResult
+      parsed = toStoredQueryResult(JSON.parse(row.result))
+
+      if (parsed === null) {
+        parseError = 'Stored result could not be read.'
+      }
     } catch {
       parseError = 'Stored result could not be read.'
     }

--- a/src/server/services/worksheet-service.test.ts
+++ b/src/server/services/worksheet-service.test.ts
@@ -1,6 +1,8 @@
+import { eq } from 'drizzle-orm'
 import { Effect, Layer } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import { worksheetsTable } from '@/database/schema'
 import {
   makeTestAppDatabase,
   TestSecretStorage
@@ -113,5 +115,47 @@ describe('WorksheetService', () => {
     )
 
     expect(names).toEqual(['Second', 'First'])
+  })
+
+  // Every field of the patch is optional, so an empty body is schema-valid.
+  // Drizzle rejects an empty SET, which used to surface as "the app database is
+  // unavailable".
+  it('treats an empty patch as a no-op', async () => {
+    const { after, before } = await run(
+      Effect.gen(function* () {
+        const service = yield* WorksheetService
+
+        const before = yield* service.create({ name: 'Untouched' })
+        const after = yield* service.update(before.id, {})
+
+        return { after, before }
+      })
+    )
+
+    expect(after).toEqual(before)
+  })
+
+  it('refuses to update a soft-deleted worksheet', async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const service = yield* WorksheetService
+        const appDatabase = yield* AppDatabase
+
+        const created = yield* service.create({ name: 'Doomed' })
+
+        yield* appDatabase.execute((client) =>
+          client
+            .update(worksheetsTable)
+            .set({ deletedAt: Date.now() })
+            .where(eq(worksheetsTable.id, created.id))
+        )
+
+        return yield* Effect.either(
+          service.update(created.id, { name: 'Resurrected' })
+        )
+      })
+    )
+
+    expect(result._tag).toEqual('Left')
   })
 })

--- a/src/server/services/worksheet-service.ts
+++ b/src/server/services/worksheet-service.ts
@@ -115,11 +115,36 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
           ...(updates.name === undefined ? {} : { name: updates.name })
         }
 
+        const activeWorksheet = and(
+          eq(worksheetsTable.id, id),
+          isNull(worksheetsTable.deletedAt)
+        )
+
+        // Every field is optional, so an empty patch is a schema-valid request.
+        // Drizzle throws "No values to set" on an empty SET, which surfaced as
+        // a misleading 500 — a no-op request has to be a no-op.
+        if (Object.keys(changes).length === 0) {
+          const [existing] = yield* appDatabase.execute((client) =>
+            client.select().from(worksheetsTable).where(activeWorksheet).limit(1)
+          )
+
+          if (existing === undefined) {
+            return yield* new WorksheetNotFoundError({
+              message: 'This worksheet no longer exists.',
+              worksheetId: id
+            })
+          }
+
+          return transformWorksheet(existing)
+        }
+
         const [worksheet] = yield* appDatabase.execute((client) =>
           client
             .update(worksheetsTable)
             .set(changes)
-            .where(eq(worksheetsTable.id, id))
+            // Soft-deleted worksheets are excluded like they are in list and
+            // reorder; without this a PATCH would resurrect and return one.
+            .where(activeWorksheet)
             .returning()
         )
 


### PR DESCRIPTION
**Stack:** #23 ← **this** ← `fix/durable-lifecycle` ← `fix/local-api-hardening` ← `fix/packaged-native-modules`

Review on top of #23. Everything here serves one outcome: when something goes
wrong, the user sees something they can act on instead of a broken screen.

### The database form lost its inline errors

The derived client encodes payloads against the contract *before* sending, so
invalid input failed with a `ParseError` whose message is the multi-line schema
tree. `toThrowable` classified that as infrastructure and produced
`ApiError(500, <tree>)` with no `details`, so the form dumped the tree into a
toast and `applyServerFieldErrors` became a no-op.

`ParseError` is now classified by phase — a per-call marker records whether the
request was actually sent — so an encode failure becomes a 400 carrying field
details built with `ParseResult.ArrayFormatter`, the same shape the server's
decode errors already use. A response that doesn't match the contract is
reported as a bug instead. Undeclared statuses and transport failures no longer
leak `StatusCode: non 2xx status code` into toasts; the real message goes to the
console.

### One unreadable secret bricked the whole databases list

`DatabaseService.list` used fail-fast `Effect.forEach`, so a single connection
whose stored secret couldn't be decrypted — after an OS keychain reset, say —
failed the entire route, and `orDieInternal` discarded the authored remediation
message on the way out. The result was a permanently empty databases UI behind a
bare 500. Rows now degrade individually with `connectionInfo: null` (mirroring
how stored query results are already handled) and the form says so and repairs
the row on save.

### The query history was unreachable against real data

Found by running the branch against a real app database, not by the test suite:
`GET /queries` answered **400 with a 4.5 MB body** of encode issues.
`transformQueryRow` cast parsed JSON straight to `QueryResult`, and results
stored by earlier versions have no `truncated` field, so one legacy row failed
*response* encoding and took the whole list down. The existing comment already
promised "one unreadable stored result must not take down the whole history
list" — the guard just only covered `JSON.parse` throwing, not shape drift.

Worth knowing generally: strict Effect Schema response encoding turns any drift
between historical stored JSON and a current DTO into a total route failure.

### Also here

Both `update` methods lacked the `isNull(deletedAt)` filter their siblings all
have, so a PATCH on a soft-deleted database re-encrypted a password onto the row
`remove()` had deliberately purged. `AppDatabase` reported every SQLite failure
as "the app database is unavailable", which misdiagnosed constraint violations.
An empty worksheet patch is a no-op instead of a 500. Plus: the client is
resolved once per session rather than rebuilt on every call including the 250 ms
poller, renderer spans regained `http.status_code`, and a rejected token promise
is no longer cached forever.

### Verification

`yarn typecheck`, `yarn lint`, 503 tests pass on this branch alone. Driven in
the real app: Test Connection with an empty Host renders `Host is required.`
under the field and sends no request (only the span exporter fires), and the
same `GET /queries` that returned 400 now returns 200 with all 60 queries.