### PR TITLE
fix: close off the loopback API

### DIFF
--- a/src/server/http/api.test.ts
+++ b/src/server/http/api.test.ts
@@ -31,6 +31,22 @@ function rawRequest(
   )
 }
 
+function rawHeaders(
+  request: HttpClientRequest.HttpClientRequest,
+  options: TestApiOptions = {}
+): Promise<Record<string, string>> {
+  const { layer } = makeTestApi(options)
+
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const http = yield* HttpClient.HttpClient
+      const response = yield* http.execute(request)
+
+      return { ...response.headers }
+    }).pipe(Effect.scoped, Effect.provide(layer))
+  )
+}
+
 describe('authentication', () => {
   it('serves /health without a token', async () => {
     const response = await rawRequest(HttpClientRequest.get('/health'))
@@ -109,5 +125,144 @@ describe('authentication', () => {
     expect(response.body).toEqual(
       expect.objectContaining({ _tag: 'HttpApiDecodeError' })
     )
+  })
+
+  // The scheme token is case-insensitive per RFC 7235, and the platform's own
+  // bearer decoder ignores its case, so the trace-read middleware must too.
+  it('accepts a lowercase bearer scheme on a normal route', async () => {
+    const response = await rawRequest(
+      HttpClientRequest.get('/databases').pipe(
+        HttpClientRequest.setHeader('authorization', `bearer ${testApiToken}`)
+      )
+    )
+
+    expect(response).toEqual({ body: { databases: [] }, status: 200 })
+  })
+
+  it('accepts a lowercase bearer scheme on trace reads', async () => {
+    const response = await rawRequest(
+      HttpClientRequest.get('/traces').pipe(
+        HttpClientRequest.setHeader('authorization', `bearer ${testApiToken}`)
+      )
+    )
+
+    expect(response).toEqual({ body: { traces: [] }, status: 200 })
+  })
+
+  // A browser always sends Origin cross-origin, so the development carve-out
+  // must not apply to it — otherwise any visited page could read the span
+  // store, which carries the user's SQL.
+  it('requires the token for a browser trace read even with public reads on', async () => {
+    const response = await rawRequest(
+      HttpClientRequest.get('/traces').pipe(
+        HttpClientRequest.setHeader('origin', 'null')
+      ),
+      { publicTraceReads: true }
+    )
+
+    expect(response).toEqual({
+      body: { _tag: 'UnauthorizedError', message: 'Unauthorized' },
+      status: 401
+    })
+  })
+})
+
+describe('cors', () => {
+  it('does not echo an allowed origin back to a foreign origin', async () => {
+    const headers = await rawHeaders(
+      HttpClientRequest.get('/health').pipe(
+        HttpClientRequest.setHeader('origin', 'https://evil.example')
+      )
+    )
+
+    expect(headers['access-control-allow-origin']).toBeUndefined()
+  })
+
+  it('allows the origin a packaged renderer sends', async () => {
+    const headers = await rawHeaders(
+      HttpClientRequest.get('/health').pipe(
+        HttpClientRequest.setHeader('origin', 'null')
+      )
+    )
+
+    expect(headers['access-control-allow-origin']).toEqual('null')
+  })
+
+  it('allows a configured development origin', async () => {
+    const headers = await rawHeaders(
+      HttpClientRequest.get('/health').pipe(
+        HttpClientRequest.setHeader('origin', 'http://localhost:5173')
+      ),
+      { allowedOrigins: ['null', 'http://localhost:5173'] }
+    )
+
+    expect(headers['access-control-allow-origin']).toEqual(
+      'http://localhost:5173'
+    )
+  })
+})
+
+describe('request guards', () => {
+  // CORS cannot stop DNS rebinding, so the Host header is checked separately.
+  it('refuses a request addressed to a foreign host', async () => {
+    const response = await rawRequest(
+      HttpClientRequest.get('/health').pipe(
+        HttpClientRequest.setHeader('host', 'attacker.example')
+      )
+    )
+
+    expect(response.status).toEqual(403)
+  })
+
+  it('serves a request addressed to loopback', async () => {
+    const response = await rawRequest(HttpClientRequest.get('/health'))
+
+    expect(response.status).toEqual(200)
+  })
+
+  // Asserts the invariant rather than the status: the guard answers as soon as
+  // Content-Length exceeds the limit, without consuming the body, so this
+  // client usually sees the connection close before it can read the 413. What
+  // must hold is that the oversized body was never stored.
+  it('does not store an oversized request body', async () => {
+    const { layer } = makeTestApi()
+
+    const worksheets = await Effect.runPromise(
+      Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient
+
+        yield* http
+          .execute(
+            HttpClientRequest.post('/worksheets').pipe(
+              HttpClientRequest.setHeader(
+                'authorization',
+                `Bearer ${testApiToken}`
+              ),
+              HttpClientRequest.bodyUnsafeJson({
+                name: 'x'.repeat(9 * 1024 * 1024)
+              })
+            )
+          )
+          .pipe(Effect.ignore)
+
+        const response = yield* http.execute(
+          HttpClientRequest.get('/worksheets').pipe(
+            HttpClientRequest.setHeader(
+              'authorization',
+              `Bearer ${testApiToken}`
+            )
+          )
+        )
+
+        const body = (yield* response.json) as {
+          worksheets: Array<{ name: string }>
+        }
+
+        return body.worksheets.map((worksheet) => worksheet.name)
+      }).pipe(Effect.scoped, Effect.provide(layer))
+    )
+
+    // Only the default worksheet the service seeds — the oversized one is gone.
+    expect(worksheets).toEqual(['My First Worksheet'])
   })
 })

