### PR TITLE
fix: survive shutdown and a second instance

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -48,7 +48,8 @@
       "Bash(head -30 /Users/artmann/code/squeal/tsconfig.*.json)",
       "Bash(git commit:*)",
       "Bash(git push:*)",
-      "mcp__package-registry__get-npm-package-details"
+      "mcp__package-registry__get-npm-package-details",
+      "mcp__deepwiki__ask_question"
     ],
     "deny": [],
     "ask": []

--- a/src/glue/api/schemas.ts
+++ b/src/glue/api/schemas.ts
@@ -2,6 +2,8 @@
 // main-process imports — the renderer bundles it.
 import { Schema } from 'effect'
 
+import { isValidSpanId, isValidTraceId } from '../tracing/traceparent'
+
 // --- Request ids ---------------------------------------------------------------
 // Validated but deliberately unbranded: ids round-trip through DTOs and the
 // typed client as plain strings, and a brand here would force a decode at
@@ -12,7 +14,11 @@ export const DatabaseId = Schema.String.pipe(Schema.minLength(1))
 
 export const QueryId = Schema.String.pipe(Schema.minLength(1))
 
-export const TraceId = Schema.String.pipe(Schema.pattern(/^[0-9a-f]{32}$/))
+export const TraceId = Schema.String.pipe(
+  Schema.filter(isValidTraceId, {
+    message: () => 'Expected a 32-character hexadecimal trace id.'
+  })
+)
 
 export const WorksheetId = Schema.String.pipe(Schema.minLength(1))
 
@@ -305,8 +311,20 @@ export type ConnectionTestResponse = Schema.Schema.Type<
 
 // --- Traces ---------------------------------------------------------------------
 
