### PR TITLE
fix(app): number untitled worksheets past the highest suffix

### DIFF
--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -204,7 +204,7 @@ export function useUpdateDatabase() {
         databases.utils.writeUpsert(response.database)
       }
 
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: queryKeys.schema(response.database.id)
       })
     }

--- a/src/app/worksheet-naming.test.ts
+++ b/src/app/worksheet-naming.test.ts
@@ -36,4 +36,23 @@ describe('getNextUntitledName', () => {
       getNextUntitledName([worksheet('Revenue'), worksheet('Untitled notes')])
     ).toEqual('Untitled')
   })
+
+  // Counting the untitled worksheets collides the moment the set has a gap.
+  it('does not reuse a name after an earlier untitled worksheet is renamed', () => {
+    expect(
+      getNextUntitledName([worksheet('Revenue'), worksheet('Untitled 2')])
+    ).toEqual('Untitled 3')
+  })
+
+  it('does not reuse a name after an untitled worksheet is deleted', () => {
+    expect(
+      getNextUntitledName([worksheet('Untitled'), worksheet('Untitled 3')])
+    ).toEqual('Untitled 4')
+  })
+
+  it('goes past the highest suffix, not the count', () => {
+    expect(
+      getNextUntitledName([worksheet('Untitled'), worksheet('Untitled 9')])
+    ).toEqual('Untitled 10')
+  })
 })

--- a/src/app/worksheet-naming.ts
+++ b/src/app/worksheet-naming.ts
@@ -2,14 +2,27 @@ import type { WorksheetDto } from '@/glue/worksheets'
 
 /**
  * Names a new worksheet "Untitled", then "Untitled 2", "Untitled 3" and so on.
- * Counts the existing untitled worksheets rather than tracking a counter, so
- * the name stays stable across restarts.
+ *
+ * Takes one past the highest suffix already in use rather than counting the
+ * untitled worksheets. Counting collides as soon as the set has a gap: rename
+ * "Untitled" to something else while "Untitled 2" exists and the count is 1
+ * again, so the next worksheet is named "Untitled 2" on top of the one already
+ * there. Deleting one does the same.
  */
 export function getNextUntitledName(worksheets: WorksheetDto[]): string {
-  const untitledCount = worksheets.filter(
-    (worksheet) =>
-      worksheet.name === 'Untitled' || /^Untitled \d+$/.test(worksheet.name)
-  ).length
+  const suffixes = worksheets.flatMap((worksheet) => {
+    if (worksheet.name === 'Untitled') {
+      return [1]
+    }
 
-  return untitledCount === 0 ? 'Untitled' : `Untitled ${untitledCount + 1}`
+    const numbered = /^Untitled (\d+)$/.exec(worksheet.name)
+
+    return numbered ? [Number(numbered[1])] : []
+  })
+
+  if (suffixes.length === 0) {
+    return 'Untitled'
+  }
+
+  return `Untitled ${Math.max(...suffixes) + 1}`
 }


### PR DESCRIPTION
Two small renderer defects from `todo.md`.

## Untitled numbering could reuse a name that is taken

`getNextUntitledName` counted the untitled worksheets and added one, which collides as soon as the set has a gap:

| Existing worksheets | Count + 1 (before) | Highest + 1 (after) |
| --- | --- | --- |
| `Revenue`, `Untitled 2` | **`Untitled 2`** 💥 | `Untitled 3` |
| `Untitled`, `Untitled 3` | **`Untitled 3`** 💥 | `Untitled 4` |
| `Untitled`, `Untitled 9` | `Untitled 3` | `Untitled 10` |

Renaming `Untitled` to something else drops the count back, so the next new worksheet lands on a name that already exists. Deleting one does the same — which matters more once worksheet delete exists.

## A floating promise

`hooks/mutations.ts:207` was the one `invalidateQueries` in the file neither awaited nor voided (`:131`, `:158`, `:185` all are). Violates *"No Floating Promises"* in `CLAUDE.md`.

## Verification

- `yarn typecheck` clean, `yarn lint` clean
- `CI=1 vitest run` — **678 passed** (675 before, 3 new)

The three new naming tests were run against the old implementation and all three fail there:

```
× does not reuse a name after an earlier untitled worksheet is renamed
× does not reuse a name after an untitled worksheet is deleted
× goes past the highest suffix, not the count
Tests  3 failed | 4 passed (7)
```