### PR TITLE
fix(ui): stop ResizeHandle from pinning user-select app-wide

### DIFF
--- a/src/app/components/ResizeHandle.test.tsx
+++ b/src/app/components/ResizeHandle.test.tsx
@@ -1,9 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ResizeHandle } from './ResizeHandle'
 
 describe('ResizeHandle', () => {
+  // The handle suppresses text selection on the body while dragging. A test
+  // that leaked 'none' would hand the next one a poisoned starting value and
+  // hide exactly the bug these tests are here to catch.
+  beforeEach(() => {
+    document.body.style.userSelect = ''
+  })
+
   it('exposes a separator with the axis it resizes', () => {
     render(
       <ResizeHandle
@@ -66,9 +73,8 @@ describe('ResizeHandle', () => {
     expect(onResize).toHaveBeenCalledWith(440)
   })
 
-  it('stops resizing once the pointer is released', () => {
+  it('ignores a mousedown from a button other than the primary one', () => {
     const onResize = vi.fn()
-    const onResizeEnd = vi.fn()
 
     render(
       <ResizeHandle
@@ -76,7 +82,30 @@ describe('ResizeHandle', () => {
         orientation="col"
         size={264}
         onResize={onResize}
-        onResizeEnd={onResizeEnd}
+      />
+    )
+
+    // Right-clicking opens the context menu, and the mouseup that follows
+    // lands there rather than on the document.
+    fireEvent.mouseDown(screen.getByRole('separator'), {
+      button: 2,
+      clientX: 100
+    })
+    fireEvent.mouseMove(document, { clientX: 300 })
+
+    expect(onResize).not.toHaveBeenCalled()
+    expect(document.body.style.userSelect).toEqual('')
+  })
+
+  it('stops resizing once the pointer is released', () => {
+    const onResize = vi.fn()
+
+    render(
+      <ResizeHandle
+        ariaLabel="Resize sidebar"
+        orientation="col"
+        size={264}
+        onResize={onResize}
       />
     )
 
@@ -85,7 +114,6 @@ describe('ResizeHandle', () => {
     fireEvent.mouseMove(document, { clientX: 300 })
 
     expect(onResize).not.toHaveBeenCalled()
-    expect(onResizeEnd).toHaveBeenCalledTimes(1)
   })
 
   it('stops resizing when the handle unmounts mid-drag', () => {
@@ -107,6 +135,89 @@ describe('ResizeHandle', () => {
     fireEvent.mouseMove(document, { clientX: 300 })
 
     expect(onResize).not.toHaveBeenCalled()
+  })
+
+  it('restores text selection when the handle unmounts mid-drag', () => {
+    const { unmount } = render(
+      <ResizeHandle
+        ariaLabel="Resize sidebar"
+        orientation="col"
+        size={264}
+        onResize={vi.fn()}
+      />
+    )
+
+    fireEvent.mouseDown(screen.getByRole('separator'), { clientX: 100 })
+
+    expect(document.body.style.userSelect).toEqual('none')
+
+    unmount()
+
+    expect(document.body.style.userSelect).toEqual('')
+  })
+
+  it('restores text selection when a drag starts after a lost mouseup', () => {
+    render(
+      <ResizeHandle
+        ariaLabel="Resize sidebar"
+        orientation="col"
+        size={264}
+        onResize={vi.fn()}
+      />
+    )
+
+    const handle = screen.getByRole('separator')
+
+    // The mouseup of the first drag never arrives: the button was released
+    // outside the window, so document never sees the event.
+    fireEvent.mouseDown(handle, { clientX: 100 })
+    fireEvent.mouseDown(handle, { clientX: 100 })
+    fireEvent.mouseUp(document)
+
+    expect(document.body.style.userSelect).toEqual('')
+  })
+
+  it('restores text selection when another handle left a drag dangling', () => {
+    // The app always has both of these mounted at once, and the body style
+    // they fight over is global.
+    render(
+      <>
+        <ResizeHandle
+          ariaLabel="Resize sidebar"
+          orientation="col"
+          size={264}
+          onResize={vi.fn()}
+        />
+        <ResizeHandle
+          ariaLabel="Resize results panel"
+          growsToward="start"
+          orientation="row"
+          size={400}
+          onResize={vi.fn()}
+        />
+      </>
+    )
+
+    const resultsHandle = screen.getByRole('separator', {
+      name: 'Resize results panel'
+    })
+    const sidebarHandle = screen.getByRole('separator', {
+      name: 'Resize sidebar'
+    })
+
+    // The sidebar drag never gets its mouseup, so it is still holding the body
+    // at 'none' when the results drag begins.
+    fireEvent.mouseDown(sidebarHandle, { clientX: 100 })
+    fireEvent.mouseDown(resultsHandle, { clientY: 500 })
+    fireEvent.mouseUp(document)
+
+    expect(document.body.style.userSelect).toEqual('')
+
+    // And a later clean drag has to leave it recovered too.
+    fireEvent.mouseDown(sidebarHandle, { clientX: 100 })
+    fireEvent.mouseUp(document)
+
+    expect(document.body.style.userSelect).toEqual('')
   })
 
   it('resizes by 10px with the arrow keys and 40px with shift', () => {

--- a/src/app/components/ResizeHandle.tsx
+++ b/src/app/components/ResizeHandle.tsx
@@ -17,8 +17,6 @@ interface ResizeHandleProps {
   // leading edge, like the results splitter, grows toward 'start'.
   growsToward?: ResizeGrowth
   onResize: (size: number) => void
-  onResizeEnd?: () => void
-  onResizeStart?: () => void
   orientation: ResizeOrientation
   size: number
 }
@@ -32,8 +30,6 @@ export function ResizeHandle({
   className,
   growsToward = 'end',
   onResize,
-  onResizeEnd,
-  onResizeStart,
   orientation,
   size
 }: ResizeHandleProps): ReactElement {
@@ -42,20 +38,38 @@ export function ResizeHandle({
   // that no longer exists.
   const detachRef = useRef<(() => void) | null>(null)
 
-  useEffect(() => {
-    return () => {
-      detachRef.current?.()
-      detachRef.current = null
-    }
+  // The only place a drag is released. A mouseup, a second mousedown that
+  // never got one, and unmount all end a drag the same way, so they all come
+  // through here instead of each undoing its own subset.
+  const endDrag = useCallback(() => {
+    detachRef.current?.()
+    detachRef.current = null
   }, [])
+
+  // `endDrag` has to keep its empty dependency list. This effect re-runs its
+  // cleanup whenever `endDrag` changes, and that cleanup aborts a live drag —
+  // so giving `endDrag` a render-state dependency would kill every drag on its
+  // first pixel, since `size` changes on every mousemove.
+  useEffect(() => {
+    return endDrag
+  }, [endDrag])
 
   const handleMouseDown = useCallback(
     (event: React.MouseEvent) => {
+      // Only the primary button drags. A right-click opening the context menu
+      // is one of the ways a mouseup goes missing, so refusing it removes a
+      // cause instead of only recovering from one.
+      if (event.button !== 0) {
+        return
+      }
+
+      // A second mousedown without a mouseup should never stack listeners.
+      endDrag()
+
       const direction = growsToward === 'start' ? -1 : 1
       const startPosition =
         orientation === 'col' ? event.clientX : event.clientY
       const startSize = size
-      const previousUserSelect = document.body.style.userSelect
 
       function handleMouseMove(moveEvent: MouseEvent): void {
         const position =
@@ -66,27 +80,24 @@ export function ResizeHandle({
 
       function detach(): void {
         document.removeEventListener('mousemove', handleMouseMove)
-        document.removeEventListener('mouseup', handleMouseUp)
-        document.body.style.userSelect = previousUserSelect
-      }
+        document.removeEventListener('mouseup', endDrag)
 
-      function handleMouseUp(): void {
-        detach()
-        detachRef.current = null
-        onResizeEnd?.()
+        // Released by removing the property, never by restoring a value read
+        // at mousedown. Both of the handles the app mounts write to this one
+        // global style, so a handle that sampled it while the other sat
+        // mid-drag would capture 'none' and restore 'none' on every drag
+        // afterwards — text selection dead app-wide with no drag in sight.
+        // With nothing sampled there is nothing to poison, and releasing
+        // twice or out of order is harmless.
+        document.body.style.removeProperty('user-select')
       }
-
-      // A second mousedown without a mouseup should never stack listeners.
-      detachRef.current?.()
 
       document.addEventListener('mousemove', handleMouseMove)
-      document.addEventListener('mouseup', handleMouseUp)
+      document.addEventListener('mouseup', endDrag)
       document.body.style.userSelect = 'none'
       detachRef.current = detach
-
-      onResizeStart?.()
     },
-    [growsToward, onResize, onResizeEnd, onResizeStart, orientation, size]
+    [endDrag, growsToward, onResize, orientation, size]
   )
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION
Closes #68.

## The bug

Text selection could die app-wide for the rest of the session, with no recovery short of restarting the app: `document.body.style.userSelect` got pinned to `none`.

`ResizeHandle` sampled `previousUserSelect` at the top of `handleMouseDown`, but the re-entrancy guard that undoes a stale drag ran 22 lines later. So a mousedown following a *lost* mouseup — button released outside the window, a context menu, alt-tab — sampled the `none` the previous drag had installed, then restored that `none` when it ended. Every drag after that re-poisoned itself.

The guard the author added to make the lost-mouseup case safe was precisely what made it permanent.

## The worse case, found in review

The first pass at this fix only handled re-entrancy within a single handle. But the app always mounts two `ResizeHandle` instances at once — the sidebar (`AppSidebar.tsx`) and the results splitter (`ResultsPane.tsx`) — each with its own `previousUserSelect`, both writing to one global style.

So a dangling drag on one handle poisoned the value the *other* sampled, and because the poisoned restore ran last, the body stuck at `none` with no drag active — and stayed there, since every later drag on either handle sampled `none` too. That is the exact symptom #68 reports, and it survived the first fix.

## The fix

Stop sampling. Release now removes the property outright:

```ts
document.body.style.removeProperty('user-select')
```

With nothing sampled there is nothing to poison, releasing twice or out of order is harmless, and the cross-handle case disappears rather than being narrowed. Nothing else in the app sets an inline `user-select` on `document.body`, so there is no value worth preserving.

Alongside that:

- **One release site.** A component-scope `endDrag()` owns the in-flight drag; mouseup, the re-entrancy guard, and unmount all go through it, instead of three paths each undoing a different subset.
- **`event.button !== 0` now refuses to start a drag.** A right-click opening the context menu is one of the ways a mouseup goes missing, so this removes a cause rather than only recovering from one.
- **Dropped the unused `onResizeStart` / `onResizeEnd` props.** Neither consumer passed them and the only reference anywhere was the test file — they existed solely to be tested, and they were the reason the three release paths had diverged.

## Tests

Four new cases, all verified to fail against the pre-fix component — including with the `beforeEach` reset actively working against them, so none is a tautology:

- a drag starting after a lost mouseup restores text selection
- **a second handle left mid-drag does not poison the first** — asserts recovery both at the shared mouseup and after a subsequent clean drag, pinning the permanence symptom
- unmount mid-drag restores text selection
- a non-primary button does not start a drag

Assertions compare against a literal `''` rather than a value read back from the live body, so the tests cannot silently pass on a poisoned starting state.

`865` tests pass; typecheck, lint, and prettier are clean.