### PR TITLE
fix: make packaged builds able to open any database

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,9 +11,29 @@ import { cpSync, existsSync, mkdirSync, readFileSync } from 'fs'
 import { join, resolve } from 'path'
 
 // Root external packages (Vite externals that need runtime resolution).
-const rootExternalPackages = ['@libsql/client', 'pg']
+// Every module externalized in vite.main.config.ts has to be reachable from
+// this list, either directly or as a transitive dependency. mysql2 and
+// pg-cursor are not dependencies of @libsql/client or pg, so they need naming:
+// src/databases/create-adapter.ts imports all three adapters at module level,
+// which means a single missing package breaks every database type, not just its
+// own.
+const rootExternalPackages = [
+  '@libsql/client',
+  'mysql2',
+  'pg',
+  'pg-cursor'
+]
 
-function readPackageDependencyNames(packageJsonPath: string): string[] {
+interface PackageDependency {
+  name: string
+  // Optional dependencies are mostly per-platform native binaries, so the ones
+  // for other platforms are legitimately absent from this machine.
+  optional: boolean
+}
+
+function readPackageDependencyNames(
+  packageJsonPath: string
+): PackageDependency[] {
   if (!existsSync(packageJsonPath)) {
     return []
   }
@@ -21,8 +41,14 @@ function readPackageDependencyNames(packageJsonPath: string): string[] {
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
 
   return [
-    ...Object.keys(packageJson.dependencies ?? {}),
-    ...Object.keys(packageJson.optionalDependencies ?? {})
+    ...Object.keys(packageJson.dependencies ?? {}).map((name) => ({
+      name,
+      optional: false
+    })),
+    ...Object.keys(packageJson.optionalDependencies ?? {}).map((name) => ({
+      name,
+      optional: true
+    }))
   ]
 }
 
@@ -31,7 +57,7 @@ function getPackageDependencies(
   nodeModulesPath: string,
   packageName: string,
   visited = new Set<string>()
-): string[] {
+): PackageDependency[] {
   if (visited.has(packageName)) {
     return []
   }
@@ -39,25 +65,40 @@ function getPackageDependencies(
 
   const packagePath = join(nodeModulesPath, ...packageName.split('/'))
   const packageJsonPath = join(packagePath, 'package.json')
-  const allDeps: string[] = []
+  const allDeps: PackageDependency[] = []
 
   for (const dep of readPackageDependencyNames(packageJsonPath)) {
     allDeps.push(dep)
-    allDeps.push(...getPackageDependencies(nodeModulesPath, dep, visited))
+    allDeps.push(
+      ...getPackageDependencies(nodeModulesPath, dep.name, visited).map(
+        // Anything reached through an optional dependency is itself optional.
+        (nested) => ({
+          name: nested.name,
+          optional: dep.optional || nested.optional
+        })
+      )
+    )
   }
 
   return allDeps
 }
 
-// Collect the externalized packages and their transitive dependencies.
-function collectPackagesToCopy(sourceNodeModules: string): Set<string> {
-  const allPackages = new Set<string>()
+// Collect the externalized packages and their transitive dependencies, mapped
+// to whether their absence should be reported.
+function collectPackagesToCopy(
+  sourceNodeModules: string
+): Map<string, boolean> {
+  const allPackages = new Map<string, boolean>()
+
+  const record = (name: string, optional: boolean) => {
+    allPackages.set(name, (allPackages.get(name) ?? true) && optional)
+  }
 
   for (const rootPackage of rootExternalPackages) {
-    allPackages.add(rootPackage)
+    record(rootPackage, false)
 
     for (const dep of getPackageDependencies(sourceNodeModules, rootPackage)) {
-      allPackages.add(dep)
+      record(dep.name, dep.optional)
     }
   }
 
@@ -67,15 +108,27 @@ function collectPackagesToCopy(sourceNodeModules: string): Set<string> {
 function copyPackage(
   sourceNodeModules: string,
   destNodeModules: string,
-  packageName: string
+  packageName: string,
+  optional: boolean
 ): void {
   const sourcePath = join(sourceNodeModules, ...packageName.split('/'))
   const destPath = join(destNodeModules, ...packageName.split('/'))
 
-  if (existsSync(sourcePath)) {
-    mkdirSync(join(destPath, '..'), { recursive: true })
-    cpSync(sourcePath, destPath, { recursive: true })
+  if (!existsSync(sourcePath)) {
+    // Loud on purpose for required packages: silently skipping one turns into a
+    // module-not-found crash in the packaged app, long after this build passed.
+    // Optional ones are per-platform binaries and are expected to be absent.
+    if (!optional) {
+      console.warn(
+        `[forge] Cannot bundle "${packageName}": ${sourcePath} does not exist.`
+      )
+    }
+
+    return
   }
+
+  mkdirSync(join(destPath, '..'), { recursive: true })
+  cpSync(sourcePath, destPath, { recursive: true })
 }
 
 const config: ForgeConfig = {
@@ -87,7 +140,9 @@ const config: ForgeConfig = {
   ],
   packagerConfig: {
     asar: {
-      unpack: '**/node_modules/{@libsql,pg}/**/*'
+      // Kept in step with rootExternalPackages: these resolve at runtime, so
+      // they must stay outside the archive. libsql carries the native binding.
+      unpack: '**/node_modules/{@libsql,libsql,mysql2,pg,pg-cursor}/**/*'
     },
     icon: './assets/icons/icon'
   },
@@ -133,8 +188,10 @@ const config: ForgeConfig = {
       const sourceNodeModules = resolve(import.meta.dirname, 'node_modules')
       const destNodeModules = join(buildPath, 'node_modules')
 
-      for (const packageName of collectPackagesToCopy(sourceNodeModules)) {
-        copyPackage(sourceNodeModules, destNodeModules, packageName)
+      for (const [packageName, optional] of collectPackagesToCopy(
+        sourceNodeModules
+      )) {
+        copyPackage(sourceNodeModules, destNodeModules, packageName, optional)
       }
     }
   },


### PR DESCRIPTION
**Stack:** #23 ← #24 ← #25 ← #26 ← **this** (top of stack)

Review #26 first. Small and self-contained.

`vite.main.config.ts` externalizes `mysql2` and `pg-cursor`, so both must exist
in `node_modules` at runtime — but neither is a dependency of `@libsql/client`
or `pg`, the only roots the copy walk seeded from, so neither was ever copied
into the package.

The blast radius is larger than it looks: `create-adapter.ts` imports all three
adapters at module level, so the resulting `require` failure would break **every**
database type, not just MySQL. `libsql`, `mysql2` and `pg-cursor` are also added
to the asar unpack glob.

A missing source package was previously skipped in silence, which is how this
went unnoticed — it now warns. Optional dependencies stay quiet, since those are
per-platform native binaries that are legitimately absent (this machine has 8 of
them for other platforms).

Predates the migration; grouped here because it's the last thing standing
between the branch and a working release build.

### Verification

Verified with a real `yarn package`, which is the only way to actually prove
this one: `mysql2`, `pg-cursor` and `libsql` are unpacked alongside `pg` and
`@libsql`, their transitive dependencies are in the archive, and the packaged app
boots and serves `/health` — which it could not do if any adapter import failed
to resolve. `yarn typecheck`, `yarn lint` and 518 tests also pass.