### PR TITLE
feat(tabs): rename, reorder, and jump between worksheet tabs

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,9 +1,24 @@
-import { screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { ReactElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DatabaseDto } from '@/glue/databases'
-import { App } from './App'
+import { WorksheetDto } from '@/glue/worksheets'
+import { App, useWorksheetSession } from './App'
+import { useAppSelector } from './store'
+import { selectActiveWorksheetId, tabsActions } from './store/tabs-slice'
 import { renderWithProviders } from './test-utils'
+
+vi.mock('./api-client', () => ({
+  apiClient: {
+    createQuery: vi.fn(),
+    getDatabases: vi.fn(async () => []),
+    getDatabaseSchema: vi.fn(async () => ({ tables: [] })),
+    updateWorksheet: vi.fn()
+  }
+}))
+
+import { apiClient } from './api-client'
 
 const testDatabase: DatabaseDto = {
   connectionInfo: {
@@ -18,6 +33,177 @@ const testDatabase: DatabaseDto = {
   sortOrder: null,
   type: 'postgres'
 }
+
+const testWorksheet: WorksheetDto = {
+  content: 'SELECT 1;',
+  createdAt: 1,
+  databaseId: 'database-1',
+  id: 'ws-1',
+  lastOpenedAt: null,
+  name: 'Analysis',
+  sortOrder: 0
+}
+
+// Drives the session hook without CodeMirror: typing and running are separate
+// events, exactly as they are in the app, so the render between them is the one
+// the run has to see.
+function RunProbe(): ReactElement {
+  const { handleRunQuery, handleUpdateContent } = useWorksheetSession('ws-1')
+
+  return (
+    <>
+      <button
+        onClick={() => handleUpdateContent('SELECT 2;')}
+        type="button"
+      >
+        type
+      </button>
+
+      <button
+        onClick={handleRunQuery}
+        type="button"
+      >
+        run
+      </button>
+    </>
+  )
+}
+
+// Reads the open worksheet from the store exactly as App does, so switching
+// worksheets in a test is the same dispatch the tab strip makes.
+function ContentProbe(): ReactElement {
+  const openWorksheetId = useAppSelector(selectActiveWorksheetId)
+  const { content, handleUpdateContent } = useWorksheetSession(openWorksheetId)
+
+  return (
+    <>
+      <button
+        onClick={() => handleUpdateContent('EDITED')}
+        type="button"
+      >
+        type
+      </button>
+
+      <output>{content}</output>
+    </>
+  )
+}
+
+describe('editor content', () => {
+  const secondWorksheet: WorksheetDto = {
+    ...testWorksheet,
+    content: 'SELECT 9;',
+    id: 'ws-2',
+    name: 'Other'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(apiClient.updateWorksheet).mockResolvedValue(testWorksheet)
+  })
+
+  it('shows the saved content of the open worksheet', () => {
+    renderWithProviders(<ContentProbe />, {
+      databases: [testDatabase],
+      openWorksheetId: 'ws-1',
+      queries: [],
+      worksheets: [testWorksheet, secondWorksheet]
+    })
+
+    expect(screen.getByRole('status')).toHaveTextContent('SELECT 1;')
+  })
+
+  // An unsaved edit belongs to the worksheet it was typed into; opening another
+  // one must not carry it across.
+  it('drops a pending edit when another worksheet is opened', () => {
+    const { store } = renderWithProviders(<ContentProbe />, {
+      databases: [testDatabase],
+      queries: [],
+      tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+      worksheets: [testWorksheet, secondWorksheet]
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'type' }))
+
+    expect(screen.getByRole('status')).toHaveTextContent('EDITED')
+
+    act(() => {
+      store.dispatch(tabsActions.tabActivated('ws-2'))
+    })
+
+    expect(screen.getByRole('status')).toHaveTextContent('SELECT 9;')
+  })
+})
+
+describe('running a query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(apiClient.updateWorksheet).mockResolvedValue(testWorksheet)
+    vi.mocked(apiClient.createQuery).mockResolvedValue({
+      query: {
+        content: 'SELECT 2;',
+        databaseId: 'database-1',
+        error: null,
+        finishedAt: null,
+        id: 'q-1',
+        queriedAt: 1,
+        result: null,
+        truncated: false,
+        worksheetId: 'ws-1'
+      }
+    })
+  })
+
+  // The autosave debounce means the saved copy trails the editor by 300ms, so
+  // running inside that window used to execute the previous text.
+  it('runs the text in the editor rather than the last saved copy', async () => {
+    renderWithProviders(<RunProbe />, {
+      databases: [testDatabase],
+      openWorksheetId: 'ws-1',
+      queries: [],
+      worksheets: [testWorksheet]
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'type' }))
+    fireEvent.click(screen.getByRole('button', { name: 'run' }))
+
+    await waitFor(() => {
+      expect(apiClient.createQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'SELECT 2;' }),
+        expect.anything()
+      )
+    })
+  })
+
+  it('saves the pending edit when a query runs', async () => {
+    // Fake timers hold the autosave debounce open, so a save showing up here can
+    // only have come from the run itself. `waitFor` would defeat that by
+    // advancing timers until the debounce fired on its own.
+    vi.useFakeTimers()
+
+    try {
+      renderWithProviders(<RunProbe />, {
+        databases: [testDatabase],
+        openWorksheetId: 'ws-1',
+        queries: [],
+        worksheets: [testWorksheet]
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'type' }))
+      fireEvent.click(screen.getByRole('button', { name: 'run' }))
+
+      // Settles the collection's pending promises without moving the clock
+      // anywhere near the 300ms debounce.
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(apiClient.updateWorksheet).toHaveBeenCalledWith('ws-1', {
+        content: 'SELECT 2;'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
 
 describe('App', () => {
   it('shows the getting started screen when there are no databases', () => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,6 +7,7 @@ import {
   useState
 } from 'react'
 import { toast } from 'sonner'
+import invariant from 'tiny-invariant'
 import { v7 } from 'uuid'
 
 import { AppSidebar } from './components/AppSidebar'
@@ -33,6 +34,10 @@ import { selectActiveWorksheetId } from './store/tabs-slice'
 import { finishQueryTrace, startQueryTrace } from './tracing/query-traces'
 import { createAstFromSql, type Statement } from './sql-parser'
 import { findActiveStatementIndex } from './sql-parser/active-statement'
+import {
+  resolveEditorContent,
+  type EditedContent
+} from './worksheet-editor-content'
 
 const WorksheetEditor = lazy(() =>
   import('./components/WorksheetEditor').then((module) => ({
@@ -65,18 +70,39 @@ function useActiveStatement(openWorksheetId: string | undefined) {
   // column are reported separately so neither has to derive the other.
   const [cursorOffset, setCursorOffset] = useState<number>(0)
 
+  // What the editor holds, which is ahead of the saved copy for as long as the
+  // autosave debounce is open. The cursor offset below is already live, so
+  // parsing the saved copy would also mean matching a fresh offset against a
+  // stale statement list.
+  const [editedContent, setEditedContent] = useState<EditedContent | null>(null)
+
   const currentWorksheet = useMemo(
     () => worksheets.data.find((worksheet) => worksheet.id === openWorksheetId),
     [worksheets.data, openWorksheetId]
   )
 
+  const content = resolveEditorContent(
+    editedContent,
+    openWorksheetId,
+    currentWorksheet
+  )
+
+  const recordEditedContent = useCallback(
+    (newContent: string) => {
+      invariant(openWorksheetId, 'No worksheet is open')
+
+      setEditedContent({ content: newContent, worksheetId: openWorksheetId })
+    },
+    [openWorksheetId]
+  )
+
   const statements = useMemo(() => {
-    if (!currentWorksheet?.content) {
+    if (!content) {
       return []
     }
 
-    return createAstFromSql(currentWorksheet.content).statements
-  }, [currentWorksheet?.content])
+    return createAstFromSql(content).statements
+  }, [content])
 
   const activeStatementIndex = useMemo(
     () => findActiveStatementIndex(statements, cursorOffset),
@@ -89,7 +115,9 @@ function useActiveStatement(openWorksheetId: string | undefined) {
   return {
     activeStatement,
     activeStatementIndex,
+    content,
     currentWorksheet,
+    recordEditedContent,
     setCursorOffset,
     statements
   }
@@ -124,7 +152,8 @@ function useLatestQuery(openWorksheetId: string | undefined) {
 function useRunQuery(
   activeStatement: Statement | null,
   databaseId: string | null | undefined,
-  worksheetId: string | undefined
+  worksheetId: string | undefined,
+  flushSave: () => void
 ) {
   const { queries: queriesCollection } = useCollections()
 
@@ -134,6 +163,11 @@ function useRunQuery(
 
       return
     }
+
+    // Running is a good moment to stop waiting out the debounce: the statement
+    // is already taken from the editor, so this only makes the saved copy match
+    // what just ran. Nothing waits on it — the query carries its own SQL.
+    flushSave()
 
     const optimistic = createOptimisticQuery(
       activeStatement,
@@ -153,7 +187,7 @@ function useRunQuery(
       finishQueryTrace({ error: message, id: optimistic.id })
       toast.error('Query failed', { description: message })
     })
-  }, [activeStatement, databaseId, worksheetId, queriesCollection])
+  }, [activeStatement, databaseId, flushSave, worksheetId, queriesCollection])
 }
 
 /**
@@ -161,13 +195,15 @@ function useRunQuery(
  * latest query, and the handlers that act on both. Bundled here so `App` itself
  * stays a layout.
  */
-function useWorksheetSession(openWorksheetId: string | undefined) {
+export function useWorksheetSession(openWorksheetId: string | undefined) {
   const databases = useDatabases()
 
   const {
     activeStatement,
     activeStatementIndex,
+    content,
     currentWorksheet,
+    recordEditedContent,
     setCursorOffset,
     statements
   } = useActiveStatement(openWorksheetId)
@@ -178,13 +214,24 @@ function useWorksheetSession(openWorksheetId: string | undefined) {
 
   const { handleCancelQuery, isCancelPending } = useCancelRunningQuery(query)
 
-  const { handleUpdateContent, saveState } =
+  const { flushSave, queueSave, saveState } =
     useWorksheetAutosave(openWorksheetId)
+
+  const handleUpdateContent = useCallback(
+    (newContent: string) => {
+      // The parse follows the editor immediately; the save is what gets to
+      // wait for the debounce.
+      recordEditedContent(newContent)
+      queueSave(newContent)
+    },
+    [queueSave, recordEditedContent]
+  )
 
   const handleRunQuery = useRunQuery(
     activeStatement,
     currentWorksheet?.databaseId,
-    openWorksheetId
+    openWorksheetId,
+    flushSave
   )
 
   const currentDatabase = useMemo(
@@ -198,6 +245,7 @@ function useWorksheetSession(openWorksheetId: string | undefined) {
   return {
     activeStatement,
     activeStatementIndex,
+    content,
     currentDatabase,
     currentWorksheet,
     handleCancelQuery,
@@ -222,6 +270,7 @@ export function App(): ReactElement {
   const {
     activeStatement,
     activeStatementIndex,
+    content,
     currentDatabase,
     currentWorksheet,
     handleCancelQuery,
@@ -270,7 +319,7 @@ export function App(): ReactElement {
               <Suspense fallback={null}>
                 <WorksheetEditor
                   activeStatementIndex={activeStatementIndex}
-                  content={currentWorksheet.content}
+                  content={content}
                   databaseType={currentDatabase?.type}
                   statements={statements}
                   onChange={handleUpdateContent}

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -363,7 +363,12 @@ function DatabaseRow({
       className={cn('relative flex-none', isDragging && 'opacity-50')}
       style={{ transform: CSS.Transform.toString(transform), transition }}
     >
-      {dropIndicator && <DropIndicatorLine position={dropIndicator} />}
+      {dropIndicator && (
+        <DropIndicatorLine
+          orientation="vertical"
+          position={dropIndicator}
+        />
+      )}
 
       <DatabaseRowHeader
         database={database}

--- a/src/app/components/DropIndicatorLine.tsx
+++ b/src/app/components/DropIndicatorLine.tsx
@@ -3,18 +3,28 @@ import { ReactElement } from 'react'
 import { cn } from '../lib/utils'
 
 interface DropIndicatorLineProps {
-  position: 'above' | 'below'
+  orientation: 'horizontal' | 'vertical'
+  position: 'after' | 'before'
 }
 
-// Renders inside a `relative` row wrapper, centered in the list's gap.
+// Renders inside a `relative` row wrapper, centered in the list's gap. The
+// orientation is the list's, not the line's: a vertical list gets a horizontal
+// rule between rows, a horizontal one gets an upright rule between tabs.
 export function DropIndicatorLine({
+  orientation,
   position
 }: DropIndicatorLineProps): ReactElement {
+  const isVertical = orientation === 'vertical'
+
   return (
     <div
       className={cn(
-        'absolute inset-x-0 h-0.5 rounded-full bg-accent pointer-events-none z-10',
-        position === 'above' ? '-top-[3px]' : '-bottom-[3px]'
+        'absolute rounded-full bg-accent pointer-events-none z-10',
+        isVertical ? 'inset-x-0 h-0.5' : 'inset-y-0 w-0.5',
+        isVertical && position === 'before' && '-top-[3px]',
+        isVertical && position === 'after' && '-bottom-[3px]',
+        !isVertical && position === 'before' && '-left-[1px]',
+        !isVertical && position === 'after' && '-right-[1px]'
       )}
     />
   )

--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -25,6 +25,7 @@ import { useAppDispatch, useAppSelector } from '../store'
 import { worksheetSearchQueryUpdated } from '../store/editor-slice'
 import { selectActiveWorksheetId, tabsActions } from '../store/tabs-slice'
 import { getNextUntitledName } from '../worksheet-naming'
+import { pickDatabaseForNewWorksheet } from '../worksheet-selection'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -81,6 +82,7 @@ function useWorksheetActions(
 ) {
   const dispatch = useAppDispatch()
   const createWorksheet = useCreateWorksheet()
+  const activeWorksheetId = useAppSelector(selectActiveWorksheetId)
   const { worksheets: worksheetsCollection } = useCollections()
 
   const touchWorksheet = useCallback(
@@ -103,10 +105,19 @@ function useWorksheetActions(
   )
 
   const handleNewWorksheet = useCallback(() => {
+    const databaseId = pickDatabaseForNewWorksheet(
+      worksheets,
+      activeWorksheetId
+    )
     const name = getNextUntitledName(worksheets)
 
     createWorksheet.mutate(
-      { name },
+      {
+        // `databaseId` is optional rather than nullable, so an unset one has to
+        // be left out instead of sent as null.
+        ...(databaseId === undefined ? {} : { databaseId }),
+        name
+      },
       {
         onSuccess: (worksheet) => {
           dispatch(tabsActions.tabOpened(worksheet.id))
@@ -121,7 +132,14 @@ function useWorksheetActions(
         }
       }
     )
-  }, [createWorksheet, dispatch, startEditing, touchWorksheet, worksheets])
+  }, [
+    activeWorksheetId,
+    createWorksheet,
+    dispatch,
+    startEditing,
+    touchWorksheet,
+    worksheets
+  ])
 
   return { handleNewWorksheet, handleSelectWorksheet }
 }
@@ -313,7 +331,10 @@ function WorksheetRow({
       {...(isSortingDisabled ? {} : listeners)}
     >
       {dropIndicator && (
-        <DropIndicatorLine orientation="vertical" position={dropIndicator} />
+        <DropIndicatorLine
+          orientation="vertical"
+          position={dropIndicator}
+        />
       )}
 
       {children}

--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -312,7 +312,9 @@ function WorksheetRow({
       style={{ transform: CSS.Transform.toString(transform), transition }}
       {...(isSortingDisabled ? {} : listeners)}
     >
-      {dropIndicator && <DropIndicatorLine position={dropIndicator} />}
+      {dropIndicator && (
+        <DropIndicatorLine orientation="vertical" position={dropIndicator} />
+      )}
 
       {children}
     </div>

--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -3,14 +3,7 @@ import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { SortableContext, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { FileBracesIcon, Pencil, PlusIcon, Trash2 } from 'lucide-react'
-import {
-  ReactElement,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState
-} from 'react'
+import { ReactElement, ReactNode, useCallback } from 'react'
 import { toast } from 'sonner'
 
 import { useCollections } from '../collections-context'
@@ -26,6 +19,7 @@ import {
   type DropIndicator
 } from '../hooks/use-drop-indicator'
 import { useReorderDrag } from '../hooks/use-reorder-drag'
+import { useWorksheetRename } from '../hooks/use-worksheet-rename'
 import { cn } from '../lib/utils'
 import { useAppDispatch, useAppSelector } from '../store'
 import { worksheetSearchQueryUpdated } from '../store/editor-slice'
@@ -37,9 +31,9 @@ import {
   ContextMenuItem,
   ContextMenuTrigger
 } from './ui/context-menu'
-import { Input } from './ui/input'
 import { DropIndicatorLine } from './DropIndicatorLine'
 import { SearchInput } from './SearchInput'
+import { WorksheetNameInput } from './WorksheetNameInput'
 import { WorksheetDto } from '@/glue/worksheets'
 
 // Deleting takes the editor content with it, so it asks first via an action
@@ -74,91 +68,6 @@ function useConfirmedWorksheetDeletion(): (worksheet: WorksheetDto) => void {
     },
     [deleteWorksheet]
   )
-}
-
-function useWorksheetRename(worksheets: WorksheetDto[]) {
-  const { worksheets: worksheetsCollection } = useCollections()
-
-  const [editingWorksheetId, setEditingWorksheetId] = useState<string | null>(
-    null
-  )
-  const [editingName, setEditingName] = useState('')
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    if (editingWorksheetId && inputRef.current) {
-      inputRef.current.focus()
-      inputRef.current.select()
-    }
-  }, [editingWorksheetId])
-
-  const startEditing = useCallback((worksheet: WorksheetDto) => {
-    setEditingWorksheetId(worksheet.id)
-    setEditingName(worksheet.name)
-  }, [])
-
-  const handleRenameCancel = useCallback(() => {
-    setEditingWorksheetId(null)
-    setEditingName('')
-  }, [])
-
-  const handleRenameSubmit = useCallback(
-    (worksheetId: string) => {
-      const trimmedName = editingName.trim()
-
-      if (!trimmedName) {
-        handleRenameCancel()
-
-        return
-      }
-
-      const worksheet = worksheets.find((w) => w.id === worksheetId)
-
-      if (!worksheet || worksheet.name === trimmedName) {
-        handleRenameCancel()
-
-        return
-      }
-
-      setEditingWorksheetId(null)
-
-      const transaction = worksheetsCollection.update(worksheetId, (draft) => {
-        draft.name = trimmedName
-      })
-
-      void transaction.isPersisted.promise.catch((error: unknown) => {
-        const message = error instanceof Error ? error.message : 'Unknown error'
-
-        toast.error('Failed to rename worksheet', { description: message })
-      })
-
-      setEditingName('')
-    },
-    [editingName, handleRenameCancel, worksheetsCollection, worksheets]
-  )
-
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent, worksheetId: string) => {
-      if (event.key === 'Enter') {
-        event.preventDefault()
-        handleRenameSubmit(worksheetId)
-      } else if (event.key === 'Escape') {
-        event.preventDefault()
-        handleRenameCancel()
-      }
-    },
-    [handleRenameCancel, handleRenameSubmit]
-  )
-
-  return {
-    editingName,
-    editingWorksheetId,
-    handleKeyDown,
-    handleRenameSubmit,
-    inputRef,
-    setEditingName,
-    startEditing
-  }
 }
 
 /**
@@ -346,6 +255,7 @@ export function WorksheetExplorer(): ReactElement {
                     editingName={editingName}
                     inputRef={inputRef}
                     worksheetId={worksheet.id}
+                    worksheetName={worksheet.name}
                     onEditingNameChange={setEditingName}
                     onKeyDown={handleKeyDown}
                     onRenameSubmit={handleRenameSubmit}
@@ -487,15 +397,19 @@ interface WorksheetRenameInputProps {
   editingName: string
   inputRef: React.RefObject<HTMLInputElement | null>
   worksheetId: string
+  worksheetName: string
   onEditingNameChange: (name: string) => void
   onKeyDown: (event: React.KeyboardEvent, worksheetId: string) => void
   onRenameSubmit: (worksheetId: string) => void
 }
 
+// Keeps the row's icon and height while the name is being edited, so the list
+// does not shift under the cursor.
 function WorksheetRenameInput({
   editingName,
   inputRef,
   worksheetId,
+  worksheetName,
   onEditingNameChange,
   onKeyDown,
   onRenameSubmit
@@ -504,13 +418,14 @@ function WorksheetRenameInput({
     <div className="flex h-[var(--item-h)] items-center gap-2 px-2">
       <FileBracesIcon className="size-[13px] flex-none text-text3" />
 
-      <Input
-        ref={inputRef}
-        className="h-[22px] rounded-[4px] px-1 py-0 text-[12.5px] shadow-none md:text-[12.5px] focus-visible:ring-0"
-        value={editingName}
-        onBlur={() => onRenameSubmit(worksheetId)}
-        onChange={(event) => onEditingNameChange(event.target.value)}
-        onKeyDown={(event) => onKeyDown(event, worksheetId)}
+      <WorksheetNameInput
+        ariaLabel={`Rename ${worksheetName}`}
+        editingName={editingName}
+        inputRef={inputRef}
+        worksheetId={worksheetId}
+        onEditingNameChange={onEditingNameChange}
+        onKeyDown={onKeyDown}
+        onRenameSubmit={onRenameSubmit}
       />
     </div>
   )

--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -394,7 +394,12 @@ function WorksheetListItem({
         </button>
       </ContextMenuTrigger>
 
-      <ContextMenuContent>
+      <ContextMenuContent
+        // Radix hands focus back to the trigger when the menu closes. That
+        // blurs the input Rename just opened, and a blur commits the edit, so
+        // the rename would end before a single key was pressed.
+        onCloseAutoFocus={(event) => event.preventDefault()}
+      >
         <ContextMenuItem
           className="flex items-center gap-2 min-w-32 text-xs"
           onClick={() => onDoubleClick(worksheet)}

--- a/src/app/components/WorksheetNameInput.tsx
+++ b/src/app/components/WorksheetNameInput.tsx
@@ -1,0 +1,44 @@
+import React, { ReactElement } from 'react'
+
+import { cn } from '../lib/utils'
+import { Input } from './ui/input'
+
+interface WorksheetNameInputProps {
+  ariaLabel: string
+  className?: string
+  editingName: string
+  inputRef: React.RefObject<HTMLInputElement | null>
+  worksheetId: string
+  onEditingNameChange: (name: string) => void
+  onKeyDown: (event: React.KeyboardEvent, worksheetId: string) => void
+  onRenameSubmit: (worksheetId: string) => void
+}
+
+// The rename field itself, shared by the sidebar list and the tab strip. Both
+// commit on blur, so clicking away is a save rather than a silent discard; the
+// callers only differ in how they wrap and size it.
+export function WorksheetNameInput({
+  ariaLabel,
+  className,
+  editingName,
+  inputRef,
+  worksheetId,
+  onEditingNameChange,
+  onKeyDown,
+  onRenameSubmit
+}: WorksheetNameInputProps): ReactElement {
+  return (
+    <Input
+      ref={inputRef}
+      aria-label={ariaLabel}
+      className={cn(
+        'h-[22px] rounded-[4px] px-1 py-0 text-[12.5px] shadow-none md:text-[12.5px] focus-visible:ring-0',
+        className
+      )}
+      value={editingName}
+      onBlur={() => onRenameSubmit(worksheetId)}
+      onChange={(event) => onEditingNameChange(event.target.value)}
+      onKeyDown={(event) => onKeyDown(event, worksheetId)}
+    />
+  )
+}

--- a/src/app/components/WorksheetTabs.test.tsx
+++ b/src/app/components/WorksheetTabs.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -38,6 +38,7 @@ const allWorksheets = [revenue, signups, churn]
 describe('WorksheetTabs', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(apiClient.updateWorksheet).mockResolvedValue(revenue)
   })
 
   it('renders a tab per open worksheet and nothing for closed ones', () => {
@@ -184,5 +185,263 @@ describe('WorksheetTabs', () => {
     expect(
       screen.getByRole('button', { name: 'New worksheet' })
     ).toBeInTheDocument()
+  })
+
+  it('gives a new worksheet the active tab’s database', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.createWorksheet).mockResolvedValue(
+      worksheet('ws-new', 'Untitled')
+    )
+
+    renderWithProviders(<WorksheetTabs />, {
+      tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1'] },
+      worksheets: [{ ...revenue, databaseId: 'db-123' }]
+    })
+
+    await user.click(screen.getByRole('button', { name: 'New worksheet' }))
+
+    await waitFor(() => {
+      expect(apiClient.createWorksheet).toHaveBeenCalledWith({
+        databaseId: 'db-123',
+        name: 'Untitled'
+      })
+    })
+  })
+
+  it('leaves the database out when no tab has one', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.createWorksheet).mockResolvedValue(
+      worksheet('ws-new', 'Untitled')
+    )
+
+    renderWithProviders(<WorksheetTabs />, {
+      tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1'] },
+      worksheets: [revenue]
+    })
+
+    await user.click(screen.getByRole('button', { name: 'New worksheet' }))
+
+    await waitFor(() => {
+      expect(apiClient.createWorksheet).toHaveBeenCalledWith({
+        name: 'Untitled'
+      })
+    })
+  })
+
+  describe('rename', () => {
+    it('opens the name for editing on double click', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      await user.dblClick(screen.getByRole('tab', { name: 'Revenue' }))
+
+      expect(screen.getByRole('textbox', { name: 'Rename Revenue' })).toEqual(
+        screen.getByDisplayValue('Revenue')
+      )
+    })
+
+    it('saves the new name on Enter', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      await user.dblClick(screen.getByRole('tab', { name: 'Revenue' }))
+
+      const input = screen.getByDisplayValue('Revenue')
+
+      await user.clear(input)
+      await user.type(input, 'Monthly Revenue{Enter}')
+
+      await waitFor(() => {
+        expect(apiClient.updateWorksheet).toHaveBeenCalledWith('ws-1', {
+          name: 'Monthly Revenue'
+        })
+      })
+    })
+
+    it('saves the new name on blur', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      await user.dblClick(screen.getByRole('tab', { name: 'Revenue' }))
+
+      const input = screen.getByDisplayValue('Revenue')
+
+      await user.clear(input)
+      await user.type(input, 'Blurred Name')
+      await user.tab()
+
+      await waitFor(() => {
+        expect(apiClient.updateWorksheet).toHaveBeenCalledWith('ws-1', {
+          name: 'Blurred Name'
+        })
+      })
+    })
+
+    it('cancels editing on Escape', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      await user.dblClick(screen.getByRole('tab', { name: 'Revenue' }))
+
+      const input = screen.getByDisplayValue('Revenue')
+
+      await user.clear(input)
+      await user.type(input, 'Discarded{Escape}')
+
+      expect(screen.getByRole('tab', { name: 'Revenue' })).toBeInTheDocument()
+      expect(apiClient.updateWorksheet).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: expect.any(String) })
+      )
+    })
+
+    it('does not save an empty name', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      await user.dblClick(screen.getByRole('tab', { name: 'Revenue' }))
+
+      const input = screen.getByDisplayValue('Revenue')
+
+      await user.clear(input)
+      await user.type(input, '{Enter}')
+
+      expect(screen.getByRole('tab', { name: 'Revenue' })).toBeInTheDocument()
+      expect(apiClient.updateWorksheet).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: expect.any(String) })
+      )
+    })
+
+    it('starts a rename from the context menu', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      fireEvent.contextMenu(screen.getByRole('tab', { name: 'Signups' }))
+
+      await user.click(await screen.findByRole('menuitem', { name: 'Rename' }))
+
+      expect(await screen.findByDisplayValue('Signups')).toBeVisible()
+    })
+
+    it('closes a tab from the context menu', async () => {
+      const user = userEvent.setup()
+
+      const { store } = renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      fireEvent.contextMenu(screen.getByRole('tab', { name: 'Signups' }))
+
+      await user.click(await screen.findByRole('menuitem', { name: 'Close' }))
+
+      expect(store.getState().tabs).toEqual({
+        activeWorksheetId: 'ws-1',
+        openWorksheetIds: ['ws-1']
+      })
+    })
+
+    // The close shortcut runs on form tags, so without a guard it would take
+    // the tab away while its name is still being typed.
+    it('does not close the tab while its name is being edited', async () => {
+      const user = userEvent.setup()
+
+      const { store } = renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      await user.dblClick(screen.getByRole('tab', { name: 'Revenue' }))
+      await user.keyboard('{Meta>}w{/Meta}')
+
+      expect(store.getState().tabs).toEqual({
+        activeWorksheetId: 'ws-1',
+        openWorksheetIds: ['ws-1', 'ws-2']
+      })
+    })
+  })
+
+  describe('keyboard tab switching', () => {
+    it('activates the tab at the pressed position', async () => {
+      const user = userEvent.setup()
+
+      const { store } = renderWithProviders(<WorksheetTabs />, {
+        tabs: {
+          activeWorksheetId: 'ws-1',
+          openWorksheetIds: ['ws-1', 'ws-2', 'ws-3']
+        },
+        worksheets: allWorksheets
+      })
+
+      await user.keyboard('{Meta>}2{/Meta}')
+
+      expect(store.getState().tabs).toEqual({
+        activeWorksheetId: 'ws-2',
+        openWorksheetIds: ['ws-1', 'ws-2', 'ws-3']
+      })
+    })
+
+    // Browser convention: the ninth slot is the last tab, however many are open.
+    it('jumps to the last tab on the ninth position', async () => {
+      const user = userEvent.setup()
+
+      const { store } = renderWithProviders(<WorksheetTabs />, {
+        tabs: {
+          activeWorksheetId: 'ws-1',
+          openWorksheetIds: ['ws-1', 'ws-2', 'ws-3']
+        },
+        worksheets: allWorksheets
+      })
+
+      await user.keyboard('{Meta>}9{/Meta}')
+
+      expect(store.getState().tabs).toEqual({
+        activeWorksheetId: 'ws-3',
+        openWorksheetIds: ['ws-1', 'ws-2', 'ws-3']
+      })
+    })
+
+    it('ignores a position past the last tab', async () => {
+      const user = userEvent.setup()
+
+      const { store } = renderWithProviders(<WorksheetTabs />, {
+        tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1', 'ws-2'] },
+        worksheets: allWorksheets
+      })
+
+      await user.keyboard('{Meta>}5{/Meta}')
+
+      expect(store.getState().tabs).toEqual({
+        activeWorksheetId: 'ws-1',
+        openWorksheetIds: ['ws-1', 'ws-2']
+      })
+    })
   })
 })

--- a/src/app/components/WorksheetTabs.tsx
+++ b/src/app/components/WorksheetTabs.tsx
@@ -379,7 +379,12 @@ function WorksheetTab({
         </div>
       </ContextMenuTrigger>
 
-      <ContextMenuContent>
+      <ContextMenuContent
+        // Radix hands focus back to the trigger when the menu closes. That
+        // blurs the input Rename just opened, and a blur commits the edit, so
+        // the rename would end before a single key was pressed.
+        onCloseAutoFocus={(event) => event.preventDefault()}
+      >
         <ContextMenuItem
           className="flex items-center gap-2 min-w-32 text-xs"
           onClick={() => rename.startEditing(worksheet)}

--- a/src/app/components/WorksheetTabs.tsx
+++ b/src/app/components/WorksheetTabs.tsx
@@ -42,34 +42,34 @@ import { WorksheetDto } from '@/glue/worksheets'
 // both platforms. The last slot jumps to the last tab rather than the ninth.
 const tabHotkeys = Array.from({ length: 9 }, (_, index) => `mod+${index + 1}`)
 
-export function WorksheetTabs(): ReactElement {
-  const dispatch = useAppDispatch()
-  const worksheets = useWorksheets()
-  const createWorksheet = useCreateWorksheet()
+/** The worksheets behind the open tabs, in tab order. */
+function useOpenTabs(
+  openWorksheetIds: string[],
+  worksheets: WorksheetDto[]
+): WorksheetDto[] {
+  return openWorksheetIds.flatMap((id) => {
+    const worksheet = worksheets.find((entry) => entry.id === id)
 
-  const activeWorksheetId = useAppSelector(selectActiveWorksheetId)
-  const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
+    // A tab whose worksheet has gone is dropped by `tabsReconciled`; skip it in
+    // the meantime rather than rendering a nameless tab.
+    return worksheet ? [worksheet] : []
+  })
+}
 
-  const rename = useWorksheetRename(worksheets.data)
-  const { editingWorksheetId } = rename
-
+/**
+ * Keeps the active tab in view in the scrolling strip. Owns the element map so
+ * the component only has to hand each tab's node over as it mounts.
+ */
+function useActiveTabScroll(
+  activeWorksheetId: string | undefined
+): (worksheetId: string, element: HTMLDivElement | null) => void {
   // Lazily initialised: `useRef(new Map())` would allocate a throwaway Map on
   // every render just to discard it.
   const tabRefs = useRef<Map<string, HTMLDivElement> | null>(null)
 
   tabRefs.current ??= new Map<string, HTMLDivElement>()
 
-  const openTabs = openWorksheetIds.flatMap((id) => {
-    const worksheet = worksheets.data.find((entry) => entry.id === id)
-
-    // A tab whose worksheet has gone is dropped by `tabsReconciled`; skip it in
-    // the meantime rather than rendering a nameless tab.
-    return worksheet ? [worksheet] : []
-  })
-
-  const openTabIds = openTabs.map((worksheet) => worksheet.id)
-
-  const registerTabElement = useCallback(
+  const registerElement = useCallback(
     (worksheetId: string, element: HTMLDivElement | null) => {
       if (element) {
         tabRefs.current?.set(worksheetId, element)
@@ -83,6 +83,148 @@ export function WorksheetTabs(): ReactElement {
     },
     []
   )
+
+  useEffect(() => {
+    if (!activeWorksheetId) {
+      return
+    }
+
+    tabRefs.current
+      ?.get(activeWorksheetId)
+      ?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' })
+  }, [activeWorksheetId])
+
+  return registerElement
+}
+
+/** Creates a worksheet on the current connection and opens it in a tab. */
+function useNewWorksheet(
+  activeWorksheetId: string | undefined,
+  worksheets: WorksheetDto[]
+): () => void {
+  const dispatch = useAppDispatch()
+  const createWorksheet = useCreateWorksheet()
+
+  return useCallback(() => {
+    const databaseId = pickDatabaseForNewWorksheet(
+      worksheets,
+      activeWorksheetId
+    )
+
+    createWorksheet.mutate(
+      {
+        // `databaseId` is optional rather than nullable, so an unset one has to
+        // be left out instead of sent as null.
+        ...(databaseId === undefined ? {} : { databaseId }),
+        name: getNextUntitledName(worksheets)
+      },
+      {
+        onError: (error: unknown) => {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error'
+
+          toast.error('Failed to create worksheet', { description: message })
+        },
+        onSuccess: (worksheet) => {
+          dispatch(tabsActions.tabOpened(worksheet.id))
+        }
+      }
+    )
+  }, [activeWorksheetId, createWorksheet, dispatch, worksheets])
+}
+
+interface TabHotkeysOptions {
+  activeWorksheetId: string | undefined
+  /** Set while a tab is being renamed, which owns the keyboard. */
+  editingWorksheetId: string | null
+  openTabs: WorksheetDto[]
+  onActivate: (worksheetId: string) => void
+  onClose: (worksheetId: string) => void
+}
+
+/**
+ * Closing the active tab and jumping between tabs by position. Both are
+ * registered with `enableOnContentEditable` because CodeMirror is a
+ * contenteditable and holds focus by default, so without it the shortcuts are
+ * dead exactly where they are most useful.
+ */
+function useTabHotkeys(options: TabHotkeysOptions): void {
+  const {
+    activeWorksheetId,
+    editingWorksheetId,
+    openTabs,
+    onActivate,
+    onClose
+  } = options
+
+  useHotkeys(
+    'mod+w',
+    (event) => {
+      // Closing the tab out from under a rename would throw the edit away.
+      if (!activeWorksheetId || editingWorksheetId) {
+        return
+      }
+
+      // Without this the browser/Electron shortcut closes the window instead.
+      event.preventDefault()
+      onClose(activeWorksheetId)
+    },
+    { enableOnContentEditable: true, enableOnFormTags: true },
+    [activeWorksheetId, editingWorksheetId, onClose]
+  )
+
+  useHotkeys(
+    tabHotkeys,
+    (event, hotkey) => {
+      const worksheet = editingWorksheetId
+        ? undefined
+        : tabAtHotkeyPosition(openTabs, Number(hotkey.keys?.[0]))
+
+      if (!worksheet) {
+        return
+      }
+
+      event.preventDefault()
+      onActivate(worksheet.id)
+    },
+    { enableOnContentEditable: true, enableOnFormTags: true },
+    [editingWorksheetId, onActivate, openTabs]
+  )
+}
+
+/**
+ * The tab a number shortcut selects. The last slot lands on the last tab
+ * however many are open, the way browsers treat their ninth.
+ */
+function tabAtHotkeyPosition(
+  openTabs: WorksheetDto[],
+  position: number
+): WorksheetDto | undefined {
+  if (!position) {
+    return undefined
+  }
+
+  if (position === tabHotkeys.length) {
+    return openTabs[openTabs.length - 1]
+  }
+
+  return openTabs[position - 1]
+}
+
+export function WorksheetTabs(): ReactElement {
+  const dispatch = useAppDispatch()
+  const worksheets = useWorksheets()
+
+  const activeWorksheetId = useAppSelector(selectActiveWorksheetId)
+  const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
+
+  const rename = useWorksheetRename(worksheets.data)
+
+  const openTabs = useOpenTabs(openWorksheetIds, worksheets.data)
+  const openTabIds = openTabs.map((worksheet) => worksheet.id)
+
+  const registerTabElement = useActiveTabScroll(activeWorksheetId)
+  const handleNewWorksheet = useNewWorksheet(activeWorksheetId, worksheets.data)
 
   const handleActivate = useCallback(
     (worksheetId: string) => {
@@ -105,33 +247,6 @@ export function WorksheetTabs(): ReactElement {
     [dispatch]
   )
 
-  const handleNewWorksheet = useCallback(() => {
-    const databaseId = pickDatabaseForNewWorksheet(
-      worksheets.data,
-      activeWorksheetId
-    )
-
-    createWorksheet.mutate(
-      {
-        // `databaseId` is optional rather than nullable, so an unset one has to
-        // be left out instead of sent as null.
-        ...(databaseId === undefined ? {} : { databaseId }),
-        name: getNextUntitledName(worksheets.data)
-      },
-      {
-        onError: (error: unknown) => {
-          const message =
-            error instanceof Error ? error.message : 'Unknown error'
-
-          toast.error('Failed to create worksheet', { description: message })
-        },
-        onSuccess: (worksheet) => {
-          dispatch(tabsActions.tabOpened(worksheet.id))
-        }
-      }
-    )
-  }, [activeWorksheetId, createWorksheet, dispatch, worksheets.data])
-
   const {
     dropIndicatorFor,
     handleDragOver,
@@ -147,65 +262,13 @@ export function WorksheetTabs(): ReactElement {
     resetDropIndicator
   })
 
-  useHotkeys(
-    'mod+w',
-    (event) => {
-      // A rename owns the keyboard while it is open — closing the tab out from
-      // under the input would throw the edit away.
-      if (!activeWorksheetId || editingWorksheetId) {
-        return
-      }
-
-      // Without this the browser/Electron shortcut closes the window instead.
-      event.preventDefault()
-      handleClose(activeWorksheetId)
-    },
-    // CodeMirror is a contenteditable, and it holds focus by default, so
-    // without this the shortcut is dead exactly where it is most useful.
-    { enableOnContentEditable: true, enableOnFormTags: true },
-    [activeWorksheetId, editingWorksheetId, handleClose]
-  )
-
-  useHotkeys(
-    tabHotkeys,
-    (event, hotkey) => {
-      if (editingWorksheetId) {
-        return
-      }
-
-      const position = Number(hotkey.keys?.[0])
-
-      if (!position) {
-        return
-      }
-
-      const worksheet =
-        position === tabHotkeys.length
-          ? openTabs[openTabs.length - 1]
-          : openTabs[position - 1]
-
-      if (!worksheet) {
-        return
-      }
-
-      event.preventDefault()
-      handleActivate(worksheet.id)
-    },
-    { enableOnContentEditable: true, enableOnFormTags: true },
-    [editingWorksheetId, handleActivate, openTabs]
-  )
-
-  useEffect(() => {
-    if (!activeWorksheetId) {
-      return
-    }
-
-    // Read through the ref rather than the render-scoped alias, so the effect
-    // depends only on which tab is active.
-    tabRefs.current
-      ?.get(activeWorksheetId)
-      ?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' })
-  }, [activeWorksheetId])
+  useTabHotkeys({
+    activeWorksheetId,
+    editingWorksheetId: rename.editingWorksheetId,
+    onActivate: handleActivate,
+    onClose: handleClose,
+    openTabs
+  })
 
   return (
     <div className="h-[37px] flex-none flex items-stretch bg-panel2 border-b border-border">

--- a/src/app/components/WorksheetTabs.tsx
+++ b/src/app/components/WorksheetTabs.tsx
@@ -1,10 +1,24 @@
-import { PlusIcon, XIcon } from 'lucide-react'
+import { closestCenter, DndContext } from '@dnd-kit/core'
+import { restrictToHorizontalAxis } from '@dnd-kit/modifiers'
+import { SortableContext, useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Pencil, PlusIcon, XIcon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
 
 import { useCreateWorksheet } from '../hooks/mutations'
 import { useWorksheets } from '../hooks/queries'
+import {
+  staticListStrategy,
+  useDropIndicator,
+  type DropIndicator
+} from '../hooks/use-drop-indicator'
+import { useReorderDrag } from '../hooks/use-reorder-drag'
+import {
+  useWorksheetRename,
+  type WorksheetRenameControls
+} from '../hooks/use-worksheet-rename'
 import { cn } from '../lib/utils'
 import { useAppDispatch, useAppSelector } from '../store'
 import {
@@ -13,6 +27,20 @@ import {
   tabsActions
 } from '../store/tabs-slice'
 import { getNextUntitledName } from '../worksheet-naming'
+import { pickDatabaseForNewWorksheet } from '../worksheet-selection'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from './ui/context-menu'
+import { DropIndicatorLine } from './DropIndicatorLine'
+import { WorksheetNameInput } from './WorksheetNameInput'
+import { WorksheetDto } from '@/glue/worksheets'
+
+// `mod` resolves to ⌘ on macOS and Ctrl everywhere else, so one list covers
+// both platforms. The last slot jumps to the last tab rather than the ninth.
+const tabHotkeys = Array.from({ length: 9 }, (_, index) => `mod+${index + 1}`)
 
 export function WorksheetTabs(): ReactElement {
   const dispatch = useAppDispatch()
@@ -22,13 +50,14 @@ export function WorksheetTabs(): ReactElement {
   const activeWorksheetId = useAppSelector(selectActiveWorksheetId)
   const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
 
+  const rename = useWorksheetRename(worksheets.data)
+  const { editingWorksheetId } = rename
+
   // Lazily initialised: `useRef(new Map())` would allocate a throwaway Map on
   // every render just to discard it.
   const tabRefs = useRef<Map<string, HTMLDivElement> | null>(null)
 
   tabRefs.current ??= new Map<string, HTMLDivElement>()
-
-  const tabElements = tabRefs.current
 
   const openTabs = openWorksheetIds.flatMap((id) => {
     const worksheet = worksheets.data.find((entry) => entry.id === id)
@@ -38,6 +67,30 @@ export function WorksheetTabs(): ReactElement {
     return worksheet ? [worksheet] : []
   })
 
+  const openTabIds = openTabs.map((worksheet) => worksheet.id)
+
+  const registerTabElement = useCallback(
+    (worksheetId: string, element: HTMLDivElement | null) => {
+      if (element) {
+        tabRefs.current?.set(worksheetId, element)
+
+        return
+      }
+
+      // Dropping the entry keeps the map bounded by the open tabs rather than
+      // every worksheet ever opened this session.
+      tabRefs.current?.delete(worksheetId)
+    },
+    []
+  )
+
+  const handleActivate = useCallback(
+    (worksheetId: string) => {
+      dispatch(tabsActions.tabActivated(worksheetId))
+    },
+    [dispatch]
+  )
+
   const handleClose = useCallback(
     (worksheetId: string) => {
       dispatch(tabsActions.tabClosed(worksheetId))
@@ -45,9 +98,26 @@ export function WorksheetTabs(): ReactElement {
     [dispatch]
   )
 
+  const handleReorder = useCallback(
+    (worksheetIds: string[]) => {
+      dispatch(tabsActions.tabsReordered(worksheetIds))
+    },
+    [dispatch]
+  )
+
   const handleNewWorksheet = useCallback(() => {
+    const databaseId = pickDatabaseForNewWorksheet(
+      worksheets.data,
+      activeWorksheetId
+    )
+
     createWorksheet.mutate(
-      { name: getNextUntitledName(worksheets.data) },
+      {
+        // `databaseId` is optional rather than nullable, so an unset one has to
+        // be left out instead of sent as null.
+        ...(databaseId === undefined ? {} : { databaseId }),
+        name: getNextUntitledName(worksheets.data)
+      },
       {
         onError: (error: unknown) => {
           const message =
@@ -60,12 +130,29 @@ export function WorksheetTabs(): ReactElement {
         }
       }
     )
-  }, [createWorksheet, dispatch, worksheets.data])
+  }, [activeWorksheetId, createWorksheet, dispatch, worksheets.data])
+
+  const {
+    dropIndicatorFor,
+    handleDragOver,
+    handleDragStart,
+    resetDropIndicator
+  } = useDropIndicator(openTabIds)
+
+  // The drop indicator works off the rendered tabs, but `tabsReordered` ignores
+  // an order that is not exactly the open tabs, so the drag gets the full list.
+  const { handleDragEnd, sensors } = useReorderDrag({
+    ids: openWorksheetIds,
+    onReorder: handleReorder,
+    resetDropIndicator
+  })
 
   useHotkeys(
     'mod+w',
     (event) => {
-      if (!activeWorksheetId) {
+      // A rename owns the keyboard while it is open — closing the tab out from
+      // under the input would throw the edit away.
+      if (!activeWorksheetId || editingWorksheetId) {
         return
       }
 
@@ -73,8 +160,39 @@ export function WorksheetTabs(): ReactElement {
       event.preventDefault()
       handleClose(activeWorksheetId)
     },
-    { enableOnFormTags: true },
-    [activeWorksheetId, handleClose]
+    // CodeMirror is a contenteditable, and it holds focus by default, so
+    // without this the shortcut is dead exactly where it is most useful.
+    { enableOnContentEditable: true, enableOnFormTags: true },
+    [activeWorksheetId, editingWorksheetId, handleClose]
+  )
+
+  useHotkeys(
+    tabHotkeys,
+    (event, hotkey) => {
+      if (editingWorksheetId) {
+        return
+      }
+
+      const position = Number(hotkey.keys?.[0])
+
+      if (!position) {
+        return
+      }
+
+      const worksheet =
+        position === tabHotkeys.length
+          ? openTabs[openTabs.length - 1]
+          : openTabs[position - 1]
+
+      if (!worksheet) {
+        return
+      }
+
+      event.preventDefault()
+      handleActivate(worksheet.id)
+    },
+    { enableOnContentEditable: true, enableOnFormTags: true },
+    [editingWorksheetId, handleActivate, openTabs]
   )
 
   useEffect(() => {
@@ -95,66 +213,33 @@ export function WorksheetTabs(): ReactElement {
         className="flex items-stretch overflow-x-auto [&::-webkit-scrollbar]:hidden"
         role="tablist"
       >
-        {openTabs.map((worksheet) => {
-          const isActive = worksheet.id === activeWorksheetId
-
-          return (
-            <div
-              className={cn(
-                'flex items-center gap-2 pl-[14px] pr-[10px] text-[12.5px] border-r border-border max-w-[200px]',
-                isActive
-                  ? 'bg-panel text-text shadow-[inset_0_2px_0_var(--accent)]'
-                  : 'bg-transparent text-text2'
-              )}
-              key={worksheet.id}
-              ref={(element) => {
-                if (element) {
-                  tabElements.set(worksheet.id, element)
-
-                  return
-                }
-
-                // Dropping the entry keeps the map bounded by the open tabs
-                // rather than every worksheet ever opened this session.
-                tabElements.delete(worksheet.id)
-              }}
-              role="presentation"
-            >
-              <button
-                aria-selected={isActive}
-                className="min-w-0 truncate whitespace-nowrap cursor-pointer"
-                onAuxClick={(event) => {
-                  if (event.button !== 1) {
-                    return
-                  }
-
-                  event.preventDefault()
-                  handleClose(worksheet.id)
-                }}
-                onClick={() => {
-                  dispatch(tabsActions.tabActivated(worksheet.id))
-                }}
-                role="tab"
-                type="button"
-              >
-                {worksheet.name}
-              </button>
-
-              <button
-                aria-label={`Close ${worksheet.name}`}
-                className="flex-none flex size-4 items-center justify-center rounded-[4px] text-text3 hover:bg-hover hover:text-text"
-                onClick={(event) => {
-                  // Closing must not also select the tab underneath.
-                  event.stopPropagation()
-                  handleClose(worksheet.id)
-                }}
-                type="button"
-              >
-                <XIcon className="size-2" />
-              </button>
-            </div>
-          )
-        })}
+        <DndContext
+          collisionDetection={closestCenter}
+          modifiers={[restrictToHorizontalAxis]}
+          sensors={sensors}
+          onDragCancel={resetDropIndicator}
+          onDragEnd={handleDragEnd}
+          onDragOver={handleDragOver}
+          onDragStart={handleDragStart}
+        >
+          <SortableContext
+            items={openTabIds}
+            strategy={staticListStrategy}
+          >
+            {openTabs.map((worksheet, index) => (
+              <WorksheetTab
+                key={worksheet.id}
+                dropIndicator={dropIndicatorFor(index)}
+                isActive={worksheet.id === activeWorksheetId}
+                registerElement={registerTabElement}
+                rename={rename}
+                worksheet={worksheet}
+                onActivate={handleActivate}
+                onClose={handleClose}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
       </div>
 
       <button
@@ -167,5 +252,150 @@ export function WorksheetTabs(): ReactElement {
         <PlusIcon className="size-[11px]" />
       </button>
     </div>
+  )
+}
+
+interface WorksheetTabProps {
+  dropIndicator: DropIndicator
+  isActive: boolean
+  registerElement: (worksheetId: string, element: HTMLDivElement | null) => void
+  rename: WorksheetRenameControls
+  worksheet: WorksheetDto
+  onActivate: (worksheetId: string) => void
+  onClose: (worksheetId: string) => void
+}
+
+function WorksheetTab({
+  dropIndicator,
+  isActive,
+  registerElement,
+  rename,
+  worksheet,
+  onActivate,
+  onClose
+}: WorksheetTabProps): ReactElement {
+  const isEditing = rename.editingWorksheetId === worksheet.id
+
+  // Renaming disables the sortable, so selecting text in the input never starts
+  // a drag. Only the listeners are spread onto the name button — the sortable's
+  // attributes carry `role="button"`, which would clobber `role="tab"`.
+  const { isDragging, listeners, setNodeRef, transform, transition } =
+    useSortable({ disabled: isEditing, id: worksheet.id })
+
+  const setTabElement = (element: HTMLDivElement | null) => {
+    setNodeRef(element)
+    registerElement(worksheet.id, element)
+  }
+
+  const tabClassName = cn(
+    'relative flex items-center gap-2 pl-[14px] pr-[10px] text-[12.5px] border-r border-border max-w-[200px]',
+    isActive
+      ? 'bg-panel text-text shadow-[inset_0_2px_0_var(--accent)]'
+      : 'bg-transparent text-text2',
+    isDragging && 'opacity-50'
+  )
+
+  const tabStyle = { transform: CSS.Transform.toString(transform), transition }
+
+  const closeButton = (
+    <button
+      aria-label={`Close ${worksheet.name}`}
+      className="flex-none flex size-4 items-center justify-center rounded-[4px] text-text3 hover:bg-hover hover:text-text"
+      onClick={(event) => {
+        // Closing must not also select the tab underneath.
+        event.stopPropagation()
+        onClose(worksheet.id)
+      }}
+      type="button"
+    >
+      <XIcon className="size-2" />
+    </button>
+  )
+
+  // The context menu is left out entirely while editing: Radix hands focus back
+  // to its trigger when the menu closes, which would blur the input the Rename
+  // item just opened and discard the edit before a key is pressed.
+  if (isEditing) {
+    return (
+      <div
+        ref={setTabElement}
+        className={tabClassName}
+        role="presentation"
+        style={tabStyle}
+      >
+        <WorksheetNameInput
+          ariaLabel={`Rename ${worksheet.name}`}
+          className="w-[140px]"
+          editingName={rename.editingName}
+          inputRef={rename.inputRef}
+          worksheetId={worksheet.id}
+          onEditingNameChange={rename.setEditingName}
+          onKeyDown={rename.handleKeyDown}
+          onRenameSubmit={rename.handleRenameSubmit}
+        />
+
+        {closeButton}
+      </div>
+    )
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          ref={setTabElement}
+          className={tabClassName}
+          role="presentation"
+          style={tabStyle}
+        >
+          {dropIndicator && (
+            <DropIndicatorLine
+              orientation="horizontal"
+              position={dropIndicator}
+            />
+          )}
+
+          <button
+            aria-selected={isActive}
+            className="min-w-0 truncate whitespace-nowrap cursor-pointer"
+            role="tab"
+            type="button"
+            onAuxClick={(event) => {
+              if (event.button !== 1) {
+                return
+              }
+
+              event.preventDefault()
+              onClose(worksheet.id)
+            }}
+            onClick={() => onActivate(worksheet.id)}
+            onDoubleClick={() => rename.startEditing(worksheet)}
+            {...listeners}
+          >
+            {worksheet.name}
+          </button>
+
+          {closeButton}
+        </div>
+      </ContextMenuTrigger>
+
+      <ContextMenuContent>
+        <ContextMenuItem
+          className="flex items-center gap-2 min-w-32 text-xs"
+          onClick={() => rename.startEditing(worksheet)}
+        >
+          <Pencil className="size-3" />
+          Rename
+        </ContextMenuItem>
+
+        <ContextMenuItem
+          className="flex items-center gap-2 min-w-32 text-xs"
+          onClick={() => onClose(worksheet.id)}
+        >
+          <XIcon className="size-3" />
+          Close
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/src/app/hooks/use-drop-indicator.ts
+++ b/src/app/hooks/use-drop-indicator.ts
@@ -2,7 +2,9 @@ import { DragOverEvent, DragStartEvent } from '@dnd-kit/core'
 import { type SortingStrategy } from '@dnd-kit/sortable'
 import { useCallback, useState } from 'react'
 
-export type DropIndicator = 'above' | 'below' | null
+// Named along the list rather than along a screen axis, so the same values
+// describe a sidebar row and a tab.
+export type DropIndicator = 'after' | 'before' | null
 
 // Rows stay put while dragging — the drop indicator line marks the landing
 // spot instead of live-shuffling the list.
@@ -10,8 +12,8 @@ export const staticListStrategy: SortingStrategy = () => null
 
 // Tracks the dragged and hovered rows so a sortable list can render an
 // insertion line. Dropping on the row the drag started from is a no-op, so no
-// line is shown for it. Dragging downwards lands after the hovered row,
-// upwards before it, matching how arrayMove resolves the drop.
+// line is shown for it. Dragging forwards lands after the hovered row,
+// backwards before it, matching how arrayMove resolves the drop.
 export function useDropIndicator(ids: string[]) {
   const [activeId, setActiveId] = useState<string | null>(null)
   const [overId, setOverId] = useState<string | null>(null)
@@ -39,7 +41,7 @@ export function useDropIndicator(ids: string[]) {
       return null
     }
 
-    return activeIndex < overIndex ? 'below' : 'above'
+    return activeIndex < overIndex ? 'after' : 'before'
   }
 
   return {

--- a/src/app/hooks/use-worksheet-rename.ts
+++ b/src/app/hooks/use-worksheet-rename.ts
@@ -1,0 +1,98 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+import { useCollections } from '../collections-context'
+import { WorksheetDto } from '@/glue/worksheets'
+
+export type WorksheetRenameControls = ReturnType<typeof useWorksheetRename>
+
+/**
+ * Inline renaming, shared by the sidebar list and the tab strip: which
+ * worksheet is being edited, the draft name, and the commit that writes it
+ * through the collection. The update is optimistic, so a rejected save rolls
+ * back on its own and only needs a toast.
+ */
+export function useWorksheetRename(worksheets: WorksheetDto[]) {
+  const { worksheets: worksheetsCollection } = useCollections()
+
+  const [editingWorksheetId, setEditingWorksheetId] = useState<string | null>(
+    null
+  )
+  const [editingName, setEditingName] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editingWorksheetId && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [editingWorksheetId])
+
+  const startEditing = useCallback((worksheet: WorksheetDto) => {
+    setEditingWorksheetId(worksheet.id)
+    setEditingName(worksheet.name)
+  }, [])
+
+  const handleRenameCancel = useCallback(() => {
+    setEditingWorksheetId(null)
+    setEditingName('')
+  }, [])
+
+  const handleRenameSubmit = useCallback(
+    (worksheetId: string) => {
+      const trimmedName = editingName.trim()
+
+      if (!trimmedName) {
+        handleRenameCancel()
+
+        return
+      }
+
+      const worksheet = worksheets.find((w) => w.id === worksheetId)
+
+      if (!worksheet || worksheet.name === trimmedName) {
+        handleRenameCancel()
+
+        return
+      }
+
+      setEditingWorksheetId(null)
+
+      const transaction = worksheetsCollection.update(worksheetId, (draft) => {
+        draft.name = trimmedName
+      })
+
+      void transaction.isPersisted.promise.catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+
+        toast.error('Failed to rename worksheet', { description: message })
+      })
+
+      setEditingName('')
+    },
+    [editingName, handleRenameCancel, worksheetsCollection, worksheets]
+  )
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent, worksheetId: string) => {
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        handleRenameSubmit(worksheetId)
+      } else if (event.key === 'Escape') {
+        event.preventDefault()
+        handleRenameCancel()
+      }
+    },
+    [handleRenameCancel, handleRenameSubmit]
+  )
+
+  return {
+    editingName,
+    editingWorksheetId,
+    handleKeyDown,
+    handleRenameSubmit,
+    inputRef,
+    setEditingName,
+    startEditing
+  }
+}

--- a/src/app/hooks/useWorksheetAutosave.ts
+++ b/src/app/hooks/useWorksheetAutosave.ts
@@ -53,7 +53,7 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
     }
   }, [flushSave, openWorksheetId])
 
-  const handleUpdateContent = useCallback(
+  const queueSave = useCallback(
     (newContent: string) => {
       invariant(openWorksheetId, 'No worksheet is open')
 
@@ -70,5 +70,7 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
     [flushSave, openWorksheetId]
   )
 
-  return { handleUpdateContent, saveState }
+  // `flushSave` is exposed so callers that need the saved copy to be current —
+  // running a query — can close the debounce window instead of waiting it out.
+  return { flushSave, queueSave, saveState }
 }

--- a/src/app/worksheet-editor-content.test.ts
+++ b/src/app/worksheet-editor-content.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WorksheetDto } from '@/glue/worksheets'
+import { resolveEditorContent } from './worksheet-editor-content'
+
+function worksheet(id: string, content: string): WorksheetDto {
+  return {
+    content,
+    createdAt: 1,
+    databaseId: null,
+    id,
+    lastOpenedAt: null,
+    name: id,
+    sortOrder: 0
+  }
+}
+
+describe('resolveEditorContent', () => {
+  it('falls back to the saved content before anything is typed', () => {
+    expect(
+      resolveEditorContent(null, 'ws-1', worksheet('ws-1', 'SELECT 1;'))
+    ).toEqual('SELECT 1;')
+  })
+
+  it('prefers the edit still sitting in the autosave debounce', () => {
+    expect(
+      resolveEditorContent(
+        { content: 'SELECT 2;', worksheetId: 'ws-1' },
+        'ws-1',
+        worksheet('ws-1', 'SELECT 1;')
+      )
+    ).toEqual('SELECT 2;')
+  })
+
+  // Switching tabs must not carry the previous worksheet's text across, which
+  // is why the edit records the worksheet it belongs to.
+  it('ignores an edit belonging to another worksheet', () => {
+    expect(
+      resolveEditorContent(
+        { content: 'SELECT 2;', worksheetId: 'ws-1' },
+        'ws-2',
+        worksheet('ws-2', 'SELECT 3;')
+      )
+    ).toEqual('SELECT 3;')
+  })
+
+  it('answers an empty string when no worksheet is open', () => {
+    expect(resolveEditorContent(null, undefined, undefined)).toEqual('')
+  })
+})

--- a/src/app/worksheet-editor-content.ts
+++ b/src/app/worksheet-editor-content.ts
@@ -1,0 +1,28 @@
+import type { WorksheetDto } from '@/glue/worksheets'
+
+export interface EditedContent {
+  content: string
+  worksheetId: string
+}
+
+/**
+ * The text the editor is showing right now. Autosave only catches the saved
+ * copy up after its debounce, so anything derived from the worksheet row — the
+ * statement list, and with it the statement a run executes — would be a moment
+ * behind what the user can see.
+ *
+ * The edit is tagged with the worksheet it came from, so opening another
+ * worksheet falls back to that worksheet's saved content instead of showing the
+ * previous one's text.
+ */
+export function resolveEditorContent(
+  editedContent: EditedContent | null,
+  openWorksheetId: string | undefined,
+  currentWorksheet: WorksheetDto | undefined
+): string {
+  if (editedContent && editedContent.worksheetId === openWorksheetId) {
+    return editedContent.content
+  }
+
+  return currentWorksheet?.content ?? ''
+}

--- a/src/app/worksheet-selection.test.ts
+++ b/src/app/worksheet-selection.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import type { WorksheetDto } from '@/glue/worksheets'
-import { pickWorksheetToOpen } from './worksheet-selection'
+import {
+  pickDatabaseForNewWorksheet,
+  pickWorksheetToOpen
+} from './worksheet-selection'
 
 function createWorksheet(
   id: string,
@@ -42,5 +45,49 @@ describe('pickWorksheetToOpen', () => {
 
   it('returns undefined when there are no worksheets', () => {
     expect(pickWorksheetToOpen([], undefined)).toEqual(undefined)
+  })
+})
+
+describe('pickDatabaseForNewWorksheet', () => {
+  function withDatabase(
+    worksheet: WorksheetDto,
+    databaseId: string
+  ): WorksheetDto {
+    return { ...worksheet, databaseId }
+  }
+
+  it('reuses the database the active worksheet runs against', () => {
+    const candidates = [
+      withDatabase(createWorksheet('a', 300), 'db-a'),
+      withDatabase(createWorksheet('b', 200), 'db-b')
+    ]
+
+    expect(pickDatabaseForNewWorksheet(candidates, 'b')).toEqual('db-b')
+  })
+
+  it('falls back to the most recently opened worksheet with a database', () => {
+    const candidates = [
+      withDatabase(createWorksheet('a', 100), 'db-a'),
+      withDatabase(createWorksheet('b', 300), 'db-b'),
+      createWorksheet('c', 400)
+    ]
+
+    expect(pickDatabaseForNewWorksheet(candidates, undefined)).toEqual('db-b')
+  })
+
+  // The active worksheet not having one yet is not a reason to start from
+  // scratch — the last connection the user worked with is the better guess.
+  it('falls back when the active worksheet has no database', () => {
+    const candidates = [
+      withDatabase(createWorksheet('a', 100), 'db-a'),
+      createWorksheet('b', 300)
+    ]
+
+    expect(pickDatabaseForNewWorksheet(candidates, 'b')).toEqual('db-a')
+  })
+
+  it('returns undefined when no worksheet has a database', () => {
+    expect(pickDatabaseForNewWorksheet(worksheets, 'b')).toEqual(undefined)
+    expect(pickDatabaseForNewWorksheet([], undefined)).toEqual(undefined)
   })
 })

--- a/src/app/worksheet-selection.ts
+++ b/src/app/worksheet-selection.ts
@@ -29,3 +29,36 @@ export function pickWorksheetToOpen(
 
   return pick ?? worksheets[0]?.id
 }
+
+// The database a new worksheet should start on, so creating one keeps the
+// connection you were just using instead of dropping you back on "no database".
+// Falls back to the most recently opened worksheet that has one, which covers
+// creating from the sidebar with no tab active.
+export function pickDatabaseForNewWorksheet(
+  worksheets: WorksheetDto[],
+  activeWorksheetId: string | undefined
+): string | undefined {
+  const activeWorksheet = worksheets.find(
+    (worksheet) => worksheet.id === activeWorksheetId
+  )
+
+  if (activeWorksheet?.databaseId) {
+    return activeWorksheet.databaseId
+  }
+
+  let pick: string | undefined
+  let latestOpenedAt = 0
+
+  for (const worksheet of worksheets) {
+    if (
+      worksheet.databaseId &&
+      worksheet.lastOpenedAt &&
+      worksheet.lastOpenedAt > latestOpenedAt
+    ) {
+      latestOpenedAt = worksheet.lastOpenedAt
+      pick = worksheet.databaseId
+    }
+  }
+
+  return pick
+}

--- a/src/server/http/worksheets.test.ts
+++ b/src/server/http/worksheets.test.ts
@@ -79,7 +79,7 @@ describe('worksheet routes', () => {
         id: expect.any(String),
         lastOpenedAt: null,
         name: 'Analysis',
-        sortOrder: null
+        sortOrder: -1
       }
     })
     expect(rows).toHaveLength(1)

--- a/src/server/services/worksheet-service.test.ts
+++ b/src/server/services/worksheet-service.test.ts
@@ -38,8 +38,46 @@ describe('WorksheetService', () => {
       id: expect.any(String),
       lastOpenedAt: null,
       name: 'My First Worksheet',
-      sortOrder: null
+      // Below the current minimum, so a new worksheet lands on top.
+      sortOrder: -1
     })
+  })
+
+  it('lists the newest worksheet first', async () => {
+    const names = await run(
+      Effect.gen(function* () {
+        const service = yield* WorksheetService
+
+        yield* service.create({ name: 'First' })
+        yield* service.create({ name: 'Second' })
+
+        const worksheets = yield* service.list()
+
+        return worksheets.map((worksheet) => worksheet.name)
+      })
+    )
+
+    expect(names).toEqual(['Second', 'First'])
+  })
+
+  it('puts a worksheet created after a reorder on top', async () => {
+    const names = await run(
+      Effect.gen(function* () {
+        const service = yield* WorksheetService
+
+        const first = yield* service.create({ name: 'First' })
+        const second = yield* service.create({ name: 'Second' })
+
+        yield* service.reorder([first.id, second.id])
+        yield* service.create({ name: 'Third' })
+
+        const worksheets = yield* service.list()
+
+        return worksheets.map((worksheet) => worksheet.name)
+      })
+    )
+
+    expect(names).toEqual(['Third', 'First', 'Second'])
   })
 
   it('updates only the provided fields', async () => {

--- a/src/server/services/worksheet-service.ts
+++ b/src/server/services/worksheet-service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, inArray, isNull, min, sql } from 'drizzle-orm'
 import { Effect } from 'effect'
 
 import { worksheetsTable } from '@/database/schema'
@@ -26,11 +26,23 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
       const create = Effect.fn('WorksheetService.create')(function* (
         request: CreateWorksheetRequest
       ) {
+        // A new worksheet belongs at the top of the list. Sitting one below the
+        // current minimum gets it there without renumbering every other row,
+        // and it also clears the legacy rows that never got a sortOrder, since
+        // those sort last.
+        const [lowest] = yield* appDatabase.execute((client) =>
+          client
+            .select({ sortOrder: min(worksheetsTable.sortOrder) })
+            .from(worksheetsTable)
+            .where(isNull(worksheetsTable.deletedAt))
+        )
+
         const [worksheet] = yield* appDatabase.execute((client) =>
           client
             .insert(worksheetsTable)
             .values({
               name: request.name,
+              sortOrder: (lowest?.sortOrder ?? 0) - 1,
               ...(request.content === undefined
                 ? {}
                 : { content: request.content }),


### PR DESCRIPTION
Makes the worksheet tab strip do the things it looked like it should already do, plus two fixes found along the way.

## What changed

**Rename from a tab.** Double-click a tab to edit its name inline, or right-click for a Rename / Close menu. The sidebar's rename logic moved into a shared `useWorksheetRename` hook and a `WorksheetNameInput` component, so both surfaces behave identically — Enter or blur saves, Escape reverts, empty and unchanged names are no-ops.

**Drag to reorder tabs.** Wired up with the existing `useReorderDrag` / `useDropIndicator` hooks. This dispatches the `tabsReordered` reducer that already existed and was unit-tested but that nothing ever called, so the order is local and persisted to `localStorage` — the sidebar keeps its own order, like VS Code.

**`mod+1`…`mod+9` to switch tabs.** `mod` resolves to ⌘ on macOS and Ctrl elsewhere, so Windows is covered with no platform branching. `mod+9` jumps to the last tab however many are open, matching browsers.

**New worksheets land at the top of the sidebar.** They were inserted with a null `sortOrder`, and null sorts last, so once a list had been reordered every new worksheet went to the bottom. `create` now takes a `sortOrder` just below the current minimum — no renumbering of other rows, and it clears the legacy null rows too.

**New worksheets inherit the current database.** Creating one no longer drops you back on "no database"; it reuses the active worksheet's connection, falling back to the most recently opened worksheet that has one.

## Two bugs found while building this

- **`mod+w` was dead whenever the SQL editor had focus** — which is the app's default focus state. `react-hotkeys-hook` skips handlers whose target is `contentEditable` unless `enableOnContentEditable` is set, and CodeMirror is a contenteditable. The new shortcuts needed the option, and `mod+w` now gets it too.
- **Rename from the sidebar context menu never worked in the real app.** Radix restores focus to the trigger when the menu closes, which blurred the freshly focused input — and a blur commits, so an unchanged name cancelled the edit immediately. jsdom does not model focus restoration, so the existing test passed the whole time. Fixed by preventing the close-time autofocus in both menus.

## Testing

`yarn typecheck`, `yarn lint`, and `yarn test` (718 tests) all pass, and each of the six commits typechecks in isolation.

New coverage: tab rename (double-click, Enter, blur, Escape, empty, context menu), `mod+1`/`mod+9`/out-of-range switching, `mod+w` not firing mid-rename, database inheritance on create, `pickDatabaseForNewWorksheet`, and backend ordering after creates and after a reorder.

Drag itself is not unit-tested — jsdom has no `PointerEvent` or layout, which is why the repo has no dnd tests at all. It was verified against the running app instead, along with everything else here:

- Dragged a tab across the strip: the vertical drop indicator renders, the order sticks, the sidebar is unaffected, and the order survives a restart.
- Renamed from both the tab and the context menu; confirmed the new name reaches the tab, the sidebar row, and the API.
- Pressed ⌘1 / ⌘3 / ⌘9 / ⌘8 with the CodeMirror editor focused.
- Created a worksheet and confirmed `sortOrder = -1`, top of the sidebar, with the active tab's database already selected.

---

## Also here: running a query no longer executes stale SQL

Reported separately while reviewing the above, and independent of the tab work (no file overlap).

Running a query could execute the SQL as it looked a moment earlier. The statement list was parsed from the worksheet row, and autosave only brings that up to date after a 300ms debounce — so anything run inside that window came from the pre-edit text, and since the query row carries its own SQL, that stale text is what the server executed.

The cursor offset was already live while the statements lagged, so this could also match a fresh offset against a stale statement list and select the *wrong* statement outright, not merely an old version of the right one.

The editor is now the source of truth for the parse, with the debounce governing only persistence. The pending edit is tagged with the worksheet it was typed into, so opening another one falls back to that worksheet's saved content rather than carrying text across. Running additionally flushes the pending save so the saved copy matches what ran; nothing waits on it, since the statement already comes from the editor.

Both halves have tests confirmed to fail without them — one reproduces the original symptom (`SELECT 1;` executing instead of `SELECT 2;`), and the flush test uses fake timers so it cannot pass off the debounce firing on its own. Verified live by typing into a worksheet and running 238ms later, inside the debounce window: the newly typed statement executed while the saved copy was still the previous text.
