### PR TITLE
fix(databases): pair the database type with its connection info

### DIFF
--- a/src/app/api-client.test.ts
+++ b/src/app/api-client.test.ts
@@ -31,7 +31,9 @@ interface CapturedRequest {
   url: string
 }
 
-function toHeaderRecord(source: HeadersInit | undefined): Record<string, string> {
+function toHeaderRecord(
+  source: HeadersInit | undefined
+): Record<string, string> {
   const headers: Record<string, string> = {}
 
   if (source === undefined) {
@@ -201,10 +203,14 @@ describe('apiClient', () => {
         })
       )
 
-      const result = await apiClient.testConnection(
-        { database: 'testdb', host: 'localhost', username: 'admin' },
-        'postgres'
-      )
+      const result = await apiClient.testConnection({
+        connectionInfo: {
+          database: 'testdb',
+          host: 'localhost',
+          username: 'admin'
+        },
+        type: 'postgres'
+      })
 
       expect(result).toEqual({
         message: 'password authentication failed',
@@ -396,10 +402,10 @@ describe('apiClient', () => {
     // schema tree ParseError.message renders.
     it('maps an encode failure to field errors and sends nothing', async () => {
       try {
-        await apiClient.testConnection(
-          { database: 'testdb', host: '', username: 'admin' },
-          'postgres'
-        )
+        await apiClient.testConnection({
+          connectionInfo: { database: 'testdb', host: '', username: 'admin' },
+          type: 'postgres'
+        })
         expect.fail('Expected the request to reject')
       } catch (error) {
         expect(error).toBeInstanceOf(ApiError)

--- a/src/app/api-client.ts
+++ b/src/app/api-client.ts
@@ -27,7 +27,6 @@ import type {
   CreateQueryResponse,
   CreateWorksheetRequest,
   DatabaseDto,
-  DatabaseType,
   ListTracesUrlParams,
   QueryDto,
   ReorderDatabasesResponse,
@@ -35,7 +34,7 @@ import type {
   SchemaInfoDto,
   SpanDto,
   TraceSummaryDto,
-  UpdateConnectionInfo,
+  UpdateDatabaseConnection,
   UpdateDatabaseRequest,
   UpdateDatabaseResponse,
   UpdateWorksheetRequest,
@@ -322,8 +321,13 @@ export const apiClient = {
       'HTTP POST /databases',
       { method: 'POST', path: '/databases' },
       undefined,
+      // The payload schema is a union discriminated on `type`, so the generated
+      // client's options object is a union too. Narrowing here hands it one
+      // concrete member instead of reaching for a cast.
       Effect.flatMap(client, (api) =>
-        api.databases.create({ payload: request })
+        request.type === 'sqlite'
+          ? api.databases.create({ payload: request })
+          : api.databases.create({ payload: request })
       )
     )
   },
@@ -495,22 +499,23 @@ export const apiClient = {
   },
 
   async testConnection(
-    connectionInfo: UpdateConnectionInfo,
-    type: DatabaseType,
+    connection: UpdateDatabaseConnection,
     databaseId?: string
   ): Promise<ConnectionTestResponse> {
+    const target = databaseId === undefined ? {} : { databaseId }
+
     return traced(
       'HTTP POST /connection-tests',
       { method: 'POST', path: '/connection-tests' },
       undefined,
       Effect.flatMap(client, (api) =>
-        api.connectionTests.create({
-          payload: {
-            connectionInfo,
-            type,
-            ...(databaseId === undefined ? {} : { databaseId })
-          }
-        })
+        connection.type === 'sqlite'
+          ? api.connectionTests.create({
+              payload: { ...connection, ...target }
+            })
+          : api.connectionTests.create({
+              payload: { ...connection, ...target }
+            })
       )
     )
   },
@@ -524,7 +529,9 @@ export const apiClient = {
       { method: 'PATCH', path: `/databases/${databaseId}` },
       undefined,
       Effect.flatMap(client, (api) =>
-        api.databases.update({ path: { id: databaseId }, payload: request })
+        request.type === 'sqlite'
+          ? api.databases.update({ path: { id: databaseId }, payload: request })
+          : api.databases.update({ path: { id: databaseId }, payload: request })
       )
     )
   },

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -16,7 +16,7 @@ import type {
   CreateDatabaseRequest,
   DatabaseType,
   SslMode,
-  UpdateConnectionInfo,
+  UpdateDatabaseConnection,
   UpdateDatabaseRequest
 } from '@/glue/api/schemas'
 // The form is validated client-side with zod through react-hook-form's
@@ -366,14 +366,15 @@ function useConnectionTest({
 
       const minDelay = new Promise<void>((resolve) => setTimeout(resolve, 100))
 
-      Promise.all([
-        apiClient.testConnection(
-          normalizedConnectionInfo as UpdateConnectionInfo,
-          databaseType,
-          databaseId
-        ),
-        minDelay
-      ])
+      // The type and its info travel as one value to the API, which validates
+      // the pair. Narrowed here for the same reason the submit path does it:
+      // zod types the transformed connectionInfo as optional.
+      const connection = {
+        connectionInfo: normalizedConnectionInfo,
+        type: databaseType
+      } as UpdateDatabaseConnection
+
+      Promise.all([apiClient.testConnection(connection, databaseId), minDelay])
         .then(([result]) => {
           if (result.success) {
             toast.success('Connection successful!')

--- a/src/databases/create-adapter.ts
+++ b/src/databases/create-adapter.ts
@@ -1,27 +1,27 @@
 import type { DatabaseAdapter } from './adapter'
 import { MysqlAdapter } from './mysql-adapter'
 import { PostgresAdapter } from './postgres-adapter'
+import type { DatabaseConnection } from './schemas'
 import { SqliteAdapter } from './sqlite-adapter'
-import type {
-  ConnectionInfo,
-  DatabaseType,
-  MysqlConnectionInfo,
-  PostgresConnectionInfo,
-  SqliteConnectionInfo
-} from './schemas'
 
-export function createAdapter(
-  type: DatabaseType,
-  connectionInfo: ConnectionInfo
-): DatabaseAdapter {
-  switch (type) {
+// Takes the type and its connection info as one discriminated value rather than
+// two independent arguments, so `switch` narrows the shape and no cast is
+// needed: a SQLite connection can only arrive carrying a SQLite path.
+export function createAdapter(connection: DatabaseConnection): DatabaseAdapter {
+  switch (connection.type) {
     case 'mysql':
-      return new MysqlAdapter(connectionInfo as MysqlConnectionInfo)
+      return new MysqlAdapter(connection.connectionInfo)
     case 'postgres':
-      return new PostgresAdapter(connectionInfo as PostgresConnectionInfo)
+      return new PostgresAdapter(connection.connectionInfo)
     case 'sqlite':
-      return new SqliteAdapter(connectionInfo as SqliteConnectionInfo)
+      return new SqliteAdapter(connection.connectionInfo)
     default:
-      throw new Error(`Unsupported database type: ${type}`)
+      // Unreachable for validated input. It still guards a stored row whose
+      // `type` column holds something this build does not know about.
+      throw new Error(
+        `Unsupported database type: ${String(
+          (connection as { type: unknown }).type
+        )}`
+      )
   }
 }

--- a/src/databases/schemas.ts
+++ b/src/databases/schemas.ts
@@ -5,13 +5,12 @@
 import { z } from 'zod'
 
 import type {
-  ConnectionInfo,
-  DatabaseType,
+  DatabaseConnection,
   ServerConnectionInfo,
   SqliteConnectionInfo
 } from '@/glue/api/schemas'
 
-export type { ConnectionInfo, DatabaseType, SqliteConnectionInfo }
+export type { DatabaseConnection, SqliteConnectionInfo }
 
 // MySQL and PostgreSQL connections share the same shape.
 export type MysqlConnectionInfo = ServerConnectionInfo
@@ -64,6 +63,11 @@ const updateConnectionInfoSchema = z.union([
 ])
 
 export { databaseTypeSchema }
+
+// These validate `type` and `connectionInfo` independently, which is fine for a
+// form whose type selector resets connectionInfo on every change. The pairing
+// is enforced where it matters — `DatabaseConnection` in the contract, which
+// every request decodes against.
 
 export const createDatabaseSchema = z.object({
   connectionInfo: connectionInfoSchema,

--- a/src/databases/sqlite-adapter.test.ts
+++ b/src/databases/sqlite-adapter.test.ts
@@ -71,6 +71,24 @@ describe('SqliteAdapter', () => {
     vi.clearAllMocks()
   })
 
+  // Requests are validated against the contract, but stored rows are only
+  // JSON.parsed, so a row an older build saved as SQLite with server connection
+  // info can still reach the constructor. It used to fail as
+  // `pathToFileURL(undefined)` deep inside the driver.
+  describe('a connection with no file path', () => {
+    it('fails with an actionable message instead of a driver error', () => {
+      expect(() => new SqliteAdapter({ path: '' })).toThrow(
+        'This connection is saved as SQLite but has no database file. Edit the connection and choose a file.'
+      )
+    })
+
+    it('rejects a missing path as well as an empty one', () => {
+      expect(() => new SqliteAdapter({} as { path: string })).toThrow(
+        /has no database file/
+      )
+    })
+  })
+
   describe('testConnection', () => {
     it('connects and executes SELECT 1', async () => {
       mockExecute.mockResolvedValueOnce({ columns: [], rows: [] })

--- a/src/databases/sqlite-adapter.ts
+++ b/src/databases/sqlite-adapter.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@libsql/client'
 import Database from 'libsql'
+import invariant from 'tiny-invariant'
 import { pathToFileURL } from 'url'
 
 import { maxResultRows } from './adapter'
@@ -19,6 +20,15 @@ export class SqliteAdapter implements DatabaseAdapter {
   protected readonly connectionInfo: SqliteConnectionInfo
 
   constructor(connectionInfo: SqliteConnectionInfo) {
+    // Requests are validated against the contract's DatabaseConnection, but
+    // stored rows are only JSON.parsed, so a row an older build saved with a
+    // server-shaped info can still land here. Without this the failure was
+    // `pathToFileURL(undefined)` deep in the driver.
+    invariant(
+      connectionInfo.path,
+      'This connection is saved as SQLite but has no database file. Edit the connection and choose a file.'
+    )
+
     this.connectionInfo = connectionInfo
   }
 

--- a/src/glue/api/schemas.ts
+++ b/src/glue/api/schemas.ts
@@ -93,12 +93,43 @@ const UpdateServerConnectionInfo = Schema.Struct({
   password: Schema.optional(Schema.String)
 })
 
-const UpdateConnectionInfo = Schema.Union(
-  UpdateServerConnectionInfo,
-  SqliteConnectionInfo
+// --- Database connections ------------------------------------------------------
+
+// `type` and `connectionInfo` only mean anything as a pair: SQLite needs a file
+// path, a server needs a host and credentials. Validating them independently let
+// `{ type: 'sqlite', connectionInfo: { host, … } }` decode cleanly and then
+// reach the SQLite adapter with no path at all. Discriminating on `type` turns
+// that into a decode failure at the boundary instead of a crash deeper in.
+const serverConnectionFields = {
+  connectionInfo: ServerConnectionInfo,
+  type: Schema.Literal('mysql', 'postgres')
+} as const
+
+const sqliteConnectionFields = {
+  connectionInfo: SqliteConnectionInfo,
+  type: Schema.Literal('sqlite')
+} as const
+
+// SQLite has no password to omit, so it reuses the same member here.
+const updateServerConnectionFields = {
+  connectionInfo: UpdateServerConnectionInfo,
+  type: Schema.Literal('mysql', 'postgres')
+} as const
+
+// Only the types are consumed — the payload schemas below are what the routes
+// decode against, so these two stay module-private like ConnectionInfo above.
+const DatabaseConnection = Schema.Union(
+  Schema.Struct(serverConnectionFields),
+  Schema.Struct(sqliteConnectionFields)
 )
-export type UpdateConnectionInfo = Schema.Schema.Type<
-  typeof UpdateConnectionInfo
+export type DatabaseConnection = Schema.Schema.Type<typeof DatabaseConnection>
+
+const UpdateDatabaseConnection = Schema.Union(
+  Schema.Struct(updateServerConnectionFields),
+  Schema.Struct(sqliteConnectionFields)
+)
+export type UpdateDatabaseConnection = Schema.Schema.Type<
+  typeof UpdateDatabaseConnection
 >
 
 // The renderer never receives stored passwords — API responses use this
@@ -128,24 +159,22 @@ export const DatabaseDto = Schema.Struct({
 })
 export type DatabaseDto = Schema.Schema.Type<typeof DatabaseDto>
 
-export const CreateDatabaseRequest = Schema.Struct({
-  connectionInfo: ConnectionInfo,
-  name: Schema.String.pipe(
-    Schema.minLength(1, { message: () => 'Name is required.' })
-  ),
-  type: DatabaseType
-})
+const databaseName = Schema.String.pipe(
+  Schema.minLength(1, { message: () => 'Name is required.' })
+)
+
+export const CreateDatabaseRequest = Schema.Union(
+  Schema.Struct({ ...serverConnectionFields, name: databaseName }),
+  Schema.Struct({ ...sqliteConnectionFields, name: databaseName })
+)
 export type CreateDatabaseRequest = Schema.Schema.Type<
   typeof CreateDatabaseRequest
 >
 
-export const UpdateDatabaseRequest = Schema.Struct({
-  connectionInfo: UpdateConnectionInfo,
-  name: Schema.String.pipe(
-    Schema.minLength(1, { message: () => 'Name is required.' })
-  ),
-  type: DatabaseType
-})
+export const UpdateDatabaseRequest = Schema.Union(
+  Schema.Struct({ ...updateServerConnectionFields, name: databaseName }),
+  Schema.Struct({ ...sqliteConnectionFields, name: databaseName })
+)
 export type UpdateDatabaseRequest = Schema.Schema.Type<
   typeof UpdateDatabaseRequest
 >
@@ -298,11 +327,16 @@ export type SchemaInfoDto = Schema.Schema.Type<typeof SchemaInfoDto>
 
 // --- Connection tests ------------------------------------------------------------
 
-export const ConnectionTestRequest = Schema.Struct({
-  connectionInfo: UpdateConnectionInfo,
-  databaseId: Schema.optional(Schema.String),
-  type: DatabaseType
-})
+export const ConnectionTestRequest = Schema.Union(
+  Schema.Struct({
+    ...updateServerConnectionFields,
+    databaseId: Schema.optional(Schema.String)
+  }),
+  Schema.Struct({
+    ...sqliteConnectionFields,
+    databaseId: Schema.optional(Schema.String)
+  })
+)
 export type ConnectionTestRequest = Schema.Schema.Type<
   typeof ConnectionTestRequest
 >

--- a/src/server/http/databases.test.ts
+++ b/src/server/http/databases.test.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@effect/platform'
+import { HttpClient, HttpClientRequest } from '@effect/platform'
 import { Effect, Option } from 'effect'
 import { describe, expect, it } from 'vitest'
 
@@ -8,6 +8,7 @@ import { DatabaseService } from '@/server/services/database-service'
 import {
   makeAuthorizedClient,
   makeTestApi,
+  testApiToken,
   testEncryptionPrefix,
   type TestApiOptions
 } from '@/test/effect-test-helper'
@@ -28,6 +29,35 @@ function run<A, E>(
   const { layer } = makeTestApi(options)
 
   return Effect.runPromise(Effect.provide(effect, layer))
+}
+
+// The typed client cannot express a mismatched type/connectionInfo pair, which
+// is the point — so these go over raw HTTP to prove the server rejects what a
+// hand-rolled or older client could still send.
+function rawPost(
+  path: string,
+  body: unknown,
+  options: TestApiOptions = {}
+): Promise<{ body: unknown; status: number }> {
+  const { layer } = makeTestApi(options)
+
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const http = yield* HttpClient.HttpClient
+
+      const response = yield* http.execute(
+        HttpClientRequest.post(path).pipe(
+          HttpClientRequest.setHeader(
+            'authorization',
+            `Bearer ${testApiToken}`
+          ),
+          HttpClientRequest.bodyUnsafeJson(body)
+        )
+      )
+
+      return { body: yield* response.json, status: response.status }
+    }).pipe(Effect.scoped, Effect.provide(layer))
+  )
 }
 
 describe('database routes', () => {
@@ -83,7 +113,7 @@ describe('database routes', () => {
     expect(Option.isSome(stored)).toEqual(true)
 
     if (Option.isSome(stored)) {
-      expect(stored.value.connectionInfo).toEqual(connectionInfo)
+      expect(stored.value.connection.connectionInfo).toEqual(connectionInfo)
       expect(stored.value.name).toEqual('Renamed')
     }
   })
@@ -257,5 +287,93 @@ describe('database routes', () => {
         unknownIds: ['missing']
       })
     )
+  })
+
+  // `type` and `connectionInfo` used to be validated independently, so a SQLite
+  // row could be saved with server connection info and then crashed the adapter
+  // on `pathToFileURL(undefined)` when anything tried to open it.
+  it('rejects a create whose type and connection info disagree', async () => {
+    const response = await rawPost('/databases', {
+      connectionInfo,
+      name: 'Mismatched',
+      type: 'sqlite'
+    })
+
+    expect(response.status).toEqual(400)
+  })
+
+  it('rejects a connection test whose type and connection info disagree', async () => {
+    const response = await rawPost('/connection-tests', {
+      connectionInfo: { path: '/tmp/pagila.sqlite3' },
+      type: 'postgres'
+    })
+
+    expect(response.status).toEqual(400)
+  })
+
+  it('stores nothing when the pair is rejected', async () => {
+    const { layer } = makeTestApi({})
+
+    // One layer for both halves, so the row check reads the same database the
+    // rejected request was aimed at.
+    const { rows, status } = await Effect.runPromise(
+      Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient
+        const appDatabase = yield* AppDatabase
+
+        const response = yield* http.execute(
+          HttpClientRequest.post('/databases').pipe(
+            HttpClientRequest.setHeader(
+              'authorization',
+              `Bearer ${testApiToken}`
+            ),
+            HttpClientRequest.bodyUnsafeJson({
+              connectionInfo,
+              name: 'Mismatched',
+              type: 'sqlite'
+            })
+          )
+        )
+
+        const rows = yield* appDatabase.execute((db) =>
+          db.select().from(databasesTable)
+        )
+
+        return { rows, status: response.status }
+      }).pipe(Effect.scoped, Effect.provide(layer))
+    )
+
+    expect(status).toEqual(400)
+    expect(rows).toEqual([])
+  })
+
+  it('builds a SQLite adapter from a SQLite pair', async () => {
+    const { adapterState, layer } = makeTestApi({})
+
+    await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const client = yield* makeAuthorizedClient
+
+          const created = yield* client.databases.create({
+            payload: {
+              connectionInfo: { path: '/tmp/pagila.sqlite3' },
+              name: 'Local',
+              type: 'sqlite'
+            }
+          })
+
+          return yield* client.databases.schema({
+            path: { id: created.database.id }
+          })
+        }),
+        layer
+      )
+    )
+
+    expect(adapterState.lastType).toEqual('sqlite')
+    expect(adapterState.lastConnectionInfo).toEqual({
+      path: '/tmp/pagila.sqlite3'
+    })
   })
 })

--- a/src/server/http/handlers/connection-tests.ts
+++ b/src/server/http/handlers/connection-tests.ts
@@ -3,18 +3,22 @@ import { Effect, Option } from 'effect'
 
 import { SquealApi } from '@/glue/api/api'
 import type {
-  ConnectionInfo,
   ConnectionTestRequest,
-  UpdateConnectionInfo
+  DatabaseConnection
 } from '@/glue/api/schemas'
 import { AdapterFactory } from '@/server/services/adapter-factory'
 import { DatabaseService } from '@/server/services/database-service'
 import { orDieInternal } from '../internal-errors'
 
 type ResolvedConnection =
-  | { readonly _tag: 'resolved'; readonly connectionInfo: ConnectionInfo }
+  | { readonly _tag: 'resolved'; readonly connection: DatabaseConnection }
   | { readonly _tag: 'differentServer' }
   | { readonly _tag: 'passwordRequired' }
+
+interface ServerTarget {
+  readonly host: string
+  readonly port?: number | undefined
+}
 
 // The stored password may only be lent back to the server it was saved for.
 // Only host and port are compared, because those decide where the secret is
@@ -22,13 +26,9 @@ type ResolvedConnection =
 // trusted server, so requiring a re-typed password there would be friction
 // without a security gain.
 function targetsSameServer(
-  requested: UpdateConnectionInfo,
-  stored: ConnectionInfo
+  requested: ServerTarget,
+  stored: ServerTarget
 ): boolean {
-  if (!('username' in requested) || !('username' in stored)) {
-    return false
-  }
-
   return (
     requested.host === stored.host &&
     (requested.port ?? undefined) === (stored.port ?? undefined)
@@ -37,16 +37,31 @@ function targetsSameServer(
 
 // A test without a password uses the stored one — the renderer never sees
 // passwords, so testing an existing connection sends its databaseId instead.
-const resolveTestConnectionInfo = (payload: ConnectionTestRequest) =>
+const resolveTestConnection = (payload: ConnectionTestRequest) =>
   Effect.gen(function* () {
-    const { connectionInfo, databaseId, type } = payload
-    const hasPassword =
-      !('username' in connectionInfo) || connectionInfo.password
-
-    if (hasPassword) {
+    // SQLite carries no password, so there is nothing to look up.
+    if (payload.type === 'sqlite') {
       return {
         _tag: 'resolved',
-        connectionInfo: connectionInfo as ConnectionInfo
+        connection: {
+          connectionInfo: payload.connectionInfo,
+          type: payload.type
+        }
+      } as const
+    }
+
+    const { connectionInfo, databaseId, type } = payload
+
+    if (connectionInfo.password) {
+      return {
+        _tag: 'resolved',
+        connection: {
+          connectionInfo: {
+            ...connectionInfo,
+            password: connectionInfo.password
+          },
+          type
+        }
       } as const
     }
 
@@ -57,25 +72,32 @@ const resolveTestConnectionInfo = (payload: ConnectionTestRequest) =>
     const service = yield* DatabaseService
     const stored = yield* service.getWithSecrets(databaseId)
 
-    if (
-      Option.isNone(stored) ||
-      stored.value.type !== type ||
-      !('password' in stored.value.connectionInfo)
-    ) {
+    if (Option.isNone(stored)) {
+      return { _tag: 'passwordRequired' } as const
+    }
+
+    const storedConnection = stored.value.connection
+
+    // Excluding sqlite also narrows the stored info to the server shape, which
+    // is the only one carrying a password to lend.
+    if (storedConnection.type === 'sqlite' || storedConnection.type !== type) {
       return { _tag: 'passwordRequired' } as const
     }
 
     // Without this an authenticated caller could aim a saved password at a
     // server they control and have the app hand it over during the handshake.
-    if (!targetsSameServer(connectionInfo, stored.value.connectionInfo)) {
+    if (!targetsSameServer(connectionInfo, storedConnection.connectionInfo)) {
       return { _tag: 'differentServer' } as const
     }
 
     return {
       _tag: 'resolved',
-      connectionInfo: {
-        ...connectionInfo,
-        password: stored.value.connectionInfo.password
+      connection: {
+        connectionInfo: {
+          ...connectionInfo,
+          password: storedConnection.connectionInfo.password
+        },
+        type
       }
     } as const
   })
@@ -89,7 +111,7 @@ export const ConnectionTestsLive = HttpApiBuilder.group(
         const adapterFactory = yield* AdapterFactory
 
         const resolved: ResolvedConnection =
-          yield* resolveTestConnectionInfo(payload)
+          yield* resolveTestConnection(payload)
 
         if (resolved._tag === 'passwordRequired') {
           return { message: 'Password is required.', success: false }
@@ -102,10 +124,7 @@ export const ConnectionTestsLive = HttpApiBuilder.group(
           }
         }
 
-        const adapter = adapterFactory.create(
-          payload.type,
-          resolved.connectionInfo
-        )
+        const adapter = adapterFactory.create(resolved.connection)
 
         return yield* Effect.tryPromise(() => adapter.testConnection()).pipe(
           Effect.as({ success: true }),

--- a/src/server/http/handlers/databases.ts
+++ b/src/server/http/handlers/databases.ts
@@ -32,11 +32,7 @@ export const DatabasesLive = HttpApiBuilder.group(
         Effect.gen(function* () {
           const service = yield* DatabaseService
 
-          return yield* service.create(
-            payload.name,
-            payload.connectionInfo,
-            payload.type
-          )
+          return yield* service.create(payload.name, payload)
         }).pipe(orDieInternal)
       )
       .handle('reorder', ({ payload }) =>
@@ -62,10 +58,7 @@ export const DatabasesLive = HttpApiBuilder.group(
             })
           }
 
-          const adapter = adapterFactory.create(
-            record.value.type,
-            record.value.connectionInfo
-          )
+          const adapter = adapterFactory.create(record.value.connection)
 
           // Deliberately sequential. Running the probe alongside introspection
           // would double the connections every schema request opens, and
@@ -96,12 +89,7 @@ export const DatabasesLive = HttpApiBuilder.group(
         Effect.gen(function* () {
           const service = yield* DatabaseService
 
-          const database = yield* service.update(
-            path.id,
-            payload.name,
-            payload.connectionInfo,
-            payload.type
-          )
+          const database = yield* service.update(path.id, payload.name, payload)
 
           return { database }
         }).pipe(orDieInternal)

--- a/src/server/services/adapter-factory.ts
+++ b/src/server/services/adapter-factory.ts
@@ -4,22 +4,17 @@ import { Effect } from 'effect'
 
 import type { DatabaseAdapter } from '@/databases/adapter'
 import { createAdapter } from '@/databases/create-adapter'
-import type * as legacy from '@/databases/schemas'
-import type { ConnectionInfo, DatabaseType } from '@/glue/api/schemas'
+import type { DatabaseConnection } from '@/glue/api/schemas'
 
 export class AdapterFactory extends Effect.Service<AdapterFactory>()(
   'AdapterFactory',
   {
     accessors: true,
     sync: () => ({
-      create: (
-        type: DatabaseType,
-        connectionInfo: ConnectionInfo
-      ): DatabaseAdapter =>
-        // The glue schema types and the adapters' own types are runtime-
-        // identical; the adapters keep their historical typings until they
-        // are re-pointed at the glue schemas.
-        createAdapter(type, connectionInfo as legacy.ConnectionInfo)
+      // One discriminated value, not a (type, connectionInfo) pair that could
+      // disagree — see DatabaseConnection in the contract.
+      create: (connection: DatabaseConnection): DatabaseAdapter =>
+        createAdapter(connection)
     })
   }
 ) {}

--- a/src/server/services/database-service.test.ts
+++ b/src/server/services/database-service.test.ts
@@ -3,7 +3,10 @@ import { Effect, Layer, Option } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import { databasesTable, worksheetsTable } from '@/database/schema'
-import type { ConnectionInfo } from '@/glue/api/schemas'
+import type {
+  DatabaseConnection,
+  ServerConnectionInfo
+} from '@/glue/api/schemas'
 import {
   makeTestAppDatabase,
   testEncryptionPrefix,
@@ -13,12 +16,16 @@ import { AppDatabase } from './app-database'
 import { DatabaseService } from './database-service'
 import { WorksheetService } from './worksheet-service'
 
-const connectionInfo: ConnectionInfo = {
+const connectionInfo: ServerConnectionInfo = {
   database: 'pagila',
   host: 'localhost',
   password: 'secret',
   username: 'postgres'
 }
+
+// The type and its connection info travel as one value now, so a mismatched
+// pair cannot be constructed by accident.
+const connection: DatabaseConnection = { connectionInfo, type: 'postgres' }
 
 function makeLayer() {
   return Layer.mergeAll(
@@ -31,11 +38,7 @@ function makeLayer() {
 }
 
 function run<A, E>(
-  effect: Effect.Effect<
-    A,
-    E,
-    AppDatabase | DatabaseService | WorksheetService
-  >
+  effect: Effect.Effect<A, E, AppDatabase | DatabaseService | WorksheetService>
 ): Promise<A> {
   return Effect.runPromise(Effect.provide(effect, makeLayer()))
 }
@@ -47,7 +50,7 @@ describe('DatabaseService', () => {
         const service = yield* DatabaseService
         const appDatabase = yield* AppDatabase
 
-        const result = yield* service.create('Pagila', connectionInfo, 'postgres')
+        const result = yield* service.create('Pagila', connection)
 
         const [row] = yield* appDatabase.execute((client) =>
           client.select().from(databasesTable)
@@ -81,7 +84,7 @@ describe('DatabaseService', () => {
 
         yield* worksheets.create({ name: 'My First Worksheet' })
 
-        return yield* service.create('Pagila', connectionInfo, 'postgres')
+        return yield* service.create('Pagila', connection)
       })
     )
 
@@ -94,19 +97,17 @@ describe('DatabaseService', () => {
         const service = yield* DatabaseService
         const appDatabase = yield* AppDatabase
 
-        const created = yield* service.create('Pagila', connectionInfo, 'postgres')
+        const created = yield* service.create('Pagila', connection)
 
-        yield* service.update(
-          created.database.id,
-          'Renamed',
-          {
+        yield* service.update(created.database.id, 'Renamed', {
+          connectionInfo: {
             database: 'pagila',
             host: 'other-host',
             password: '',
             username: 'postgres'
           },
-          'postgres'
-        )
+          type: 'postgres'
+        })
 
         const [row] = yield* appDatabase.execute((client) =>
           client.select().from(databasesTable)
@@ -133,7 +134,7 @@ describe('DatabaseService', () => {
         const service = yield* DatabaseService
 
         return yield* service
-          .update('missing', 'Name', connectionInfo, 'postgres')
+          .update('missing', 'Name', connection)
           .pipe(Effect.flip)
       })
     )
@@ -150,7 +151,7 @@ describe('DatabaseService', () => {
 
         yield* worksheets.create({ name: 'My First Worksheet' })
 
-        const created = yield* service.create('Pagila', connectionInfo, 'postgres')
+        const created = yield* service.create('Pagila', connection)
 
         yield* service.remove(created.database.id)
 
@@ -191,7 +192,7 @@ describe('DatabaseService', () => {
       Effect.gen(function* () {
         const service = yield* DatabaseService
 
-        const created = yield* service.create('Pagila', connectionInfo, 'postgres')
+        const created = yield* service.create('Pagila', connection)
 
         return yield* service
           .reorder([created.database.id, 'missing'])
@@ -213,8 +214,8 @@ describe('DatabaseService', () => {
         const service = yield* DatabaseService
         const appDatabase = yield* AppDatabase
 
-        const first = yield* service.create('First', connectionInfo, 'postgres')
-        const second = yield* service.create('Second', connectionInfo, 'postgres')
+        const first = yield* service.create('First', connection)
+        const second = yield* service.create('Second', connection)
 
         const before = yield* appDatabase.execute((client) =>
           client
@@ -254,7 +255,7 @@ describe('DatabaseService', () => {
         const service = yield* DatabaseService
         const appDatabase = yield* AppDatabase
 
-        yield* service.create('Readable', connectionInfo, 'postgres')
+        yield* service.create('Readable', connection)
 
         yield* appDatabase.execute((client) =>
           client.insert(databasesTable).values({
@@ -293,21 +294,15 @@ describe('DatabaseService', () => {
       Effect.gen(function* () {
         const service = yield* DatabaseService
 
-        const created = yield* service.create(
-          'Pagila',
-          connectionInfo,
-          'postgres'
-        )
+        const created = yield* service.create('Pagila', connection)
 
         yield* service.remove(created.database.id)
 
         const result = yield* Effect.either(
-          service.update(
-            created.database.id,
-            'Renamed',
-            { ...connectionInfo, password: 'new-secret' },
-            'postgres'
-          )
+          service.update(created.database.id, 'Renamed', {
+            connectionInfo: { ...connectionInfo, password: 'new-secret' },
+            type: 'postgres'
+          })
         )
 
         const [row] = yield* (yield* AppDatabase).execute((client) =>
@@ -327,6 +322,64 @@ describe('DatabaseService', () => {
     expect(outcome.connectionInfo).toEqual(`${testEncryptionPrefix}{}`)
   })
 
+  // A row saved by an older build can pair `type` with the wrong info shape.
+  // getWithSecrets refuses it, but editing is how the user repairs it, so the
+  // update path has to tolerate a secret it cannot make sense of.
+  it('lets an update repair a row whose stored pair is mismatched', async () => {
+    const { readBack, unreadable, updated } = await run(
+      Effect.gen(function* () {
+        const service = yield* DatabaseService
+        const appDatabase = yield* AppDatabase
+
+        const created = yield* service.create('Broken', connection)
+
+        // Rewrite the stored secret as SQLite-shaped while the row says
+        // postgres — the disagreement getWithSecrets rejects.
+        yield* appDatabase.execute((client) =>
+          client
+            .update(databasesTable)
+            .set({
+              connectionInfo: `${testEncryptionPrefix}${JSON.stringify({
+                path: '/tmp/stray.sqlite3'
+              })}`
+            })
+            .where(eq(databasesTable.id, created.database.id))
+        )
+
+        const unreadable = yield* service
+          .getWithSecrets(created.database.id)
+          .pipe(Effect.flip)
+
+        // A blank password is what the renderer sends, since it never receives
+        // the stored one — so this is the path that has to look the unreadable
+        // secret up and carry on regardless.
+        const updated = yield* service.update(created.database.id, 'Repaired', {
+          connectionInfo: { ...connectionInfo, password: '' },
+          type: 'postgres'
+        })
+
+        const readBack = yield* service.getWithSecrets(created.database.id)
+
+        return { readBack, unreadable, updated }
+      })
+    )
+
+    expect(unreadable._tag).toEqual('SecretDecryptError')
+    expect(updated.name).toEqual('Repaired')
+
+    // The repaired row is readable again. The password is blank because the
+    // stored one was unrecoverable, which is the honest outcome — the user
+    // re-enters it.
+    expect(Option.isSome(readBack)).toEqual(true)
+
+    if (Option.isSome(readBack)) {
+      expect(readBack.value.connection).toEqual({
+        connectionInfo: { ...connectionInfo, password: '' },
+        type: 'postgres'
+      })
+    }
+  })
+
   it('returns none for a missing or deleted database', async () => {
     const { missing, deleted } = await run(
       Effect.gen(function* () {
@@ -334,7 +387,7 @@ describe('DatabaseService', () => {
 
         const missing = yield* service.getWithSecrets('missing')
 
-        const created = yield* service.create('Pagila', connectionInfo, 'postgres')
+        const created = yield* service.create('Pagila', connection)
 
         yield* service.remove(created.database.id)
 
@@ -353,7 +406,7 @@ describe('DatabaseService', () => {
       Effect.gen(function* () {
         const service = yield* DatabaseService
 
-        const created = yield* service.create('Pagila', connectionInfo, 'postgres')
+        const created = yield* service.create('Pagila', connection)
 
         return yield* service.getWithSecrets(created.database.id)
       })
@@ -362,7 +415,7 @@ describe('DatabaseService', () => {
     expect(Option.isSome(secrets)).toEqual(true)
 
     if (Option.isSome(secrets)) {
-      expect(secrets.value.connectionInfo).toEqual({
+      expect(secrets.value.connection.connectionInfo).toEqual({
         database: 'pagila',
         host: 'localhost',
         password: 'secret',

--- a/src/server/services/database-service.ts
+++ b/src/server/services/database-service.ts
@@ -2,13 +2,17 @@ import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { Effect, Option } from 'effect'
 
 import { databasesTable, worksheetsTable } from '@/database/schema'
-import { DatabaseNotFoundError, UnknownDatabaseIdsError } from '@/glue/api/errors'
+import {
+  DatabaseNotFoundError,
+  UnknownDatabaseIdsError
+} from '@/glue/api/errors'
 import type {
   ConnectionInfo,
+  DatabaseConnection,
   DatabaseDto,
   DatabaseType,
   PublicConnectionInfo,
-  UpdateConnectionInfo,
+  UpdateDatabaseConnection,
   WorksheetDto
 } from '@/glue/api/schemas'
 import { SecretDecryptError } from '../errors'
@@ -21,10 +25,9 @@ interface CreateDatabaseResult {
 }
 
 interface DatabaseWithSecrets {
-  connectionInfo: ConnectionInfo
+  connection: DatabaseConnection
   id: string
   name: string
-  type: DatabaseType
 }
 
 type DatabaseRow = typeof databasesTable.$inferSelect
@@ -51,6 +54,39 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
             })
           )
         )
+
+      // The stored blob is only JSON.parsed, never decoded against a schema, so
+      // its shape can disagree with the row's `type` — a row saved as SQLite
+      // whose info carries a host instead of a path. Check just enough to build
+      // the adapter safely: validating the whole shape here would reject rows
+      // that older builds wrote with fields this one no longer requires.
+      const toDatabaseConnection = (
+        type: DatabaseType,
+        connectionInfo: ConnectionInfo
+      ): Effect.Effect<DatabaseConnection, SecretDecryptError> => {
+        if (type === 'sqlite') {
+          if ('path' in connectionInfo && connectionInfo.path) {
+            return Effect.succeed({ connectionInfo, type })
+          }
+
+          return Effect.fail(
+            new SecretDecryptError({
+              message:
+                'This connection is saved as SQLite but has no database file. Edit the connection and choose a file.'
+            })
+          )
+        }
+
+        if ('host' in connectionInfo) {
+          return Effect.succeed({ connectionInfo, type })
+        }
+
+        return Effect.fail(
+          new SecretDecryptError({
+            message: `This connection is saved as ${type} but has no host. Edit the connection and save it again.`
+          })
+        )
+      }
 
       const transformDatabase = (record: DatabaseRow) =>
         parseConnectionInfo(record.connectionInfo).pipe(
@@ -118,15 +154,16 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
 
       const create = Effect.fn('DatabaseService.create')(function* (
         name: string,
-        connectionInfo: ConnectionInfo,
-        type: DatabaseType
+        connection: DatabaseConnection
       ) {
-        const encrypted = yield* secrets.encrypt(JSON.stringify(connectionInfo))
+        const encrypted = yield* secrets.encrypt(
+          JSON.stringify(connection.connectionInfo)
+        )
 
         const [record] = yield* appDatabase.execute((client) =>
           client
             .insert(databasesTable)
-            .values({ connectionInfo: encrypted, name, type })
+            .values({ connectionInfo: encrypted, name, type: connection.type })
             .returning()
         )
 
@@ -144,16 +181,17 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
         let updatedWorksheet: WorksheetDto | undefined
 
         if (existingDatabases.length === 1) {
-          const worksheetsWithoutDatabase = yield* appDatabase.execute((client) =>
-            client
-              .select()
-              .from(worksheetsTable)
-              .where(
-                and(
-                  isNull(worksheetsTable.deletedAt),
-                  isNull(worksheetsTable.databaseId)
+          const worksheetsWithoutDatabase = yield* appDatabase.execute(
+            (client) =>
+              client
+                .select()
+                .from(worksheetsTable)
+                .where(
+                  and(
+                    isNull(worksheetsTable.deletedAt),
+                    isNull(worksheetsTable.databaseId)
+                  )
                 )
-              )
           )
 
           if (worksheetsWithoutDatabase.length === 1) {
@@ -200,11 +238,15 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
             record.value.connectionInfo
           )
 
+          const connection = yield* toDatabaseConnection(
+            record.value.type as DatabaseType,
+            connectionInfo
+          )
+
           return Option.some<DatabaseWithSecrets>({
-            connectionInfo,
+            connection,
             id: record.value.id,
-            name: record.value.name,
-            type: record.value.type as DatabaseType
+            name: record.value.name
           })
         }
       )
@@ -285,40 +327,66 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
 
       // An update without a password means "keep the stored one" — the
       // renderer never sees passwords, so edits can't send them back.
-      const resolveConnectionInfo = (
+      const resolveConnection = (
         id: string,
-        connectionInfo: UpdateConnectionInfo,
-        type: DatabaseType
+        connection: UpdateDatabaseConnection
       ) =>
         Effect.gen(function* () {
-          if (!('username' in connectionInfo) || connectionInfo.password) {
-            return connectionInfo as ConnectionInfo
+          // SQLite has no password to merge back in.
+          if (connection.type === 'sqlite') {
+            return connection
           }
 
-          const existing = yield* getWithSecrets(id)
+          const { connectionInfo, type } = connection
+
+          if (connectionInfo.password) {
+            return {
+              connectionInfo: {
+                ...connectionInfo,
+                password: connectionInfo.password
+              },
+              type
+            }
+          }
+
+          // A stored secret this build cannot read must not block the edit that
+          // repairs it, so an unreadable row behaves like one with no stored
+          // password rather than failing the update.
+          const existing = yield* getWithSecrets(id).pipe(
+            Effect.catchTag('SecretDecryptError', () =>
+              Effect.succeed(Option.none<DatabaseWithSecrets>())
+            )
+          )
           const storedPassword =
             Option.isSome(existing) &&
-            existing.value.type === type &&
-            'password' in existing.value.connectionInfo
-              ? existing.value.connectionInfo.password
+            existing.value.connection.type === type &&
+            'password' in existing.value.connection.connectionInfo
+              ? existing.value.connection.connectionInfo.password
               : ''
 
-          return { ...connectionInfo, password: storedPassword }
+          return {
+            connectionInfo: { ...connectionInfo, password: storedPassword },
+            type
+          }
         })
 
       const update = Effect.fn('DatabaseService.update')(function* (
         id: string,
         name: string,
-        connectionInfo: UpdateConnectionInfo,
-        type: DatabaseType
+        connection: UpdateDatabaseConnection
       ) {
-        const resolved = yield* resolveConnectionInfo(id, connectionInfo, type)
-        const encrypted = yield* secrets.encrypt(JSON.stringify(resolved))
+        const resolved: DatabaseConnection = yield* resolveConnection(
+          id,
+          connection
+        )
+        const encrypted = yield* secrets.encrypt(
+          JSON.stringify(resolved.connectionInfo)
+        )
 
         const [record] = yield* appDatabase.execute((client) =>
           client
             .update(databasesTable)
-            .set({ connectionInfo: encrypted, name, type })
+            .set({ connectionInfo: encrypted, name, type: resolved.type })
             // Soft-deleted rows are excluded like everywhere else: without this
             // a PATCH would re-encrypt a password onto a row whose secret
             // remove() deliberately purged, and answer 200 for a database that

--- a/src/server/services/query-runner.test.ts
+++ b/src/server/services/query-runner.test.ts
@@ -56,7 +56,10 @@ function run<A, E>(
 const createDatabase = Effect.gen(function* () {
   const databases = yield* DatabaseService
 
-  const created = yield* databases.create('Pagila', connectionInfo, 'postgres')
+  const created = yield* databases.create('Pagila', {
+    connectionInfo,
+    type: 'postgres'
+  })
 
   return created.database
 })
@@ -175,10 +178,7 @@ describe('QueryRunner', () => {
           if (rejectRunningQuery === undefined) {
             return yield* Effect.fail(new Error('adapter not running yet'))
           }
-        }).pipe(
-          Effect.retry({ times: 100 }),
-          Effect.delay('1 millis')
-        )
+        }).pipe(Effect.retry({ times: 100 }), Effect.delay('1 millis'))
 
         yield* runner.awaitIdle
 

--- a/src/server/services/query-runner.ts
+++ b/src/server/services/query-runner.ts
@@ -2,7 +2,11 @@ import { desc, eq, isNull } from 'drizzle-orm'
 import { Cause, Clock, Effect, FiberMap, Option } from 'effect'
 
 import { databasesTable, queriesTable } from '@/database/schema'
-import { QueryCanceledError, type DatabaseAdapter, type QueryResult } from '@/databases/adapter'
+import {
+  QueryCanceledError,
+  type DatabaseAdapter,
+  type QueryResult
+} from '@/databases/adapter'
 import { NoDatabaseAvailableError, QueryNotFoundError } from '@/glue/api/errors'
 import type { CreateQueryRequest, QueryDto } from '@/glue/api/schemas'
 import { canceledQueryMessage } from '@/glue/queries'
@@ -62,11 +66,8 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
         }
 
         return {
-          adapter: adapterFactory.create(
-            record.value.type,
-            record.value.connectionInfo
-          ),
-          databaseType: record.value.type
+          adapter: adapterFactory.create(record.value.connection),
+          databaseType: record.value.connection.type
         }
       }).pipe(
         Effect.withSpan('query.loadConnection', {
@@ -91,9 +92,7 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
         catch: (cause) => new AdapterQueryError(cause),
         try: () => adapter.runQuery(query.content)
       }).pipe(
-        Effect.map(
-          (result): AdapterOutcome => ({ _tag: 'completed', result })
-        ),
+        Effect.map((result): AdapterOutcome => ({ _tag: 'completed', result })),
         Effect.catchIf(
           (error) => isCancellationError(error.cause),
           () =>
@@ -177,9 +176,7 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
           adapter,
           databaseType,
           query
-        ).pipe(
-          Effect.ensuring(Effect.sync(() => adapters.delete(query.id)))
-        )
+        ).pipe(Effect.ensuring(Effect.sync(() => adapters.delete(query.id))))
 
         if (outcome._tag === 'canceled') {
           // The event is recorded on the db.query span inside runAdapterQuery,
@@ -368,9 +365,7 @@ function toStoredQueryResult(value: unknown): QueryResult | null {
     return null
   }
 
-  if (
-    !candidate.rows.every((row) => typeof row === 'object' && row !== null)
-  ) {
+  if (!candidate.rows.every((row) => typeof row === 'object' && row !== null)) {
     return null
   }
 

--- a/src/test/effect-test-helper.ts
+++ b/src/test/effect-test-helper.ts
@@ -11,6 +11,7 @@ import { ConfigProvider, Effect, Layer, Redacted } from 'effect'
 import { createTables } from '@/database/tables'
 import type { SchemaInfo, QueryResult } from '@/databases/adapter'
 import { SquealApi } from '@/glue/api/api'
+import type { DatabaseConnection } from '@/glue/api/schemas'
 import { ApiToken } from '@/server/http/api-token'
 import { ApiLive, CorsLive, ServeLive } from '@/server/http/server'
 import {
@@ -93,9 +94,9 @@ export function makeTestAdapterFactory(config: TestAdapterConfig = {}) {
   const layer = Layer.succeed(
     AdapterFactory,
     AdapterFactory.make({
-      create: (type: string, connectionInfo: unknown) => {
-        state.lastConnectionInfo = connectionInfo
-        state.lastType = type
+      create: (connection: DatabaseConnection) => {
+        state.lastConnectionInfo = connection.connectionInfo
+        state.lastType = connection.type
 
         return {
           cancel: config.cancel ?? (() => Promise.resolve()),


### PR DESCRIPTION
## The defect

`type` and `connectionInfo` were validated independently, so this decoded cleanly:

```json
{ "type": "sqlite", "connectionInfo": { "host": "localhost", "database": "pagila", … } }
```

`createAdapter` then cast it to the SQLite shape and the adapter crashed on `pathToFileURL(undefined)` — a 500 defect for what is a malformed request. From `todo.md`: *"Use a discriminated union for connection info."*

## The fix

**Discriminate on `type` where the pair is formed.** The discriminant is a *sibling* of `connectionInfo`, not a field inside it, so the union lives at the level that owns both:

```ts
export const DatabaseConnection = Schema.Union(
  Schema.Struct({ connectionInfo: ServerConnectionInfo, type: Schema.Literal('mysql', 'postgres') }),
  Schema.Struct({ connectionInfo: SqliteConnectionInfo, type: Schema.Literal('sqlite') })
)
```

The create, update and connection-test payloads are built from it, so a mismatched pair fails decoding at the boundary. It now answers **400** with the precise issue (`connectionInfo.path is missing`, `Expected "mysql" | "postgres", actual "sqlite"`) instead of a 500.

**Threading one value removes both casts.** `AdapterFactory.create(connection)` and `createAdapter(connection)` take the tagged value, so `switch (connection.type)` narrows `connectionInfo` — the `as legacy.ConnectionInfo` and the three `as …ConnectionInfo` casts are gone. `DatabaseService.create`/`update`/`getWithSecrets` carry the pair too.

**Stored rows are the other trust boundary.** They are only `JSON.parse`d, never decoded against a schema, so a row an older build saved with a disagreeing shape can still arrive. `getWithSecrets` checks just enough to build the adapter safely, and `SqliteAdapter` keeps an `invariant` as the last line of defence. Both say what to do:

> This connection is saved as SQLite but has no database file. Edit the connection and choose a file.

Deliberately *not* a full schema decode of stored blobs — that would reject rows written with fields this build no longer requires.

**One regression caught and fixed:** editing a broken row is how the user repairs it, and the renderer always sends a blank password (it never receives the stored one), so `update` would have called the now-failing `getWithSecrets` and 500'd. It treats an unreadable stored secret as an absent password instead. Covered by a test that fails without the guard.

## Deliberately out of scope

- `DatabaseDto.connectionInfo` stays `NullOr(PublicConnectionInfo)`. It is null when a secret cannot be decrypted, which makes a discriminated response union awkward for no correctness gain — the response is read-only.
- The renderer's zod form schemas still validate the two independently. The form's type selector resets `connectionInfo` on every change (`DatabaseForm.tsx:179`), so it cannot produce a mismatch; a comment now points at the contract as the enforcement point.
- `query-runner.ts` had pre-existing Prettier drift. Only the semantic hunk is included here so the diff stays reviewable; a repo-wide format belongs with the PR that adds `prettier --check` to CI.

## Verification

- `yarn typecheck` — both projects clean
- `CI=1 vitest run` — **682 passed** (675 before, 7 new)
- `yarn lint` clean

New tests: mismatched create → 400 and nothing written to the database (one shared layer, so the row check reads the database the request was aimed at); mismatched connection test → 400; a SQLite pair builds a SQLite adapter; the adapter invariant for empty and missing paths; the repair path above.