### PR TITLE
fix(tabs): keep the last worksheet tab closed

### DIFF
--- a/src/app/AppShell.test.tsx
+++ b/src/app/AppShell.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { App } from './App'
 import { AppShell } from './AppShell'
 import { apiClient } from './api-client'
 import { renderWithProviders } from './test-utils'
@@ -237,6 +238,33 @@ describe('AppShell', () => {
       })
 
       releaseWorksheets?.([worksheet])
+    })
+  })
+
+  // The reconciliation effect and the tabs slice have to agree about what an
+  // empty tab strip means, and only the mounted app shows whether they do: the
+  // close is a real click, and the empty state is what the user is left with.
+  describe('closing the last tab', () => {
+    it('leaves the editor empty instead of reopening the worksheet', async () => {
+      resolveAll()
+
+      renderWithProviders(
+        <AppShell>
+          <App />
+        </AppShell>,
+        {
+          databases: [database],
+          openWorksheetId: worksheet.id,
+          queries: [],
+          worksheets: [worksheet]
+        }
+      )
+
+      await userEvent.click(
+        await screen.findByRole('button', { name: `Close ${worksheet.name}` })
+      )
+
+      expect(await screen.findByText('No worksheet open')).toBeInTheDocument()
     })
   })
 

--- a/src/app/components/WorksheetTabs.test.tsx
+++ b/src/app/components/WorksheetTabs.test.tsx
@@ -80,7 +80,8 @@ describe('WorksheetTabs', () => {
 
     expect(store.getState().tabs).toEqual({
       activeWorksheetId: 'ws-2',
-      openWorksheetIds: ['ws-1', 'ws-2']
+      openWorksheetIds: ['ws-1', 'ws-2'],
+      status: 'reconciled'
     })
   })
 
@@ -96,7 +97,8 @@ describe('WorksheetTabs', () => {
 
     expect(store.getState().tabs).toEqual({
       activeWorksheetId: 'ws-2',
-      openWorksheetIds: ['ws-2']
+      openWorksheetIds: ['ws-2'],
+      status: 'reconciled'
     })
   })
 
@@ -115,7 +117,8 @@ describe('WorksheetTabs', () => {
 
     expect(store.getState().tabs).toEqual({
       activeWorksheetId: 'ws-3',
-      openWorksheetIds: ['ws-1', 'ws-3']
+      openWorksheetIds: ['ws-1', 'ws-3'],
+      status: 'reconciled'
     })
   })
 
@@ -134,7 +137,8 @@ describe('WorksheetTabs', () => {
 
     expect(store.getState().tabs).toEqual({
       activeWorksheetId: 'ws-1',
-      openWorksheetIds: ['ws-1']
+      openWorksheetIds: ['ws-1'],
+      status: 'reconciled'
     })
   })
 
@@ -150,7 +154,8 @@ describe('WorksheetTabs', () => {
 
     expect(store.getState().tabs).toEqual({
       activeWorksheetId: 'ws-2',
-      openWorksheetIds: ['ws-2']
+      openWorksheetIds: ['ws-2'],
+      status: 'reconciled'
     })
   })
 
@@ -171,7 +176,8 @@ describe('WorksheetTabs', () => {
 
     expect(store.getState().tabs).toEqual({
       activeWorksheetId: 'ws-new',
-      openWorksheetIds: ['ws-1', 'ws-new']
+      openWorksheetIds: ['ws-1', 'ws-new'],
+      status: 'reconciled'
     })
   })
 
@@ -364,7 +370,8 @@ describe('WorksheetTabs', () => {
 
       expect(store.getState().tabs).toEqual({
         activeWorksheetId: 'ws-1',
-        openWorksheetIds: ['ws-1']
+        openWorksheetIds: ['ws-1'],
+        status: 'reconciled'
       })
     })
 
@@ -383,7 +390,8 @@ describe('WorksheetTabs', () => {
 
       expect(store.getState().tabs).toEqual({
         activeWorksheetId: 'ws-1',
-        openWorksheetIds: ['ws-1', 'ws-2']
+        openWorksheetIds: ['ws-1', 'ws-2'],
+        status: 'reconciled'
       })
     })
   })
