### PR TITLE
feat(worksheets): delete a worksheet

### DIFF
--- a/src/app/api-client.ts
+++ b/src/app/api-client.ts
@@ -372,6 +372,17 @@ export const apiClient = {
     )
   },
 
+  async deleteWorksheet(worksheetId: string): Promise<void> {
+    await traced(
+      'HTTP DELETE /worksheets/:id',
+      { method: 'DELETE', path: `/worksheets/${worksheetId}` },
+      undefined,
+      Effect.flatMap(client, (api) =>
+        api.worksheets.remove({ path: { id: worksheetId } })
+      )
+    )
+  },
+
   async getDatabaseSchema(databaseId: string): Promise<SchemaInfoDto> {
     const data = await traced(
       'HTTP GET /databases/:id/schema',

--- a/src/app/components/WorksheetExplorer.test.tsx
+++ b/src/app/components/WorksheetExplorer.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -11,6 +11,7 @@ import { WorksheetExplorer } from './WorksheetExplorer'
 vi.mock('../api-client', () => ({
   apiClient: {
     createWorksheet: vi.fn(),
+    deleteWorksheet: vi.fn(),
     getDatabases: vi.fn(async () => []),
     updateWorksheet: vi.fn()
   }
@@ -304,6 +305,88 @@ describe('WorksheetExplorer', () => {
           name: 'My New Worksheet'
         })
       })
+    })
+  })
+  describe('deleting', () => {
+    const secondWorksheet: WorksheetDto = {
+      ...testWorksheet,
+      id: 'ws-456',
+      name: 'Second Worksheet'
+    }
+
+    it('deletes a worksheet after confirming via the action toast', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(apiClient.deleteWorksheet).mockResolvedValue(undefined)
+
+      renderWithProviders(<WorksheetExplorer />, {
+        databases: [],
+        worksheets: [testWorksheet, secondWorksheet]
+      })
+
+      fireEvent.contextMenu(screen.getByText('Second Worksheet'))
+
+      await user.click(await screen.findByRole('menuitem', { name: 'Delete' }))
+
+      // The toast asks first; nothing is deleted until it is confirmed.
+      expect(apiClient.deleteWorksheet).not.toHaveBeenCalled()
+      expect(
+        await screen.findByText('Delete "Second Worksheet"?')
+      ).toBeVisible()
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+      await waitFor(() => {
+        expect(apiClient.deleteWorksheet).toHaveBeenCalledWith('ws-456')
+      })
+    })
+
+    it('does not delete when the confirmation is ignored', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<WorksheetExplorer />, {
+        databases: [],
+        worksheets: [testWorksheet, secondWorksheet]
+      })
+
+      fireEvent.contextMenu(screen.getByText('Second Worksheet'))
+
+      await user.click(await screen.findByRole('menuitem', { name: 'Delete' }))
+
+      expect(
+        await screen.findByText('Delete "Second Worksheet"?')
+      ).toBeVisible()
+      expect(apiClient.deleteWorksheet).not.toHaveBeenCalled()
+    })
+
+    // The app is built around always having a worksheet open, and the list
+    // endpoint would just recreate a default one.
+    it('disables delete for the last remaining worksheet', async () => {
+      renderWithProviders(<WorksheetExplorer />, {
+        databases: [],
+        worksheets: [testWorksheet]
+      })
+
+      fireEvent.contextMenu(screen.getByText('Test Worksheet'))
+
+      expect(
+        await screen.findByRole('menuitem', { name: 'Delete' })
+      ).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('offers Rename in the same menu', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<WorksheetExplorer />, {
+        databases: [],
+        worksheets: [testWorksheet, secondWorksheet]
+      })
+
+      fireEvent.contextMenu(screen.getByText('Second Worksheet'))
+
+      await user.click(await screen.findByRole('menuitem', { name: 'Rename' }))
+
+      expect(await screen.findByDisplayValue('Second Worksheet')).toBeVisible()
     })
   })
 })

