### PR TITLE
fix(databases): stop connection cleanup masking query errors

### DIFF
--- a/src/databases/close-quietly.test.ts
+++ b/src/databases/close-quietly.test.ts
@@ -1,0 +1,52 @@
+import { log } from 'tiny-typescript-logger'
+import { describe, expect, it, vi } from 'vitest'
+
+import { closeQuietly } from './close-quietly'
+
+vi.mock('tiny-typescript-logger', () => ({
+  log: { warn: vi.fn() }
+}))
+
+describe('closeQuietly', () => {
+  it('awaits a close that succeeds', async () => {
+    const close = vi.fn(() => Promise.resolve())
+
+    await closeQuietly(close, 'query')
+
+    expect(close).toHaveBeenCalled()
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  it('swallows a rejecting close and logs the message', async () => {
+    vi.mocked(log.warn).mockClear()
+
+    await closeQuietly(
+      () => Promise.reject(new Error('socket hang up')),
+      'query'
+    )
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'Could not close the query connection: socket hang up'
+    )
+  })
+
+  it('swallows a close that throws synchronously', async () => {
+    await closeQuietly(() => {
+      throw new Error('already destroyed')
+    }, 'schema')
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'Could not close the schema connection: already destroyed'
+    )
+  })
+
+  it('describes a non-Error rejection without crashing', async () => {
+    vi.mocked(log.warn).mockClear()
+
+    await closeQuietly(() => Promise.reject('nope'), 'probe')
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'Could not close the probe connection: nope'
+    )
+  })
+})