@@ -404,7 +412,8 @@ describe('WorksheetTabs', () => {
 
       expect(store.getState().tabs).toEqual({
         activeWorksheetId: 'ws-2',
-        openWorksheetIds: ['ws-1', 'ws-2', 'ws-3']
+        openWorksheetIds: ['ws-1', 'ws-2', 'ws-3'],
+        status: 'reconciled'
       })
     })
 
@@ -424,7 +433,8 @@ describe('WorksheetTabs', () => {
 
       expect(store.getState().tabs).toEqual({
         activeWorksheetId: 'ws-3',
-        openWorksheetIds: ['ws-1', 'ws-2', 'ws-3']
+        openWorksheetIds: ['ws-1', 'ws-2', 'ws-3'],
+        status: 'reconciled'
       })
     })
 
@@ -440,7 +450,8 @@ describe('WorksheetTabs', () => {
 
       expect(store.getState().tabs).toEqual({
         activeWorksheetId: 'ws-1',
-        openWorksheetIds: ['ws-1', 'ws-2']
+        openWorksheetIds: ['ws-1', 'ws-2'],
+        status: 'reconciled'
       })
     })
   })

--- a/src/app/store/tabs-slice.test.ts
+++ b/src/app/store/tabs-slice.test.ts
@@ -6,11 +6,14 @@ import reducer, {
   type TabsState
 } from './tabs-slice'
 