--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -2,7 +2,7 @@ import { closestCenter, DndContext } from '@dnd-kit/core'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { SortableContext, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { FileBracesIcon, PlusIcon } from 'lucide-react'
+import { FileBracesIcon, Pencil, PlusIcon, Trash2 } from 'lucide-react'
 import {
   ReactElement,
   ReactNode,
@@ -15,7 +15,11 @@ import { toast } from 'sonner'
 
 import { useCollections } from '../collections-context'
 import { useDatabases, useWorksheets } from '../hooks/queries'
-import { useCreateWorksheet, useReorderWorksheets } from '../hooks/mutations'
+import {
+  useCreateWorksheet,
+  useDeleteWorksheet,
+  useReorderWorksheets
+} from '../hooks/mutations'
 import {
   staticListStrategy,
   useDropIndicator,
@@ -27,10 +31,50 @@ import { useAppDispatch, useAppSelector } from '../store'
 import { worksheetSearchQueryUpdated } from '../store/editor-slice'
 import { selectActiveWorksheetId, tabsActions } from '../store/tabs-slice'
 import { getNextUntitledName } from '../worksheet-naming'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from './ui/context-menu'
 import { Input } from './ui/input'
 import { DropIndicatorLine } from './DropIndicatorLine'
 import { SearchInput } from './SearchInput'
 import { WorksheetDto } from '@/glue/worksheets'
+
+// Deleting takes the editor content with it, so it asks first via an action
+// toast — ignoring it is a safe no. Mirrors the database explorer.
+function useConfirmedWorksheetDeletion(): (worksheet: WorksheetDto) => void {
+  const deleteWorksheet = useDeleteWorksheet()
+
+  return useCallback(
+    (worksheet: WorksheetDto) => {
+      toast(`Delete "${worksheet.name}"?`, {
+        action: {
+          label: 'Delete',
+          onClick: () => {
+            deleteWorksheet.mutate(worksheet.id, {
+              onError: (error) => {
+                const message =
+                  error instanceof Error ? error.message : 'Unknown error'
+
+                toast.error('Failed to delete worksheet', {
+                  description: message
+                })
+              },
+              onSuccess: () => {
+                toast.success(`Deleted "${worksheet.name}"`)
+              }
+            })
+          }
+        },
+        description:
+          'This worksheet and its editor content will be removed. Query history is kept.'
+      })
+    },
+    [deleteWorksheet]
+  )
+}
 
 function useWorksheetRename(worksheets: WorksheetDto[]) {
   const { worksheets: worksheetsCollection } = useCollections()
@@ -117,6 +161,62 @@ function useWorksheetRename(worksheets: WorksheetDto[]) {
   }
 }
 
+/**
+ * What the user can do to a worksheet from the explorer: open one (which also
+ * marks it most-recently-used) and create a new one. Both need the same tab
+ * dispatch and touch, so they live together rather than in the component body.
+ */
+function useWorksheetActions(
+  worksheets: WorksheetDto[],
+  startEditing: (worksheet: WorksheetDto) => void
+) {
+  const dispatch = useAppDispatch()
+  const createWorksheet = useCreateWorksheet()
+  const { worksheets: worksheetsCollection } = useCollections()
+
+  const touchWorksheet = useCallback(
+    (worksheetId: string) => {
+      const transaction = worksheetsCollection.update(worksheetId, (draft) => {
+        draft.lastOpenedAt = Date.now()
+      })
+
+      void transaction.isPersisted.promise.catch((): void => undefined)
+    },
+    [worksheetsCollection]
+  )
+
+  const handleSelectWorksheet = useCallback(
+    (worksheetId: string) => {
+      dispatch(tabsActions.tabOpened(worksheetId))
+      touchWorksheet(worksheetId)
+    },
+    [dispatch, touchWorksheet]
+  )
+
+  const handleNewWorksheet = useCallback(() => {
+    const name = getNextUntitledName(worksheets)
+
+    createWorksheet.mutate(
+      { name },
+      {
+        onSuccess: (worksheet) => {
+          dispatch(tabsActions.tabOpened(worksheet.id))
+          touchWorksheet(worksheet.id)
+          startEditing(worksheet)
+        },
+        onError: (error) => {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error'
+
+          toast.error('Failed to create worksheet', { description: message })
+        }
+      }
+    )
+  }, [createWorksheet, dispatch, startEditing, touchWorksheet, worksheets])
+
+  return { handleNewWorksheet, handleSelectWorksheet }
+}
+
 export function WorksheetExplorer(): ReactElement {
   const dispatch = useAppDispatch()
   const databases = useDatabases()
@@ -125,9 +225,6 @@ export function WorksheetExplorer(): ReactElement {
   const worksheetSearchQuery = useAppSelector(
     (state) => state.editor.worksheetSearchQuery ?? ''
   )
-
-  const createWorksheet = useCreateWorksheet()
-  const { worksheets: worksheetsCollection } = useCollections()
 
   const {
     editingName,
@@ -138,6 +235,13 @@ export function WorksheetExplorer(): ReactElement {
     setEditingName,
     startEditing
   } = useWorksheetRename(worksheets.data)
+
+  const { handleNewWorksheet, handleSelectWorksheet } = useWorksheetActions(
+    worksheets.data,
+    startEditing
+  )
+
+  const handleDeleteWorksheet = useConfirmedWorksheetDeletion()
 
   // The list order comes from the useWorksheets live query (sortOrder, then
   // newest first).
@@ -165,46 +269,6 @@ export function WorksheetExplorer(): ReactElement {
     onReorder: reorderWorksheets.mutate,
     resetDropIndicator
   })
-
-  const touchWorksheet = useCallback(
-    (worksheetId: string) => {
-      const transaction = worksheetsCollection.update(worksheetId, (draft) => {
-        draft.lastOpenedAt = Date.now()
-      })
-
-      void transaction.isPersisted.promise.catch((): void => undefined)
-    },
-    [worksheetsCollection]
-  )
-
-  const handleSelectWorksheet = useCallback(
-    (worksheetId: string) => {
-      dispatch(tabsActions.tabOpened(worksheetId))
-      touchWorksheet(worksheetId)
-    },
-    [dispatch, touchWorksheet]
-  )
-
-  const handleNewWorksheet = useCallback(() => {
-    const name = getNextUntitledName(worksheets.data)
-
-    createWorksheet.mutate(
-      { name },
-      {
-        onSuccess: (worksheet) => {
-          dispatch(tabsActions.tabOpened(worksheet.id))
-          touchWorksheet(worksheet.id)
-          startEditing(worksheet)
-        },
-        onError: (error) => {
-          const message =
-            error instanceof Error ? error.message : 'Unknown error'
-
-          toast.error('Failed to create worksheet', { description: message })
-        }
-      }
-    )
-  }, [createWorksheet, dispatch, startEditing, touchWorksheet, worksheets.data])
 
   // Worksheets show which database they run against, so the names are looked
   // up once per render instead of per row.
@@ -288,6 +352,7 @@ export function WorksheetExplorer(): ReactElement {
                   />
                 ) : (
                   <WorksheetListItem
+                    canDelete={worksheets.data.length > 1}
                     databaseName={
                       worksheet.databaseId
                         ? databaseNames.get(worksheet.databaseId)
@@ -295,6 +360,7 @@ export function WorksheetExplorer(): ReactElement {
                     }
                     isOpen={worksheet.id === openWorksheetId}
                     worksheet={worksheet}
+                    onDelete={handleDeleteWorksheet}
                     onDoubleClick={startEditing}
                     onSelect={handleSelectWorksheet}
                   />
@@ -344,47 +410,76 @@ function WorksheetRow({
 }
 
 interface WorksheetListItemProps {
+  // False for the last remaining worksheet: the app is built around always
+  // having one open, and the list endpoint would just recreate a default.
+  canDelete: boolean
   databaseName?: string
   isOpen: boolean
   worksheet: WorksheetDto
+  onDelete: (worksheet: WorksheetDto) => void
   onDoubleClick: (worksheet: WorksheetDto) => void
   onSelect: (worksheetId: string) => void
 }
 
 function WorksheetListItem({
+  canDelete,
   databaseName,
   isOpen,
   worksheet,
+  onDelete,
   onDoubleClick,
   onSelect
 }: WorksheetListItemProps): ReactElement {
   return (
-    <button
-      className={cn(
-        'flex h-[var(--item-h)] w-full flex-none items-center gap-2 rounded-[6px] px-2 text-left hover:bg-hover',
-        isOpen ? 'bg-sel text-text' : 'text-text2'
-      )}
-      type="button"
-      onClick={() => onSelect(worksheet.id)}
-      onDoubleClick={() => onDoubleClick(worksheet)}
-    >
-      <FileBracesIcon
-        className={cn(
-          'size-[13px] flex-none',
-          isOpen ? 'text-accent' : 'text-text3'
-        )}
-      />
+    <ContextMenu>
+      <ContextMenuTrigger>
+        <button
+          className={cn(
+            'flex h-[var(--item-h)] w-full flex-none items-center gap-2 rounded-[6px] px-2 text-left hover:bg-hover',
+            isOpen ? 'bg-sel text-text' : 'text-text2'
+          )}
+          type="button"
+          onClick={() => onSelect(worksheet.id)}
+          onDoubleClick={() => onDoubleClick(worksheet)}
+        >
+          <FileBracesIcon
+            className={cn(
+              'size-[13px] flex-none',
+              isOpen ? 'text-accent' : 'text-text3'
+            )}
+          />
 
-      <span className="min-w-0 flex-1 truncate text-[12.5px]">
-        {worksheet.name}
-      </span>
+          <span className="min-w-0 flex-1 truncate text-[12.5px]">
+            {worksheet.name}
+          </span>
 
-      {databaseName !== undefined && (
-        <span className="max-w-[76px] flex-none truncate rounded-[4px] border border-border2 bg-bg px-[5px] py-[1.5px] font-mono text-[10px] text-text3">
-          {databaseName}
-        </span>
-      )}
-    </button>
+          {databaseName !== undefined && (
+            <span className="max-w-[76px] flex-none truncate rounded-[4px] border border-border2 bg-bg px-[5px] py-[1.5px] font-mono text-[10px] text-text3">
+              {databaseName}
+            </span>
+          )}
+        </button>
+      </ContextMenuTrigger>
+
+      <ContextMenuContent>
+        <ContextMenuItem
+          className="flex items-center gap-2 min-w-32 text-xs"
+          onClick={() => onDoubleClick(worksheet)}
+        >
+          <Pencil className="size-3" />
+          Rename
+        </ContextMenuItem>
+
+        <ContextMenuItem
+          className="flex items-center gap-2 min-w-32 text-xs text-destructive focus:text-destructive"
+          disabled={!canDelete}
+          onClick={() => onDelete(worksheet)}
+        >
+          <Trash2 className="size-3" />
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -133,6 +133,23 @@ export function useDeleteDatabase() {
   })
 }
 
+export function useDeleteWorksheet() {
+  const { worksheets } = useCollections()
+
+  return useMutation({
+    mutationFn: (worksheetId: string) => apiClient.deleteWorksheet(worksheetId),
+    onSuccess: (_, worksheetId) => {
+      if (worksheets.status === 'ready') {
+        worksheets.utils.writeDelete(worksheetId)
+      }
+
+      // No tab bookkeeping here on purpose: `tabsReconciled` runs on every
+      // worksheets update and drops tabs whose worksheet is gone, picking the
+      // next one to focus.
+    }
+  })
+}
+
 export function useReorderDatabases() {
   const { databases } = useCollections()
   const queryClient = useQueryClient()

--- a/src/glue/api/groups/worksheets.ts
+++ b/src/glue/api/groups/worksheets.ts
@@ -4,6 +4,7 @@ import { UnknownWorksheetIdsError, WorksheetNotFoundError } from '../errors'
 import {
   CreateWorksheetRequest,
   CreateWorksheetResponse,
+  DeleteWorksheetResponse,
   ListWorksheetsResponse,
   ReorderWorksheetsRequest,
   ReorderWorksheetsResponse,
@@ -31,6 +32,13 @@ export const worksheetsGroup = HttpApiGroup.make('worksheets')
       .setPayload(ReorderWorksheetsRequest)
       .addSuccess(ReorderWorksheetsResponse)
       .addError(UnknownWorksheetIdsError)
+  )
+  .add(
+    // Soft delete, like databases: the row keeps its queries so history
+    // survives, and every read already filters on deletedAt.
+    HttpApiEndpoint.del('remove')`/${idParam}`
+      .addSuccess(DeleteWorksheetResponse)
+      .addError(WorksheetNotFoundError)
   )
   .add(
     HttpApiEndpoint.patch('update')`/${idParam}`

--- a/src/glue/api/schemas.ts
+++ b/src/glue/api/schemas.ts
@@ -480,6 +480,10 @@ export type ReorderWorksheetsResponse = Schema.Schema.Type<
   typeof ReorderWorksheetsResponse
 >
 
+export const DeleteWorksheetResponse = Schema.Struct({
+  success: Schema.Literal(true)
+})
+
 export const GetTracesResponse = Schema.Struct({
   traces: Schema.mutable(Schema.Array(TraceSummaryDto))
 })

--- a/src/server/http/handlers/databases.ts
+++ b/src/server/http/handlers/databases.ts
@@ -7,6 +7,7 @@ import { DatabaseNotFoundError, SchemaLoadFailedError } from '@/glue/api/errors'
 import { AdapterFactory } from '@/server/services/adapter-factory'
 import { DatabaseService } from '@/server/services/database-service'
 import { orDieInternal } from '../internal-errors'
+import { answerRemoved } from '../remove-route'
 
 // A version probe opens a second connection to the user's database, so it gets
 // a bound of its own: past this the schema response goes out without a
@@ -84,13 +85,7 @@ export const DatabasesLive = HttpApiBuilder.group(
         }).pipe(orDieInternal)
       )
       .handle('remove', ({ path }) =>
-        Effect.gen(function* () {
-          const service = yield* DatabaseService
-
-          yield* service.remove(path.id)
-
-          return { success: true as const }
-        }).pipe(orDieInternal)
+        answerRemoved(DatabaseService.remove(path.id))
       )
       .handle('update', ({ path, payload }) =>
         Effect.gen(function* () {

--- a/src/server/http/handlers/worksheets.ts
+++ b/src/server/http/handlers/worksheets.ts
@@ -4,6 +4,7 @@ import { Effect } from 'effect'
 import { SquealApi } from '@/glue/api/api'
 import { WorksheetService } from '@/server/services/worksheet-service'
 import { orDieInternal } from '../internal-errors'
+import { answerRemoved } from '../remove-route'
 
 export const WorksheetsLive = HttpApiBuilder.group(
   SquealApi,
@@ -45,6 +46,9 @@ export const WorksheetsLive = HttpApiBuilder.group(
 
           return { worksheets }
         }).pipe(orDieInternal)
+      )
+      .handle('remove', ({ path }) =>
+        answerRemoved(WorksheetService.remove(path.id))
       )
       .handle('update', ({ path, payload }) =>
         Effect.gen(function* () {

--- a/src/server/http/remove-route.ts
+++ b/src/server/http/remove-route.ts
@@ -1,0 +1,13 @@
+import { Effect } from 'effect'
+
+import { orDieInternal } from './internal-errors'
+
+/**
+ * Both delete routes answer the same way once the row is gone. The service's own
+ * not-found error stays in the typed channel — only the internal errors become
+ * defects, exactly as the other handlers do it. The error type is left to
+ * `orDieInternal` to work out, since it is the one narrowing the channel.
+ */
+export function answerRemoved<E, R>(remove: Effect.Effect<void, E, R>) {
+  return remove.pipe(Effect.as({ success: true as const }), orDieInternal)
+}

--- a/src/server/http/worksheets.test.ts
+++ b/src/server/http/worksheets.test.ts
@@ -1,4 +1,5 @@
 import { HttpClient, HttpClientRequest } from '@effect/platform'
+import { eq } from 'drizzle-orm'
 import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
@@ -145,5 +146,106 @@ describe('worksheet routes', () => {
     )
 
     expect(names).toEqual(['Second', 'First'])
+  })
+
+  it('deletes a worksheet and drops it from the list', async () => {
+    const { remaining, removal, row } = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+        const appDatabase = yield* AppDatabase
+
+        const kept = yield* client.worksheets.create({
+          payload: { name: 'Kept' }
+        })
+        const doomed = yield* client.worksheets.create({
+          payload: { name: 'Doomed' }
+        })
+
+        const removal = yield* client.worksheets.remove({
+          path: { id: doomed.worksheet.id }
+        })
+
+        const listed = yield* client.worksheets.list()
+
+        // The deleted row specifically — the table still holds "Kept" too.
+        const [row] = yield* appDatabase.execute((db) =>
+          db
+            .select()
+            .from(worksheetsTable)
+            .where(eq(worksheetsTable.id, doomed.worksheet.id))
+        )
+
+        return {
+          keptId: kept.worksheet.id,
+          remaining: listed.worksheets.map((worksheet) => worksheet.name),
+          removal,
+          row
+        }
+      })
+    )
+
+    expect(removal).toEqual({ success: true })
+    expect(remaining).toEqual(['Kept'])
+
+    // Soft delete, so the row survives with a deletedAt rather than vanishing.
+    expect(row.deletedAt).not.toBeNull()
+  })
+
+  it('answers 404 when deleting the same worksheet twice', async () => {
+    const error = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+
+        const created = yield* client.worksheets.create({
+          payload: { name: 'Doomed' }
+        })
+
+        yield* client.worksheets.remove({ path: { id: created.worksheet.id } })
+
+        return yield* client.worksheets
+          .remove({ path: { id: created.worksheet.id } })
+          .pipe(Effect.flip)
+      })
+    )
+
+    expect(error._tag).toEqual('WorksheetNotFoundError')
+  })
+
+  it('answers 404 when deleting an unknown worksheet', async () => {
+    const error = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+
+        return yield* client.worksheets
+          .remove({ path: { id: 'missing' } })
+          .pipe(Effect.flip)
+      })
+    )
+
+    expect(error._tag).toEqual('WorksheetNotFoundError')
+  })
+
+  // Guards against a PATCH resurrecting a deleted worksheet.
+  it('refuses to update a deleted worksheet', async () => {
+    const error = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+
+        const created = yield* client.worksheets.create({
+          payload: { name: 'Doomed' }
+        })
+
+        yield* client.worksheets.remove({ path: { id: created.worksheet.id } })
+
+        return yield* client.worksheets
+          .update({
+            path: { id: created.worksheet.id },
+            payload: { name: 'Back from the dead' }
+          })
+          .pipe(Effect.flip)
+      })
+    )
+
+    expect(error._tag).toEqual('WorksheetNotFoundError')
   })
 })