--- a/src/databases/close-quietly.ts
+++ b/src/databases/close-quietly.ts
@@ -1,0 +1,30 @@
+import { log } from 'tiny-typescript-logger'
+
+/**
+ * Closes a connection without letting the close itself throw.
+ *
+ * Every adapter opens a connection, uses it in a `try`, and closes it in the
+ * matching `finally`. A bare `await client.end()` there is a trap: when the
+ * body already failed, a rejecting close replaces the error the caller actually
+ * needs — the failed query — with a socket error, and the connection leaks
+ * anyway because nothing retries the close. Closing is best effort by nature,
+ * so it is logged and swallowed.
+ *
+ * Accepts a sync or async close so it covers both mysql2 APIs: the promise
+ * connection returns a promise from `end()`, the callback one returns void.
+ */
+export async function closeQuietly(
+  close: () => Promise<void> | void,
+  description: string
+): Promise<void> {
+  try {
+    await close()
+  } catch (error) {
+    // The message only — a driver error object embeds the connection config.
+    log.warn(
+      `Could not close the ${description} connection: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+}

--- a/src/databases/mysql-adapter.ts
+++ b/src/databases/mysql-adapter.ts
@@ -2,6 +2,7 @@ import { createConnection, type FieldPacket } from 'mysql2'
 import mysql from 'mysql2/promise'
 
 import { maxResultRows } from './adapter'
+import { closeQuietly } from './close-quietly'
 import type { DatabaseAdapter, QueryResult, SchemaInfo } from './adapter'
 import {
   type ColumnRow,
@@ -41,7 +42,7 @@ export class MysqlAdapter implements DatabaseAdapter {
         foreignKeyRows as ForeignKeyRow[]
       )
     } finally {
-      await connection.end()
+      await closeQuietly(() => connection.end(), 'schema')
     }
   }
 
@@ -77,7 +78,7 @@ export class MysqlAdapter implements DatabaseAdapter {
       // `destroy()` has already torn the socket down; calling `end()` on top of
       // it throws.
       if (!timedOut) {
-        await connection.end()
+        await closeQuietly(() => connection.end(), 'version probe')
       }
     }
   }
@@ -161,7 +162,7 @@ export class MysqlAdapter implements DatabaseAdapter {
       })
     } finally {
       if (!destroyed) {
-        connection.end()
+        await closeQuietly(() => connection.end(), 'query')
       }
     }
   }
@@ -172,7 +173,7 @@ export class MysqlAdapter implements DatabaseAdapter {
     try {
       await connection.ping()
     } finally {
-      await connection.end()
+      await closeQuietly(() => connection.end(), 'connection test')
     }
   }
 

--- a/src/databases/postgres-adapter.test.ts
+++ b/src/databases/postgres-adapter.test.ts
@@ -459,6 +459,42 @@ describe('PostgresAdapter', () => {
       expect(mockEnd).toHaveBeenCalled()
     })
 
+    // The close lives in the `finally`, so a rejecting one used to replace the
+    // error the caller needs with a socket error — and the connection leaked
+    // anyway, since nothing retries the close.
+    it('still reports the query error when closing the connection fails', async () => {
+      cursorState.fixtures.push({
+        error: new Error('Query failed'),
+        fields: [],
+        rows: []
+      })
+      mockEnd.mockRejectedValueOnce(new Error('socket hang up'))
+
+      const adapter = new PostgresAdapter(connectionInfo)
+
+      await expect(adapter.runQuery('INVALID SQL')).rejects.toThrow(
+        'Query failed'
+      )
+    })
+
+    it('still returns rows when closing the connection fails', async () => {
+      cursorState.fixtures.push({
+        fields: [{ name: 'id' }],
+        rowCount: 1,
+        rows: [{ id: 1 }]
+      })
+      mockEnd.mockRejectedValueOnce(new Error('socket hang up'))
+
+      const adapter = new PostgresAdapter(connectionInfo)
+
+      expect(await adapter.runQuery('SELECT id FROM t')).toEqual({
+        fields: [{ name: 'id' }],
+        rowCount: 1,
+        rows: [{ id: 1 }],
+        truncated: false
+      })
+    })
+
     it('passes discrete connection fields without ssl when sslMode is disable', async () => {
       cursorState.fixtures.push({ fields: [], rows: [] })
 

--- a/src/databases/postgres-adapter.ts
+++ b/src/databases/postgres-adapter.ts
@@ -7,6 +7,7 @@ import Cursor from 'pg-cursor'
 import { log } from 'tiny-typescript-logger'
 
 import { maxResultRows, QueryCanceledError } from './adapter'
+import { closeQuietly } from './close-quietly'
 import type { DatabaseAdapter, QueryResult, SchemaInfo } from './adapter'
 import {
   extractMissingColumn,
@@ -98,7 +99,7 @@ export class PostgresAdapter implements DatabaseAdapter {
     try {
       return await this.getSchemaWithClient(client)
     } finally {
-      await client.end()
+      await closeQuietly(() => client.end(), 'schema')
     }
   }
 
@@ -125,7 +126,7 @@ export class PostgresAdapter implements DatabaseAdapter {
         rawVersion
       )
     } finally {
-      await client.end()
+      await closeQuietly(() => client.end(), 'version probe')
     }
   }
 
@@ -174,7 +175,7 @@ export class PostgresAdapter implements DatabaseAdapter {
     } finally {
       this.activeClient = null
 
-      await client.end()
+      await closeQuietly(() => client.end(), 'query')
     }
   }
 
@@ -296,7 +297,7 @@ export class PostgresAdapter implements DatabaseAdapter {
     try {
       await client.connect()
     } finally {
-      await client.end()
+      await closeQuietly(() => client.end(), 'connection test')
     }
   }
 }


### PR DESCRIPTION
## The defect

Every adapter opens a connection, uses it in a `try`, and closes it in the matching `finally`. Seven of those closes were a bare `await client.end()`:

```ts
try {
  return await this.executeQuery(client, currentQuery)
} finally {
  this.activeClient = null

  await client.end()   // rejects → replaces the query error, leaks the socket
}
```

When the body has already failed, a rejecting close replaces the error the caller actually needs with a socket error — and the connection leaks anyway, because nothing retries the close. From `todo.md`: *"Protect connection cleanup."*

## The fix

`closeQuietly` logs and swallows, which is what closing has always been — best effort:

```ts
} finally {
  this.activeClient = null

  await closeQuietly(() => client.end(), 'query')
}
```

It takes a sync **or** async close, because both mysql2 APIs are in play: the promise connection returns a promise from `end()`, the callback one returns void. Only the error message is logged — a driver error object embeds the connection config.

Sites fixed — `getSchema`, `getServerVersion`, `runQuery` and `testConnection` in both adapters.

**One was worse than unguarded.** The mysql2 callback connection in `runQuery` was closed *without* `await`:

```ts
if (!destroyed) {
  connection.end()   // floating; a failure had nowhere to surface
}
```

## Left alone deliberately

`acquireConnection` and `cancel` in the Postgres adapter already guard their teardown inline, with comments specific to abort semantics (*"Aborting is best-effort; the connect rejecting is what matters."*). Rewriting them through the helper would lose that context for no correctness gain.

## Verification

- `yarn typecheck` clean, `yarn lint` clean
- `CI=1 vitest run` — **681 passed** (675 before, 6 new: 4 for the helper, 2 for the adapter behaviour)

The two adapter tests were checked against the unfixed code and both fail there:

```
× still reports the query error when closing the connection fails
× still returns rows when closing the connection fails
Tests  2 failed | 30 passed (32)
```

They cover both directions — a failing query whose error must survive a rejecting close, and a *successful* query whose rows must still be returned when the close fails.