+// Defaults to the steady state the app spends its life in: the tabs have
+// already met the worksheet list. The bootstrap cases pass 'restored'.
 function stateOf(
   openWorksheetIds: string[],
-  activeWorksheetId?: string
+  activeWorksheetId?: string,
+  status: TabsState['status'] = 'reconciled'
 ): TabsState {
-  return { activeWorksheetId, openWorksheetIds }
+  return { activeWorksheetId, openWorksheetIds, status }
 }
 
 describe('tabsSlice', () => {
@@ -18,7 +21,7 @@ describe('tabsSlice', () => {
     it('opens and activates a worksheet that is not open yet', () => {
       const state = reducer(initialTabsState, tabsActions.tabOpened('a'))
 
-      expect(state).toEqual(stateOf(['a'], 'a'))
+      expect(state).toEqual(stateOf(['a'], 'a', 'restored'))
     })
 
     it('activates an already open worksheet without duplicating the tab', () => {
@@ -117,13 +120,15 @@ describe('tabsSlice', () => {
       expect(state).toEqual(stateOf(['z'], 'z'))
     })
 
+    // Restored rather than reconciled: an empty worksheet list says nothing
+    // about what the user wants open, so the strip has to stay bootstrappable.
     it('leaves nothing open when nothing survives and there is no fallback', () => {
       const state = reducer(
         stateOf(['a', 'b'], 'a'),
         tabsActions.tabsReconciled({ availableIds: [] })
       )
 
-      expect(state).toEqual(stateOf([], undefined))
+      expect(state).toEqual(stateOf([], undefined, 'restored'))
     })
 
     it('adopts an active tab when the stored one was missing', () => {
@@ -133,6 +138,89 @@ describe('tabsSlice', () => {
       )
 
       expect(state).toEqual(stateOf(['a', 'b'], 'b'))
+    })
+
+    // The user closed their last tab. Reconciliation runs again on that very
+    // write, and reopening the worksheet here is what made the "no worksheet
+    // open" state unreachable.
+    it('leaves the tabs closed once they have been reconciled', () => {
+      const state = reducer(
+        stateOf([], undefined),
+        tabsActions.tabsReconciled({ availableIds: ['a'], fallbackId: 'a' })
+      )
+
+      expect(state).toEqual(stateOf([], undefined))
+    })
+
+    // Booting with stored tabs whose active one is gone. The survivors are
+    // still the user's tabs, so the pick must not stand in for them — only an
+    // empty strip is short of something to show.
+    it('keeps the surviving restored tabs rather than the fallback', () => {
+      const state = reducer(
+        stateOf(['a', 'b'], 'b', 'restored'),
+        tabsActions.tabsReconciled({
+          availableIds: ['a', 'c'],
+          fallbackId: 'c'
+        })
+      )
+
+      expect(state).toEqual(stateOf(['a'], 'a'))
+    })
+
+    // Startup: nothing was stored, so a worksheet still has to be picked.
+    it('opens the fallback while the tabs are still only restored', () => {
+      const state = reducer(
+        stateOf([], undefined, 'restored'),
+        tabsActions.tabsReconciled({ availableIds: ['a'], fallbackId: 'a' })
+      )
+
+      expect(state).toEqual(stateOf(['a'], 'a'))
+    })
+
+    // Deleting a worksheet does no tab bookkeeping of its own — it relies on
+    // this fallback to open the next one.
+    it('opens the fallback when the prune itself took the last tab', () => {
+      const state = reducer(
+        stateOf(['a'], 'a'),
+        tabsActions.tabsReconciled({ availableIds: ['b'], fallbackId: 'b' })
+      )
+
+      expect(state).toEqual(stateOf(['b'], 'b'))
+    })
+
+    // The no-op guard has to notice the status alone changing. Leaving the
+    // state on 'restored' would let the next close bootstrap all over again.
+    it('records the reconciliation even when the tabs did not change', () => {
+      const state = reducer(
+        stateOf(['a'], 'a', 'restored'),
+        tabsActions.tabsReconciled({ availableIds: ['a'] })
+      )
+
+      expect(state).toEqual(stateOf(['a'], 'a'))
+    })
+
+    // The worksheet list going empty and coming back — a refetch, or another
+    // window deleting and recreating. Nothing here is the user closing a tab,
+    // so recording it as reconciled would strand the strip empty for good.
+    it('opens a worksheet again after the list emptied and refilled', () => {
+      const emptied = reducer(
+        stateOf(['a'], 'a'),
+        tabsActions.tabsReconciled({ availableIds: [] })
+      )
+
+      // The effect fires once more on the write above, still with nothing to
+      // offer. This is the pass that used to overwrite the status.
+      const settled = reducer(
+        emptied,
+        tabsActions.tabsReconciled({ availableIds: [] })
+      )
+
+      const refilled = reducer(
+        settled,
+        tabsActions.tabsReconciled({ availableIds: ['a'], fallbackId: 'a' })
+      )
+
+      expect(refilled).toEqual(stateOf(['a'], 'a'))
     })
   })
 

--- a/src/app/store/tabs-slice.ts
+++ b/src/app/store/tabs-slice.ts
@@ -3,6 +3,13 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 export interface TabsState {
   activeWorksheetId?: string
   openWorksheetIds: string[]
+  /**
+   * Whether an empty tab strip is a decision or merely a starting point.
+   * `reconciled` means these tabs have met the worksheet list, so no tabs is
+   * the user's own doing and has to be left alone. `restored` means they have
+   * not, so a worksheet still has to be picked for them.
+   */
+  status: 'reconciled' | 'restored'
 }
 
 interface TabsReconciliation {
@@ -12,8 +19,33 @@ interface TabsReconciliation {
   fallbackId?: string
 }
 
+// Restored rather than reconciled: nothing here has met the worksheet list yet,
+// so the first reconcile is free to pick a worksheet. That also makes it the
+// right answer for `readStoredTabs` when there is nothing to restore, and keeps
+// a store built without preloaded tabs from being one that never bootstraps.
 export const initialTabsState: TabsState = {
-  openWorksheetIds: []
+  openWorksheetIds: [],
+  status: 'restored'
+}
+
+/**
+ * Whether reconciliation decided anything the state does not already say. It
+ * runs on every worksheets update, so the reducer only writes when it did:
+ * assigning unconditionally would hand the persistence subscriber a new object
+ * each time and write to localStorage on every render. The status counts as a
+ * change of its own — a first reconcile that found the tabs already right still
+ * has to record itself, or the next close would bootstrap a worksheet all over
+ * again.
+ */
+function isUnchanged(state: TabsState, next: TabsState): boolean {
+  return (
+    next.status === state.status &&
+    next.activeWorksheetId === state.activeWorksheetId &&
+    next.openWorksheetIds.length === state.openWorksheetIds.length &&
+    next.openWorksheetIds.every(
+      (id, index) => id === state.openWorksheetIds[index]
+    )
+  )
 }
 
 // Closing the active tab lands on the last remaining one, matching the design's
@@ -21,6 +53,71 @@ export const initialTabsState: TabsState = {
 // the editor area shows the "no worksheet" prompt.
 function lastTab(openWorksheetIds: string[]): string | undefined {
   return openWorksheetIds[openWorksheetIds.length - 1]
+}
+
+/** Keeps the active tab while it is still open, otherwise lands on the last. */
+function pickActiveTab(
+  openWorksheetIds: string[],
+  activeWorksheetId: string | undefined
+): string | undefined {
+  if (
+    activeWorksheetId !== undefined &&
+    openWorksheetIds.includes(activeWorksheetId)
+  ) {
+    return activeWorksheetId
+  }
+
+  return lastTab(openWorksheetIds)
+}
+
+/**
+ * The tabs that should be open: the ones whose worksheet still exists, or the
+ * fallback pick when nothing is left and something ought to be.
+ *
+ * No open tabs means one of three things, and only two of them want a worksheet
+ * opened: tabs restored from storage that have not met the worksheet list yet,
+ * and a prune that just took the last one — deleting a worksheet does no tab
+ * bookkeeping of its own and relies on this. The third is the user closing
+ * their last tab, which has to stay closed.
+ */
+function resolveOpenTabs(
+  state: TabsState,
+  availableIds: string[],
+  fallbackId: string | undefined
+): string[] {
+  // A Set rather than repeated `includes`: this runs on every worksheets
+  // update, and the id list grows with the user's worksheets.
+  const available = new Set(availableIds)
+
+  const surviving = state.openWorksheetIds.filter((id) => available.has(id))
+
+  if (surviving.length > 0 || fallbackId === undefined) {
+    return surviving
+  }
+
+  // Nothing survived. Whether this reconcile is what emptied the strip is the
+  // difference between a worksheet being deleted and a user closing their tabs.
+  const pruned = surviving.length !== state.openWorksheetIds.length
+
+  return state.status === 'restored' || pruned ? [fallbackId] : surviving
+}
+
+/**
+ * Ending up with nothing to show and nothing to offer instead means the
+ * worksheet list itself is empty, so this reconcile learned nothing about what
+ * the user wants open. Holding the status at `restored` there is what lets the
+ * strip bootstrap again once a worksheet reappears; recording it as reconciled
+ * would strand the user on an empty editor for good.
+ */
+function resolveStatus(
+  openWorksheetIds: string[],
+  fallbackId: string | undefined
+): TabsState['status'] {
+  if (openWorksheetIds.length === 0 && fallbackId === undefined) {
+    return 'restored'
+  }
+
+  return 'reconciled'
 }
 
 const tabsSlice = createSlice({
@@ -63,39 +160,24 @@ const tabsSlice = createSlice({
     tabsReconciled: (state, action: PayloadAction<TabsReconciliation>) => {
       const { availableIds, fallbackId } = action.payload
 
-      // A Set rather than repeated `includes`: this runs on every worksheets
-      // update, and the id list grows with the user's worksheets.
-      const available = new Set(availableIds)
+      const openWorksheetIds = resolveOpenTabs(state, availableIds, fallbackId)
 
-      const surviving = state.openWorksheetIds.filter((id) => available.has(id))
+      const next: TabsState = {
+        activeWorksheetId: pickActiveTab(
+          openWorksheetIds,
+          state.activeWorksheetId
+        ),
+        openWorksheetIds,
+        status: resolveStatus(openWorksheetIds, fallbackId)
+      }
 
-      const openWorksheetIds =
-        surviving.length === 0 && fallbackId !== undefined
-          ? [fallbackId]
-          : surviving
-
-      const activeWorksheetId =
-        state.activeWorksheetId !== undefined &&
-        openWorksheetIds.includes(state.activeWorksheetId)
-          ? state.activeWorksheetId
-          : lastTab(openWorksheetIds)
-
-      // This runs on every worksheets update, so it only writes when something
-      // actually changed. Assigning unconditionally would hand the persistence
-      // subscriber a new object each time and write to localStorage on every
-      // render.
-      if (
-        activeWorksheetId === state.activeWorksheetId &&
-        openWorksheetIds.length === state.openWorksheetIds.length &&
-        openWorksheetIds.every(
-          (id, index) => id === state.openWorksheetIds[index]
-        )
-      ) {
+      if (isUnchanged(state, next)) {
         return
       }
 
-      state.activeWorksheetId = activeWorksheetId
-      state.openWorksheetIds = openWorksheetIds
+      state.activeWorksheetId = next.activeWorksheetId
+      state.openWorksheetIds = next.openWorksheetIds
+      state.status = next.status
     },
 
     tabsReordered: (state, action: PayloadAction<string[]>) => {

--- a/src/app/store/tabs-storage.test.ts
+++ b/src/app/store/tabs-storage.test.ts
@@ -19,12 +19,33 @@ describe('tabs storage', () => {
     expect(readStoredTabs()).toEqual(initialTabsState)
   })
 
-  it('reads back what it wrote', () => {
-    writeStoredTabs({ activeWorksheetId: 'b', openWorksheetIds: ['a', 'b'] })
+  // The status never round-trips — it is decided by what came back, not carried
+  // in the payload. Writing 'restored' and reading 'reconciled' is the proof:
+  // a readable payload is a decision the app already made.
+  it('reads back what it wrote, as tabs it has already reconciled', () => {
+    writeStoredTabs({
+      activeWorksheetId: 'b',
+      openWorksheetIds: ['a', 'b'],
+      status: 'restored'
+    })
 
     expect(readStoredTabs()).toEqual({
       activeWorksheetId: 'b',
-      openWorksheetIds: ['a', 'b']
+      openWorksheetIds: ['a', 'b'],
+      status: 'reconciled'
+    })
+  })
+
+  // Closing every tab is a decision too, and it has to survive a restart —
+  // otherwise the worksheet is back on the next launch, which is the same bug
+  // with a longer fuse.
+  it('remembers that every tab was closed deliberately', () => {
+    writeStoredTabs({ openWorksheetIds: [], status: 'reconciled' })
+
+    expect(readStoredTabs()).toEqual({
+      activeWorksheetId: undefined,
+      openWorksheetIds: [],
+      status: 'reconciled'
     })
   })
 
@@ -57,7 +78,8 @@ describe('tabs storage', () => {
 
     expect(readStoredTabs()).toEqual({
       activeWorksheetId: 'b',
-      openWorksheetIds: ['a', 'b']
+      openWorksheetIds: ['a', 'b'],
+      status: 'reconciled'
     })
   })
 
@@ -66,7 +88,8 @@ describe('tabs storage', () => {
 
     expect(readStoredTabs()).toEqual({
       activeWorksheetId: undefined,
-      openWorksheetIds: []
+      openWorksheetIds: [],
+      status: 'reconciled'
     })
   })
 })

--- a/src/app/store/tabs-storage.ts
+++ b/src/app/store/tabs-storage.ts
@@ -13,6 +13,12 @@ function isStringArray(value: unknown): value is string[] {
  * rather than throwing — a corrupt value must not stop the app from booting.
  * Ids that no longer exist are dropped later by `tabsReconciled`, once the
  * worksheets have loaded.
+ *
+ * A payload the app actually wrote comes back `reconciled`, so the user's own
+ * arrangement survives the restart — including having closed every tab. The
+ * fallbacks come back `restored`, so a fresh install still gets a worksheet
+ * picked for it. Stored tabs whose worksheets are all gone are safe either way:
+ * that is a prune, and `tabsReconciled` opens the fallback regardless.
  */
 export function readStoredTabs(): TabsState {
   try {
@@ -43,7 +49,8 @@ export function readStoredTabs(): TabsState {
         openWorksheetIds.includes(activeWorksheetId)
           ? activeWorksheetId
           : openWorksheetIds[openWorksheetIds.length - 1],
-      openWorksheetIds
+      openWorksheetIds,
+      status: 'reconciled'
     }
   } catch (error) {
     console.warn('Could not read the stored worksheet tabs.', error)
@@ -54,7 +61,15 @@ export function readStoredTabs(): TabsState {
 
 export function writeStoredTabs(state: TabsState): void {
   try {
-    localStorage.setItem(tabsStorageKey, JSON.stringify(state))
+    // Only the tabs themselves. The status is not a fact about them, it is
+    // where they came from, and `readStoredTabs` decides that on the way back
+    // in from whether the payload was readable at all.
+    const persisted = {
+      activeWorksheetId: state.activeWorksheetId,
+      openWorksheetIds: state.openWorksheetIds
+    }
+
+    localStorage.setItem(tabsStorageKey, JSON.stringify(persisted))
   } catch (error) {
     // Tabs that do not survive a restart are a much smaller problem than a
     // crash on every tab change.

--- a/src/app/test-utils.tsx
+++ b/src/app/test-utils.tsx
@@ -97,7 +97,11 @@ function createTabsState(options: RenderOptions): TabsState {
       options.tabs?.activeWorksheetId ??
       options.openWorksheetId ??
       openWorksheetIds[openWorksheetIds.length - 1],
-    openWorksheetIds
+    openWorksheetIds,
+    // Seeded tabs stand for tabs the running app already has open, so they have
+    // met the worksheet list. A test that wants the startup pick asks for
+    // `tabs: { status: 'restored' }`.
+    status: options.tabs?.status ?? 'reconciled'
   }
 }
 


### PR DESCRIPTION
Closes #59.

## The bug

Close the last worksheet tab and it immediately reopened itself. The "No worksheet open" empty state was unreachable in the shipped app whenever at least one worksheet existed.

`tabClosed` left `{ openWorksheetIds: [], activeWorksheetId: undefined }`. `AppDataLoader` subscribes to `activeWorksheetId`, so that write re-fired its effect, which dispatched `tabsReconciled` with a `fallbackId` from `pickWorksheetToOpen` — and with the active id now `undefined`, that function skips its early return and always returns a defined id. The reducer's `surviving.length === 0 && fallbackId !== undefined` then reopened the tab.

The tests missed it because the invariant was tested where it holds and broken where it is composed: `tabs-slice.test.ts` asserted the reducer leaves nothing active, which is true in isolation and undone by the effect above it.

## Root cause

`openWorksheetIds: []` was one encoding for three different situations:

- restored tabs that have not met the worksheet list yet → bootstrap a pick
- reconciliation pruned the last surviving tab → pick a replacement (`useDeleteWorksheet` relies on this and deliberately does no tab bookkeeping of its own)
- the user closed everything → leave it closed

The reducer saw only "empty" and applied the first policy to the third.

## The fix

`TabsState` gains `status: 'reconciled' | 'restored'`, so "the user has no tabs open" becomes a state the store can hold rather than an inference from emptiness. The fallback is gated on `state.status === 'restored' || pruned`, which preserves the delete-worksheet path explicitly instead of as a side effect.

Three details that took a review round to get right:

- **The no-op guard compares `status` too** (`status === state.status`). Without it the first reconcile after boot early-returns, leaves the status on `'restored'` forever, and the next close bootstraps all over again.
- **An empty worksheet list holds the status at `'restored'`.** Otherwise a list that empties and refills strands the strip empty for good: the refill sees `pruned === false` and never bootstraps. `main` self-healed here by accident; a first pass at this fix did not.
- **`writeStoredTabs` persists only the tabs**, never the status, so a stored value cannot decide a question the read should answer.

## Closing everything now survives a restart

`readStoredTabs` returns `'reconciled'` when it actually read a valid payload, and `'restored'` only for a missing key, malformed JSON, or an invalid shape. So a fresh install still bootstraps, while a user who deliberately closed every tab gets an empty editor back after relaunching instead of having that decision quietly reversed.

The five cases, verified end to end against the real read/write/reducer:

| | result |
|---|---|
| fresh install, no stored key | opens a worksheet |
| relaunch, worksheets intact | restores the tabs |
| relaunch, stored worksheets all gone | opens a replacement |
| relaunch after closing everything | stays empty |
| worksheet list empties, then refills | opens a worksheet again |

## Tests

The composition was untested at every level, so the headline test is an integration one: mount `AppShell` + `App`, click the real close button with `userEvent`, assert `No worksheet open` renders. It fails on `main`.

Alongside it, reducer and storage cases pinning each clause — verified by mutation that each is caught by exactly the intended test: dropping the `status` clause from the no-op guard, dropping `|| pruned`, dropping the gate entirely, and the empty-then-refilled sequence.

`868` tests pass; typecheck, lint, and prettier are clean.

## Visible change

Closing the last tab now leaves the editor on "No worksheet open" — and keeps it there across restarts. That is the intended fix.