--- a/src/server/services/worksheet-service.ts
+++ b/src/server/services/worksheet-service.ts
@@ -62,6 +62,33 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
         return worksheets.map(transformWorksheet)
       })
 
+      const remove = Effect.fn('WorksheetService.remove')(function* (
+        id: string
+      ) {
+        // Soft delete, so the update returns the row only while it is still
+        // live — deleting twice is a 404 rather than a silent success.
+        const [worksheet] = yield* appDatabase.execute((client) =>
+          client
+            .update(worksheetsTable)
+            .set({ deletedAt: Date.now() })
+            .where(
+              and(eq(worksheetsTable.id, id), isNull(worksheetsTable.deletedAt))
+            )
+            .returning()
+        )
+
+        if (worksheet === undefined) {
+          return yield* new WorksheetNotFoundError({
+            message: 'This worksheet no longer exists.',
+            worksheetId: id
+          })
+        }
+
+        // Queries keep their worksheetId on purpose: the history is already
+        // bounded by retention, and the rows are unreachable once the
+        // worksheet is gone.
+      })
+
       // Only writes sortOrder so a reorder can never clobber content edits
       // that are in flight.
       const reorder = Effect.fn('WorksheetService.reorder')(function* (
@@ -105,7 +132,9 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
         updates: UpdateWorksheetRequest
       ) {
         const changes = {
-          ...(updates.content === undefined ? {} : { content: updates.content }),
+          ...(updates.content === undefined
+            ? {}
+            : { content: updates.content }),
           ...(updates.databaseId === undefined
             ? {}
             : { databaseId: updates.databaseId }),
@@ -125,7 +154,11 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
         // a misleading 500 — a no-op request has to be a no-op.
         if (Object.keys(changes).length === 0) {
           const [existing] = yield* appDatabase.execute((client) =>
-            client.select().from(worksheetsTable).where(activeWorksheet).limit(1)
+            client
+              .select()
+              .from(worksheetsTable)
+              .where(activeWorksheet)
+              .limit(1)
           )
 
           if (existing === undefined) {
@@ -158,7 +191,7 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
         return transformWorksheet(worksheet)
       })
 
-      return { create, list, reorder, update } as const
+      return { create, list, remove, reorder, update } as const
     })
   }
 ) {}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -10,4 +10,18 @@ if (typeof window !== 'undefined') {
       windowMinimize: () => Promise.resolve()
     }
   })