--- a/src/server/http/authorization-live.ts
+++ b/src/server/http/authorization-live.ts
@@ -4,7 +4,7 @@ import { Config, Effect, Layer, Redacted } from 'effect'
 import { UnauthorizedError } from '@/glue/api/errors'
 import { Authorization, TraceReadAuthorization } from '@/glue/api/security'
 import { ApiToken } from './api-token'
-import { isAuthorized } from './authorization'
+import { bearerCredential, isAuthorized } from './authorization'
 
 const unauthorized = new UnauthorizedError({ message: 'Unauthorized' })
 
@@ -22,9 +22,10 @@ export const AuthorizationLive = Layer.effect(
   })
 )
 
-// Trace reads are public in development so local agents can curl them
-// without the token (the server binds loopback only). Everywhere else they
-// fall back to the same bearer check as every other route.
+// Trace reads are public in development so local agents can curl them without
+// the token (the server binds loopback only). Everywhere else — and for every
+// browser-issued request, including in development — they fall back to the same
+// bearer check as every other route.
 export const TraceReadAuthorizationLive = Layer.effect(
   TraceReadAuthorization,
   Effect.gen(function* () {
@@ -33,16 +34,26 @@ export const TraceReadAuthorizationLive = Layer.effect(
     )
     const token = yield* ApiToken
 
-    if (publicTraceReads) {
-      return Effect.void
-    }
-
     return Effect.gen(function* () {
       const request = yield* HttpServerRequest.HttpServerRequest
-      const header = request.headers.authorization ?? ''
-      const presented = header.startsWith('Bearer ') ? header.slice(7) : ''
 
-      if (!isAuthorized(presented, Redacted.value(token))) {
+      // The carve-out is deliberately limited to callers that send no Origin,
+      // which means curl and other tooling. A browser always sends one on a
+      // cross-origin fetch (an opaque origin sends the literal "null"), and
+      // 'null' has to stay on the CORS allowlist for the packaged renderer
+      // loaded from file:// — so without this check any page a developer
+      // visited could read the span store, which contains their SQL, from a
+      // sandboxed iframe.
+      if (publicTraceReads && request.headers.origin === undefined) {
+        return
+      }
+
+      if (
+        !isAuthorized(
+          bearerCredential(request.headers.authorization),
+          Redacted.value(token)
+        )
+      ) {
         return yield* Effect.fail(unauthorized)
       }
     })

--- a/src/server/http/authorization.ts
+++ b/src/server/http/authorization.ts
@@ -1,5 +1,24 @@
 import { createHash, timingSafeEqual } from 'node:crypto'
 
+const bearerScheme = /^bearer[ \t]+/i
+
+// RFC 7235 §2.1 makes the scheme token case-insensitive, and the platform's own
+// bearer decoder ignores its case too. Being stricter here is what made
+// lowercase `bearer` work on every route except the trace reads.
+export function bearerCredential(header: string | undefined): string {
+  if (header === undefined) {
+    return ''
+  }
+
+  const match = bearerScheme.exec(header)
+
+  if (match === null) {
+    return ''
+  }
+
+  return header.slice(match[0].length)
+}
+
 // Hashing both sides first makes timingSafeEqual usable for tokens of
 // unequal length without leaking the length through an early return.
 export function isAuthorized(presented: string, token: string): boolean {

--- a/src/server/http/connection-tests.test.ts
+++ b/src/server/http/connection-tests.test.ts
@@ -105,4 +105,95 @@ describe('connection test route', () => {
     expect(result).toEqual({ success: true })
     expect(adapterState.lastConnectionInfo).toEqual(connectionInfo)
   })
+
+  // Otherwise an authenticated caller could aim a saved password at a server
+  // they control and read it off the handshake.
+  it('refuses to lend the stored password to a different host', async () => {
+    const { adapterState, result } = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        return yield* client.connectionTests.create({
+          payload: {
+            connectionInfo: {
+              ...connectionInfo,
+              host: 'attacker.example',
+              password: ''
+            },
+            databaseId: created.database.id,
+            type: 'postgres'
+          }
+        })
+      })
+    )
+
+    expect(result).toEqual({
+      message: 'Enter the password to test a different server.',
+      success: false
+    })
+
+    // No adapter was built for the attacker's host, so nothing was sent.
+    expect(adapterState.lastConnectionInfo).toEqual(null)
+  })
+
+  it('refuses to lend the stored password to a different port', async () => {
+    const { result } = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        return yield* client.connectionTests.create({
+          payload: {
+            connectionInfo: { ...connectionInfo, password: '', port: 6000 },
+            databaseId: created.database.id,
+            type: 'postgres'
+          }
+        })
+      })
+    )
+
+    expect(result).toEqual({
+      message: 'Enter the password to test a different server.',
+      success: false
+    })
+  })
+
+  // Editing the username or database still targets the same trusted server, so
+  // the borrow stays allowed there.
+  it('still borrows the stored password when only the database name changes', async () => {
+    const { adapterState, result } = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        return yield* client.connectionTests.create({
+          payload: {
+            connectionInfo: {
+              ...connectionInfo,
+              database: 'other',
+              password: ''
+            },
+            databaseId: created.database.id,
+            type: 'postgres'
+          }
+        })
+      })
+    )
+
+    expect(result).toEqual({ success: true })
+    expect(adapterState.lastConnectionInfo).toEqual({
+      ...connectionInfo,
+      database: 'other'
+    })
+  })
 })