-const spanIdPattern = /^[0-9a-f]{16}$/
-const traceIdPattern = /^[0-9a-f]{32}$/
+// All-zero ids are rejected as well as malformed ones: they are unusable as a
+// lookup key, so accepting them would merge unrelated spans into one
+// unopenable trace.
+const SpanIdField = Schema.String.pipe(
+  Schema.filter(isValidSpanId, {
+    message: () => 'Expected a 16-character hexadecimal span id.'
+  })
+)
+
+const TraceIdField = Schema.String.pipe(
+  Schema.filter(isValidTraceId, {
+    message: () => 'Expected a 32-character hexadecimal trace id.'
+  })
+)
 
 const SpanAttributesDto = Schema.mutable(
   Schema.Record({
@@ -325,17 +343,15 @@ const SpanDto = Schema.Struct({
   attributes: SpanAttributesDto,
   durationMs: Schema.Number.pipe(Schema.greaterThanOrEqualTo(0)),
   events: Schema.mutable(Schema.Array(SpanEventDto)),
-  id: Schema.String.pipe(Schema.pattern(spanIdPattern)),
+  id: SpanIdField,
   kind: Schema.Literal('client', 'internal', 'server'),
   name: Schema.String.pipe(Schema.minLength(1)),
-  parentSpanId: Schema.NullOr(
-    Schema.String.pipe(Schema.pattern(spanIdPattern))
-  ),
+  parentSpanId: Schema.NullOr(SpanIdField),
   serviceName: Schema.Literal('main', 'renderer'),
   startedAt: Schema.Number,
   status: Schema.Literal('error', 'ok', 'unset'),
   statusMessage: Schema.NullOr(Schema.String),
-  traceId: Schema.String.pipe(Schema.pattern(traceIdPattern))
+  traceId: TraceIdField
 })
 export type SpanDto = Schema.Schema.Type<typeof SpanDto>
 

--- a/src/glue/tracing/traceparent.ts
+++ b/src/glue/tracing/traceparent.ts
@@ -3,10 +3,24 @@
 
 import { SpanContext } from './spans'
 
+const spanIdPattern = /^[0-9a-f]{16}$/
+const traceIdPattern = /^[0-9a-f]{32}$/
 const traceparentPattern = /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/
 
 export function formatTraceparent(context: SpanContext): string {
   return `00-${context.traceId}-${context.spanId}-01`
+}
+
+// The single source of truth for what counts as a usable id. Ids can arrive
+// from anywhere — a traceparent, a b3 header, or the renderer's span ingest —
+// and an id that fails this check cannot be looked up again, so it must never
+// be stored.
+export function isValidSpanId(value: string): boolean {
+  return spanIdPattern.test(value) && !isAllZeros(value)
+}
+
+export function isValidTraceId(value: string): boolean {
+  return traceIdPattern.test(value) && !isAllZeros(value)
 }
 
 export function parseTraceparent(
@@ -24,7 +38,7 @@ export function parseTraceparent(
     return undefined
   }
 
-  if (isAllZeros(traceId) || isAllZeros(spanId)) {
+  if (!isValidTraceId(traceId) || !isValidSpanId(spanId)) {
     return undefined
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
-import { Effect } from 'effect'
+import { Cause, Effect, Exit } from 'effect'
 import { randomBytes } from 'node:crypto'
 import { writeFileSync } from 'node:fs'
 import path from 'node:path'
@@ -52,10 +52,25 @@ if (started) {
   app.quit()
 }
 
+// Taken before anything can touch the app database. A second instance used to
+// run the boot effects against the shared SQLite file and only then fail on the
+// port bind — and reconciliation marks *every* unfinished query failed, with no
+// instance scoping, so it poisoned the running instance's in-flight queries.
+const hasSingleInstanceLock = app.requestSingleInstanceLock()
+
+if (!hasSingleInstanceLock) {
+  app.quit()
+}
+
 export let mainWindow: BrowserWindow
 
 let runtime: MainRuntime | undefined
 let quitting = false
+let disposed = false
+
+// Long enough for a normal flush, short enough that a wedged dependency cannot
+// hold the app open.
+const disposeTimeoutMs = 3_000
 
 const createWindow = async () => {
   mainWindow = new BrowserWindow({
@@ -128,6 +143,13 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+// Quitting while the layer is still building interrupts it. That is a shutdown,
+// not a boot failure, so it must not raise a dialog racing the before-quit
+// handler's own exit.
+function isShutdownInterruption(cause: Cause.Cause<unknown>): boolean {
+  return quitting || Cause.isInterruptedOnly(cause)
+}
+
 function reportBootFailure(error: unknown): void {
   // Written synchronously: app.exit terminates before buffered stdout would be
   // flushed, and a boot failure with no trace is undebuggable.
@@ -148,6 +170,12 @@ function reportBootFailure(error: unknown): void {
 }
 
 app.on('ready', async () => {
+  // A losing second instance is already quitting; booting the backend here
+  // would still write to the shared database before the process goes away.
+  if (!hasSingleInstanceLock) {
+    return
+  }
+
   applyDevelopmentDockIcon()
 
   apiToken = randomBytes(32).toString('hex')
@@ -159,14 +187,18 @@ app.on('ready', async () => {
     token: apiToken
   })
 
-  try {
-    // Forces the runtime layer to build: the app database initializes,
-    // interrupted queries are reconciled, the encryption migration runs
-    // (safeStorage is only reliable once the app is ready), and only then
-    // does the HTTP server start listening.
-    await runtime.runPromise(Effect.void)
-  } catch (error) {
-    reportBootFailure(error)
+  // Forces the runtime layer to build: the app database initializes,
+  // interrupted queries are reconciled, the encryption migration runs
+  // (safeStorage is only reliable once the app is ready), and only then
+  // does the HTTP server start listening.
+  const bootExit = await runtime.runPromiseExit(Effect.void)
+
+  if (Exit.isFailure(bootExit)) {
+    if (isShutdownInterruption(bootExit.cause)) {
+      return
+    }
+
+    reportBootFailure(Cause.squash(bootExit.cause))
     app.exit(1)
 
     return
@@ -175,23 +207,51 @@ app.on('ready', async () => {
   createWindow()
 })
 
+app.on('second-instance', () => {
+  if (mainWindow === undefined) {
+    return
+  }
+
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore()
+  }
+
+  mainWindow.focus()
+})
+
 // The first real shutdown path this app has had: disposing the runtime
 // closes the HTTP server, interrupts the retention fibers and any running
 // queries (best-effort canceling their server-side statements), and releases
 // the app database.
 app.on('before-quit', (event) => {
-  if (quitting || runtime === undefined) {
+  if (runtime === undefined || disposed) {
+    return
+  }
+
+  // Every quit signal arriving during the dispose window has to keep being
+  // prevented. Returning early without preventDefault let a second Cmd+Q — or
+  // window-all-closed firing app.quit() — complete the quit and kill the
+  // process mid-flush, defeating the whole point of this handler.
+  event.preventDefault()
+
+  if (quitting) {
     return
   }
 
   quitting = true
-  event.preventDefault()
+
+  let timer: ReturnType<typeof setTimeout> | undefined
 
   const timeout = new Promise((resolve) => {
-    setTimeout(resolve, 3_000)
+    timer = setTimeout(resolve, disposeTimeoutMs)
   })
 
   void Promise.race([runtime.dispose(), timeout]).finally(() => {
+    if (timer !== undefined) {
+      clearTimeout(timer)
+    }
+
+    disposed = true
     app.exit(0)
   })
 })

--- a/src/server/retention.ts
+++ b/src/server/retention.ts
@@ -6,21 +6,29 @@ import { Duration, Effect, Layer, Schedule } from 'effect'
 
 import { deleteExpiredQueries } from '@/main/queries/query-retention'
 import { deleteExpiredSpans } from '@/main/tracing/trace-retention'
+import { AppDatabase } from './services/app-database'
 
 function dailySweep(
   name: string,
   sweep: () => Promise<number>
-): Layer.Layer<never> {
+): Layer.Layer<never, never, AppDatabase> {
   return Layer.scopedDiscard(
-    Effect.promise(sweep).pipe(
-      // One failed sweep must not stop the schedule — log and try again
-      // tomorrow.
-      Effect.catchAllCause((cause) =>
-        Effect.logError(`${name} cleanup failed`, cause)
-      ),
-      Effect.repeat(Schedule.fixed(Duration.days(1))),
-      Effect.forkScoped
-    )
+    Effect.gen(function* () {
+      // Depending on AppDatabase is what orders the first sweep after schema
+      // initialization. Without it this layer declares no dependencies, and
+      // mergeAll starts the boot sweep concurrently with initializeDatabase().
+      yield* AppDatabase
+
+      yield* Effect.promise(sweep).pipe(
+        // One failed sweep must not stop the schedule — log and try again
+        // tomorrow.
+        Effect.catchAllCause((cause) =>
+          Effect.logError(`${name} cleanup failed`, cause)
+        ),
+        Effect.repeat(Schedule.fixed(Duration.days(1))),
+        Effect.forkScoped
+      )
+    })
   )
 }
 

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -48,14 +48,19 @@ export function makeMainRuntime(options: MainRuntimeOptions) {
     )
   )
 
+  // Order matters and is not obvious: `provideMerge` builds right to left, so
+  // ServicesLive (and with it AppDatabase) is acquired first and released last.
+  // TracerLive sits inside it deliberately — the tracer must flush its queued
+  // spans before the database handle closes, and finalizers run in reverse
+  // acquisition order.
   const MainLive = Layer.mergeAll(
     HttpLive.pipe(Layer.provide(BootLive)),
     RetentionLive
   ).pipe(
+    Layer.provideMerge(TracerLive),
     Layer.provideMerge(ServicesLive),
     Layer.provide(Layer.succeed(ApiToken, Redacted.make(options.token))),
-    Layer.provide(configuration),
-    Layer.provideMerge(TracerLive)
+    Layer.provide(configuration)
   )
 
   return ManagedRuntime.make(MainLive)

--- a/src/server/services/query-runner.ts
+++ b/src/server/services/query-runner.ts
@@ -182,7 +182,8 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
         )
 
         if (outcome._tag === 'canceled') {
-          yield* recordCanceledEvent
+          // The event is recorded on the db.query span inside runAdapterQuery,
+          // which is the span that represents the canceled statement.
           yield* writeFailure(query.id, canceledQueryMessage)
 
           return

--- a/src/server/tracing/effect-tracer.test.ts
+++ b/src/server/tracing/effect-tracer.test.ts
@@ -1,9 +1,12 @@
 import { Cause, Context, Effect, Exit, FiberId, Layer, Option, Tracer } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import { spansTable } from '@/database/schema'
 import { SpanRecord } from '@/glue/tracing/spans'
+import { AppDatabase } from '@/server/services/app-database'
+import { makeTestAppDatabase } from '@/test/effect-test-helper'
 
-import { makeSquealTracer } from './effect-tracer'
+import { makeSquealTracer, TracerLive } from './effect-tracer'
 
 const startNanos = 1_700_000_000_000_000_000n
 const endNanos = startNanos + 25_000_000n
@@ -138,6 +141,42 @@ describe('makeSquealTracer', () => {
     expect(written[0].traceId).toEqual('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
   })
 
+  // The platform's b3 fallback does not validate inbound ids at all, and an id
+  // the TraceId schema rejects would produce a trace the dashboard lists but
+  // cannot open.
+  it('ignores a parent whose trace id is not a usable W3C id', () => {
+    const { tracer, written } = makeCollector()
+    const external = Tracer.externalSpan({
+      spanId: 'aaaaaaaaaaaaaaaa',
+      traceId: 'junk'
+    })
+    const span = startSpan(tracer, { parent: Option.some(external) })
+
+    span.end(endNanos, Exit.succeed(undefined))
+
+    expect(written[0].parentSpanId).toEqual(null)
+    expect(written[0].traceId).toEqual(
+      expect.stringMatching(/^[0-9a-f]{32}$/)
+    )
+    expect(written[0].traceId).not.toEqual('junk')
+  })
+
+  it('ignores an all-zero parent so those spans do not merge into one trace', () => {
+    const { tracer, written } = makeCollector()
+    const external = Tracer.externalSpan({
+      spanId: '0000000000000000',
+      traceId: '00000000000000000000000000000000'
+    })
+    const span = startSpan(tracer, { parent: Option.some(external) })
+
+    span.end(endNanos, Exit.succeed(undefined))
+
+    expect(written[0].parentSpanId).toEqual(null)
+    expect(written[0].traceId).not.toEqual(
+      '00000000000000000000000000000000'
+    )
+  })
+
   it('coerces and truncates attribute values', () => {
     const { tracer, written } = makeCollector()
     const span = startSpan(tracer)
@@ -211,4 +250,32 @@ describe('makeSquealTracer', () => {
     expect(child.traceId).toEqual(parent.traceId)
     expect(child.parentSpanId).toEqual(parent.id)
   })
+})
+
+describe('TracerLive', () => {
+  // Spans are queued rather than written inline, so the shutdown flush is the
+  // only thing that keeps the spans explaining a shutdown from being lost.
+  it('flushes queued spans when its scope closes', async () => {
+    const rows = await Effect.runPromise(
+      Effect.gen(function* () {
+        const appDatabase = yield* AppDatabase
+
+        yield* Effect.void.pipe(
+          Effect.withSpan('queued.child'),
+          Effect.withSpan('queued.parent'),
+          Effect.provide(TracerLive)
+        )
+
+        return yield* Effect.promise(() =>
+          appDatabase.client.select().from(spansTable)
+        )
+      }).pipe(Effect.provide(makeTestAppDatabase()))
+    )
+
+    expect(rows.map((row) => row.name).sort()).toEqual([
+      'queued.child',
+      'queued.parent'
+    ])
+  })
+
 })

--- a/src/server/tracing/effect-tracer.ts
+++ b/src/server/tracing/effect-tracer.ts
@@ -2,11 +2,13 @@
 // Tracer whose spans persist straight into the spans table via writeSpans.
 // Effect already generates W3C-format ids, so the renderer's traceparent
 // propagation and the existing dashboard keep working unchanged.
-import { Cause, Exit, Layer, Option, Tracer } from 'effect'
+import { Cause, Chunk, Effect, Exit, Layer, Option, Queue, Tracer } from 'effect'
 import type { Context } from 'effect'
 import { log } from 'tiny-typescript-logger'
 
 import { generateTraceId, generateSpanId } from '@/glue/tracing/ids'
+import { isValidSpanId, isValidTraceId } from '@/glue/tracing/traceparent'
+import { AppDatabase } from '../services/app-database'
 import {
   maxAttributeValueLength,
   maxStacktraceLength,
@@ -36,7 +38,86 @@ export function makeSquealTracer(
   })
 }
 
-export const TracerLive = Layer.setTracer(makeSquealTracer())
+// Writes are batched, so one INSERT covers a whole burst rather than one per
+// span end.
+const spanBatchSize = 100
+const spanQueueCapacity = 2048
+const spanFlushTimeout = '2 seconds'
+const droppedSpanLogInterval = 100
+
+// Offering never blocks and never awaits: a span must not slow down the
+// operation it measures, and unbounded in-flight writes are exactly what this
+// queue exists to prevent. A full queue means the writer has fallen far
+// behind, so spans are dropped — loudly — instead of being retained.
+function makeQueuedPersist(
+  queue: Queue.Queue<SpanRecord>
+): (records: SpanRecord[]) => Promise<unknown> {
+  let dropped = 0
+
+  return (records) => {
+    for (const record of records) {
+      if (!Queue.unsafeOffer(queue, record)) {
+        dropped += 1
+
+        if (dropped % droppedSpanLogInterval === 1) {
+          log.warn(`Span queue is full; dropped ${dropped} span(s).`)
+        }
+      }
+    }
+
+    return Promise.resolve()
+  }
+}
+
+// Depends on AppDatabase for two reasons: spans are written through the service
+// rather than a direct `@/database` import, and the dependency forces this
+// layer to be torn down *before* the database handle closes — otherwise the
+// shutdown flush would race the closing client and lose exactly the spans that
+// explain the shutdown.
+export const TracerLive = Layer.unwrapScoped(
+  Effect.gen(function* () {
+    const appDatabase = yield* AppDatabase
+    const queue = yield* Queue.bounded<SpanRecord>(spanQueueCapacity)
+
+    const writeBatch = (records: ReadonlyArray<SpanRecord>) =>
+      appDatabase
+        .execute((client) => writeSpans([...records], client))
+        .pipe(
+          Effect.catchAllCause((cause) =>
+            Effect.logError('Could not write spans', cause)
+          ),
+          // Writing a span must never itself be traced.
+          Effect.withTracerEnabled(false)
+        )
+
+    // Registered before the drain fiber so teardown interrupts the fiber first
+    // (finalizers run last-in-first-out) and this then drains the remainder.
+    yield* Effect.addFinalizer(() =>
+      Queue.takeAll(queue).pipe(
+        Effect.flatMap((remaining) =>
+          Chunk.isEmpty(remaining)
+            ? Effect.void
+            : writeBatch(Chunk.toReadonlyArray(remaining))
+        ),
+        Effect.timeout(spanFlushTimeout),
+        Effect.catchAllCause((cause) =>
+          Effect.logError('Could not flush pending spans', cause)
+        )
+      )
+    )
+
+    yield* Effect.forkScoped(
+      Queue.takeBetween(queue, 1, spanBatchSize).pipe(
+        Effect.flatMap((records) => writeBatch(Chunk.toReadonlyArray(records))),
+        Effect.forever
+      )
+    )
+
+    return Layer.setTracer(
+      makeSquealTracer({ persist: makeQueuedPersist(queue) })
+    )
+  })
+)
 
 class SquealSpan implements Tracer.Span {
   readonly _tag = 'Span' as const
@@ -63,19 +144,29 @@ class SquealSpan implements Tracer.Span {
     kind: Tracer.SpanKind,
     persist: (records: SpanRecord[]) => Promise<unknown>
   ) {
+    // Inbound parents come from client headers, and the platform's b3 fallback
+    // does not validate them at all. An unusable id would produce a trace the
+    // dashboard lists but cannot open (GET /traces/:id rejects it), so a parent
+    // that fails validation is treated as absent and this span starts a fresh
+    // root trace.
+    const usableParent = Option.filter(
+      parent,
+      (span) => isValidTraceId(span.traceId) && isValidSpanId(span.spanId)
+    )
+
     this.context = context
     this.kind = kind
     this.links = links.slice()
     this.name = name
-    this.parent = parent
+    this.parent = usableParent
     this.persist = persist
-    this.sampled = Option.match(parent, {
+    this.sampled = Option.match(usableParent, {
       onNone: () => true,
       onSome: (span) => span.sampled
     })
     this.spanId = generateSpanId()
     this.status = { _tag: 'Started', startTime }
-    this.traceId = Option.match(parent, {
+    this.traceId = Option.match(usableParent, {
       onNone: () => generateTraceId(),
       onSome: (span) => span.traceId
     })


### PR DESCRIPTION
**Stack:** #23 ← #24 ← **this** ← `fix/local-api-hardening` ← `fix/packaged-native-modules`

Review #24 first. One outcome here: starting and stopping the app doesn't lose
or corrupt state.

### Span writes were fire-and-forget

Every span end fired an unawaited INSERT, so bursts piled up unbounded in-flight
promises and shutdown lost exactly the spans that explain a shutdown — the
writes raced the `AppDatabase` finalizer closing the same client. `main` awaited
every write inside `withSpan`'s `finally`, so this was a regression.

Spans are now offered to a bounded queue drained in batches by a fiber owned by
the tracer layer's scope, with a flush finalizer for whatever is still queued.
Offering never blocks; a full queue drops loudly rather than retaining, which is
the bound the house memory rules ask for.

The tracer layer now depends on `AppDatabase` — partly so it writes through the
service rather than a direct `@/database` import, but mainly so it is torn down
*before* the database handle closes. `runtime.ts` is reordered accordingly, and
the requirement is commented, because `provideMerge` ordering is invisible
otherwise.

### A second quit killed the flush

`before-quit` returned early without calling `preventDefault` once `quitting`
was set, so a second Cmd+Q — or `window-all-closed` firing `app.quit()` — during
the dispose window completed the quit and killed the process mid-flush, which is
exactly what the handler exists to prevent.

### A second instance clobbered the first one's queries

There was no single-instance lock. A second launch ran the boot effects against
the shared SQLite file and only *then* failed on the port bind — and
reconciliation marks every unfinished query failed with no instance scoping. So
starting a second instance poisoned the running instance's in-flight queries.
The lock is now taken before anything can touch the database.

Also: quitting mid-boot interrupts the layer build, which is a shutdown rather
than a boot failure, so it no longer raises a "Squeal could not start" dialog
racing the shutdown path. And `RetentionLive` declared no dependencies while
reaching SQLite directly, so `mergeAll` could start its boot sweep concurrently
with `initializeDatabase()`; it now depends on `AppDatabase`.

### Verification

`yarn typecheck`, `yarn lint`, 506 tests pass on this branch. Verified by hand
on a packaged build: two instances launched back to back, and the second exits
with a completely empty log — i.e. before `ready`, so it never reaches the
reconciliation that was the problem — while the first stays healthy. Quitting
logs no span-write or flush errors, meaning the flush completes before the
database closes.