+
+  // jsdom implements no part of the Pointer Capture API, and Sonner calls
+  // setPointerCapture on pointer-down for its swipe-to-dismiss. Without these
+  // every click on a toast throws an uncaught TypeError, which vitest reports
+  // as an unhandled error and warns can cause false positives.
+  for (const name of [
+    'hasPointerCapture',
+    'releasePointerCapture',
+    'setPointerCapture'
+  ] as const) {
+    if (typeof Element.prototype[name] !== 'function') {
+      Element.prototype[name] = () => undefined
+    }
+  }
 }


### PR DESCRIPTION
The only route the worksheets group was missing — `list`, `create`, `reorder` and `update` existed, but there was no way to remove a worksheet at all. From `todo.md`: *"Add worksheet delete and duplicate."*

## Backend

Soft delete mirroring `DatabaseService.remove`. The update matches on `isNull(deletedAt)` and returns the row, so **deleting twice is a 404 rather than a silent success**, and `update` already refused to resurrect a deleted worksheet.

Queries keep their `worksheetId` on purpose: the history is bounded by retention and the rows are unreachable once the worksheet is gone.

## Renderer

A row context menu with Rename and Delete, confirming through an action toast like the database explorer does:

> **Delete "Analytics"?**
> This worksheet and its editor content will be removed. Query history is kept.