--- a/src/server/http/handlers/connection-tests.ts
+++ b/src/server/http/handlers/connection-tests.ts
@@ -4,11 +4,36 @@ import { Effect, Option } from 'effect'
 import { SquealApi } from '@/glue/api/api'
 import type {
   ConnectionInfo,
-  ConnectionTestRequest
+  ConnectionTestRequest,
+  UpdateConnectionInfo
 } from '@/glue/api/schemas'
 import { AdapterFactory } from '@/server/services/adapter-factory'
 import { DatabaseService } from '@/server/services/database-service'
 import { orDieInternal } from '../internal-errors'
+
+type ResolvedConnection =
+  | { readonly _tag: 'resolved'; readonly connectionInfo: ConnectionInfo }
+  | { readonly _tag: 'differentServer' }
+  | { readonly _tag: 'passwordRequired' }
+
+// The stored password may only be lent back to the server it was saved for.
+// Only host and port are compared, because those decide where the secret is
+// actually sent: editing the username or database name still targets the same
+// trusted server, so requiring a re-typed password there would be friction
+// without a security gain.
+function targetsSameServer(
+  requested: UpdateConnectionInfo,
+  stored: ConnectionInfo
+): boolean {
+  if (!('username' in requested) || !('username' in stored)) {
+    return false
+  }
+
+  return (
+    requested.host === stored.host &&
+    (requested.port ?? undefined) === (stored.port ?? undefined)
+  )
+}
 
 // A test without a password uses the stored one — the renderer never sees
 // passwords, so testing an existing connection sends its databaseId instead.