**Delete is disabled for the last remaining worksheet.** The app is built around always having one open, and `list` would just recreate a default — so removing the only one is a worse experience than not offering it.

## No tab bookkeeping needed

`tabsReconciled` (`store/tabs-slice.ts`) already runs on every worksheets update, drops tabs whose worksheet is gone, and picks the next one to focus. Removing the row from the collection is enough — verified in the running app below.

## Verification

`yarn typecheck` and `yarn lint` clean. `CI=1 vitest run` — **683 passed** (675 before, 8 new: 4 route tests, 4 explorer tests).

Driven against the real app (`agent-browser --cdp 9222`), on throwaway worksheets only:

| Check | Result |
| --- | --- |
| `DELETE /worksheets/:id` | `{"success":true}` 200 |
| Delete the same one again | 404 `WorksheetNotFoundError` |
| `PATCH` a deleted worksheet | 404 — no resurrection |
| Gone from `GET /worksheets` | yes |
| Right-click row | menu with Rename + Delete |
| Click Delete | confirmation toast, **nothing deleted yet** |
| Confirm | row gone, `Deleted "…"` toast, absent from the API |
| Delete the **active** worksheet | its tab closed and focus moved to the next tab |
| Trace | one clean `HTTP DELETE /worksheets/:id`, 32ms, no error span |

Live worksheet count returned to its starting value, so the run left no residue.

### One extra fix

`vitest.setup.ts` now shims the Pointer Capture API. jsdom implements none of it and Sonner calls `setPointerCapture` on pointer-down, so any click on a toast threw an uncaught `TypeError` that vitest reported as an unhandled error with *"This might cause false positive tests."* This pre-dates the PR — the existing database-delete test hits the same path — and the shim removed it across 7 consecutive full runs. I saw one occurrence before adding the shim that I could not reproduce afterwards, so I would not claim the flake is provably gone, only that it is no longer reproducible.