@@ -19,11 +44,14 @@ const resolveTestConnectionInfo = (payload: ConnectionTestRequest) =>
       !('username' in connectionInfo) || connectionInfo.password
 
     if (hasPassword) {
-      return Option.some(connectionInfo as ConnectionInfo)
+      return {
+        _tag: 'resolved',
+        connectionInfo: connectionInfo as ConnectionInfo
+      } as const
     }
 
     if (databaseId === undefined) {
-      return Option.none<ConnectionInfo>()
+      return { _tag: 'passwordRequired' } as const
     }
 
     const service = yield* DatabaseService
@@ -34,13 +62,22 @@ const resolveTestConnectionInfo = (payload: ConnectionTestRequest) =>
       stored.value.type !== type ||
       !('password' in stored.value.connectionInfo)
     ) {
-      return Option.none<ConnectionInfo>()
+      return { _tag: 'passwordRequired' } as const
     }
 
-    return Option.some<ConnectionInfo>({
-      ...connectionInfo,
-      password: stored.value.connectionInfo.password
-    })
+    // Without this an authenticated caller could aim a saved password at a
+    // server they control and have the app hand it over during the handshake.
+    if (!targetsSameServer(connectionInfo, stored.value.connectionInfo)) {
+      return { _tag: 'differentServer' } as const
+    }
+
+    return {
+      _tag: 'resolved',
+      connectionInfo: {
+        ...connectionInfo,
+        password: stored.value.connectionInfo.password
+      }
+    } as const
   })
 
 export const ConnectionTestsLive = HttpApiBuilder.group(
@@ -51,15 +88,23 @@ export const ConnectionTestsLive = HttpApiBuilder.group(
       Effect.gen(function* () {
         const adapterFactory = yield* AdapterFactory
 
-        const connectionInfo = yield* resolveTestConnectionInfo(payload)
+        const resolved: ResolvedConnection =
+          yield* resolveTestConnectionInfo(payload)
 
-        if (Option.isNone(connectionInfo)) {
+        if (resolved._tag === 'passwordRequired') {
           return { message: 'Password is required.', success: false }
+        }
+
+        if (resolved._tag === 'differentServer') {
+          return {
+            message: 'Enter the password to test a different server.',
+            success: false
+          }
         }
 
         const adapter = adapterFactory.create(
           payload.type,
-          connectionInfo.value
+          resolved.connectionInfo
         )
 
         return yield* Effect.tryPromise(() => adapter.testConnection()).pipe(

--- a/src/server/http/server.ts
+++ b/src/server/http/server.ts
@@ -1,9 +1,15 @@
-import { HttpApiBuilder, HttpMiddleware, HttpServer } from '@effect/platform'
-import type { HttpServerRequest } from '@effect/platform'
+import {
+  HttpApiBuilder,
+  HttpApp,
+  HttpMiddleware,
+  HttpServer,
+  HttpServerRequest,
+  HttpServerResponse
+} from '@effect/platform'
 // Subpath import on purpose: the package barrel pulls in cluster modules
 // whose optional peers are not installed.
 import * as NodeHttpServer from '@effect/platform-node/NodeHttpServer'
-import { Config, Effect, Layer } from 'effect'
+import { Config, Effect, Layer, Option } from 'effect'
 import { createServer } from 'node:http'
 
 import { SquealApi } from '@/glue/api/api'
@@ -41,18 +47,86 @@ export const ApiLive = HttpApiBuilder.api(SquealApi).pipe(
 // CORS runs before auth so OPTIONS preflights (which never carry an
 // Authorization header) still succeed for the allowed origins. 'null' is the
 // Origin a packaged renderer sends when loaded from file://.
-const CorsLive = Layer.unwrapEffect(
+export const CorsLive = Layer.unwrapEffect(
   Effect.gen(function* () {
     const allowedOrigins = yield* Config.string('ALLOWED_ORIGINS').pipe(
       Config.withDefault('null')
     )
+    const allowed = allowedOrigins.split(',')
 
     return HttpApiBuilder.middlewareCors({
       allowedHeaders: ['Authorization', 'Content-Type', 'traceparent'],
-      allowedOrigins: allowedOrigins.split(',')
+      // A predicate rather than the array: given exactly one allowed origin the
+      // middleware takes a fast path that emits a constant header without ever
+      // comparing the request's Origin, so a packaged build (whose only allowed
+      // origin is 'null') would answer every caller with
+      // `access-control-allow-origin: null`.
+      allowedOrigins: (origin) => allowed.includes(origin)
     })
   })
 )
+
+// Generous enough for any realistic SQL text or query result while still
+// bounding what a single request can buffer in the main process.
+const maxRequestBodyBytes = 8 * 1024 * 1024
+
+const allowedHostnames = new Set(['127.0.0.1', '::1', '[::1]', 'localhost'])
+
+// Only the hostname is checked, never the port: the port is whatever the
+// server bound (the test harness uses an ephemeral one), while the hostname is
+// what a rebinding attack has to get wrong.
+function hostnameOf(host: string): string {
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']')
+
+    return end === -1 ? host : host.slice(0, end + 1)
+  }
+
+  const colon = host.indexOf(':')
+
+  return colon === -1 ? host : host.slice(0, colon)
+}
+
+// CORS cannot defend against DNS rebinding: the browser sends a legitimate
+// Origin for the attacker's own page, and the request still arrives on
+// loopback. Checking Host does defend against it. This runs outside the CORS
+// layer, so it also covers OPTIONS preflights.
+function withRequestGuards(app: HttpApp.Default): HttpApp.Default {
+  return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const host = request.headers.host
+
+    if (host === undefined || !allowedHostnames.has(hostnameOf(host))) {
+      return HttpServerResponse.unsafeJson(
+        {
+          message:
+            'Squeal only accepts requests addressed to 127.0.0.1. Use http://127.0.0.1:7847.'
+        },
+        { status: 403 }
+      )
+    }
+
+    // MaxBodySize below fails mid-stream rather than pre-checking, so a
+    // declared length is rejected up front to give a clear answer for the
+    // common case.
+    const declaredLength = Number(request.headers['content-length'] ?? '0')
+
+    if (Number.isFinite(declaredLength) && declaredLength > maxRequestBodyBytes) {
+      return HttpServerResponse.unsafeJson(
+        { message: 'The request body is too large.' },
+        { status: 413 }
+      )
+    }
+
+    return yield* app
+  }).pipe(
+    HttpServerRequest.withMaxBodySize(Option.some(maxRequestBodyBytes))
+  )
+}
+
+// Shared by the production server and the in-memory test harness so both run
+// the same guards.
+export const ServeLive = HttpApiBuilder.serve(withRequestGuards)
 
 function requestPath(request: HttpServerRequest.HttpServerRequest): string {
   const queryStart = request.url.indexOf('?')
@@ -64,7 +138,7 @@ function requestPath(request: HttpServerRequest.HttpServerRequest): string {
 // owns the socket: interrupting the layer closes the server. The platform
 // applies its request tracer automatically (parsing incoming traceparent
 // headers); withTracerDisabledWhen reproduces the legacy skip list.
-export const HttpLive = HttpApiBuilder.serve().pipe(
+export const HttpLive = ServeLive.pipe(
   HttpServer.withLogAddress,
   HttpMiddleware.withTracerDisabledWhen((request) =>
     shouldSkipTracing(request.method, requestPath(request))

--- a/src/test/effect-test-helper.ts
+++ b/src/test/effect-test-helper.ts
@@ -1,12 +1,7 @@
 // Layer-based test substitutes for the Effect services — no vi.mock. Tests
 // compose these under the service layers they exercise and get a fresh
 // in-memory app database per layer build.
-import {
-  HttpApiBuilder,
-  HttpApiClient,
-  HttpClient,
-  HttpClientRequest
-} from '@effect/platform'
+import { HttpApiClient, HttpClient, HttpClientRequest } from '@effect/platform'
 // Subpath import on purpose: the package barrel pulls in cluster modules
 // whose optional peers are not installed.
 import * as NodeHttpServer from '@effect/platform-node/NodeHttpServer'
@@ -17,7 +12,7 @@ import { createTables } from '@/database/tables'
 import type { SchemaInfo, QueryResult } from '@/databases/adapter'
 import { SquealApi } from '@/glue/api/api'
 import { ApiToken } from '@/server/http/api-token'
-import { ApiLive } from '@/server/http/server'
+import { ApiLive, CorsLive, ServeLive } from '@/server/http/server'
 import {
   AppDatabase,
   makeAppDatabaseService
@@ -125,6 +120,9 @@ export const testApiToken = 'test-api-token'
 
 export interface TestApiOptions {
   adapter?: TestAdapterConfig
+  // Defaults to the packaged profile: one allowed origin, so the CORS fast-path
+  // regression stays covered.
+  allowedOrigins?: string[]
   publicTraceReads?: boolean
 }
 
@@ -145,12 +143,16 @@ export function makeTestApi(options: TestApiOptions = {}) {
   const configuration = Layer.setConfigProvider(
     ConfigProvider.fromMap(
       new Map([
+        ['ALLOWED_ORIGINS', (options.allowedOrigins ?? ['null']).join(',')],
         ['PUBLIC_TRACE_READS', String(options.publicTraceReads ?? false)]
       ])
     )
   )
 
-  const layer = HttpApiBuilder.serve().pipe(
+  // ServeLive and CorsLive come from the production module so the harness runs
+  // the real host guard, body limit, and CORS behaviour.
+  const layer = ServeLive.pipe(
+    Layer.provide(CorsLive),
     Layer.provide(ApiLive),
     Layer.provideMerge(services),
     Layer.provide(Layer.succeed(ApiToken, Redacted.make(testApiToken))),


### PR DESCRIPTION
**Stack:** #23 ← #24 ← #25 ← **this** ← `fix/packaged-native-modules`

Review #25 first. One outcome: the local API can't be driven by anything other
than the app itself. Every finding below was confirmed by live probe, not just
by reading the code.

### The origin allowlist wasn't enforced in packaged builds

`HttpMiddleware.cors` takes a fast path when exactly one origin is allowed
(`internal/httpMiddleware.js:144`) that emits a *constant* header without ever
reading the request's `Origin`. A packaged build's allowlist is exactly
`['null']`, so it answered **every** caller with
`access-control-allow-origin: null`. Passing a predicate instead of the array
keeps it on the comparing branch.

The safer-looking profile is the one that got tested: dev has two origins and so
took the correct branch, which is why this stayed hidden.

### Any website could read the span store in dev

Development trace reads are unauthenticated, and `null` is on the CORS allowlist
— it has to be, since the packaged renderer loads from `file://`. Together that
meant any page a developer visited could read `GET /traces` from a sandboxed
iframe (opaque origin serializes to `null`), and span bodies carry `db.statement`
— the user's raw SQL.

The carve-out is now limited to callers that send **no** `Origin` header, which
keeps the documented `curl` agent workflow working and shuts browsers out. Since
CORS can't mitigate DNS rebinding either, the `Host` header is now checked
separately (hostname only — the port is whatever the server bound).

### No request body limit at all

`platform-node`'s 10 MB default is attached to server *construction*, not the
per-request context, so it never applied here: a 20 MB body was accepted and
stored. Requests are now bounded with `MaxBodySize` plus a `Content-Length`
pre-check.

### A saved password could be aimed at any host

`POST /connection-tests` merged the decrypted stored password into a
client-supplied `connectionInfo` after comparing only the database *type*. An
authenticated caller could send a saved `databaseId` with a host they control and
have the app connect out and hand the password over during the handshake — a
hostile server answering `AuthenticationCleartextPassword` receives it in the
clear, and the failure message came back at 200.

The borrow now requires the request to target the same host and port as the
stored record. Only those two are compared, because they decide where the secret
is actually sent: editing a username or database name still targets the same
trusted server, so requiring a re-typed password there would be friction without
a security gain.

This one predates the migration, but the contract now makes `databaseId` an
explicit schema field, which is the natural place for the guard.

### Also here

A lowercase `bearer` scheme worked on every route except the two trace reads.
And the test harness now provides the real CORS layer and serve-level guards, so
none of this was previously reachable from tests.

### Verification

`yarn typecheck`, `yarn lint`, 518 tests pass. Probed against both profiles of a
running app — packaged: trace reads 401, a foreign origin gets no
`access-control-allow-origin` while `null` still works for the renderer,
`Host: attacker.example` gets 403. Dev: `curl /traces` still returns 200, the
same request with any `Origin` gets 401, and span ingest is 401 either way.