### PR TITLE
fix(databases): only lend a stored password to the server it was saved for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,19 @@ from older databases. A new table or column goes in both
 - Database `connectionInfo` is encrypted at rest with Electron `safeStorage`
   once the user has granted permission (`enc:v1:` prefix in the `databases`
   table; see Secret storage below). API responses never include passwords —
-  internal callers use `getDatabaseWithSecrets()`, updates with a blank password
-  keep the stored one, and connection tests can pass a `databaseId` to borrow
-  it.
+  internal callers use `getDatabaseWithSecrets()`. A request that omits the
+  password borrows the stored one (an update by its own id, a connection test by
+  the `databaseId` it sends), and both go through
+  `DatabaseService.resolveConnection`, which lends the secret only back to the
+  server it was saved for, reached the way it was saved to be reached: `host`,
+  `port`, `sslMode`, and `sslRootCert` must all match. Editing the username or
+  database name keeps borrowing; changing where the password goes or how it
+  travels answers `DifferentServerError` (400) on the update and a
+  `success: false` message on the test, and the user re-types the password. An
+  empty stored password counts as no stored password, so a row repaired after an
+  unreadable secret is never refused over a password it does not have. The
+  update route used to merge the password in on its own, without any of that,
+  which made a PATCH a two-step way around the connection test's refusal.
 - Don't include the Claude footer in commits
 
 ## Secret storage

--- a/src/glue/api/errors.ts
+++ b/src/glue/api/errors.ts
@@ -16,6 +16,17 @@ export class DatabaseNotFoundError extends Schema.TaggedError<DatabaseNotFoundEr
   HttpApiSchema.annotations({ status: 404 })
 ) {}
 
+// A stored password is only ever lent back to the server it was saved for, so
+// an edit that moves the connection to another host or port has to carry the
+// password itself.
+export class DifferentServerError extends Schema.TaggedError<DifferentServerError>()(
+  'DifferentServerError',
+  {
+    message: Schema.String
+  },
+  HttpApiSchema.annotations({ status: 400 })
+) {}
+
 export class NoDatabaseAvailableError extends Schema.TaggedError<NoDatabaseAvailableError>()(
   'NoDatabaseAvailableError',
   {

--- a/src/glue/api/groups/databases.ts
+++ b/src/glue/api/groups/databases.ts
@@ -2,6 +2,7 @@ import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from '@effect/platform'
 
 import {
   DatabaseNotFoundError,
+  DifferentServerError,
   SchemaLoadFailedError,
   UnknownDatabaseIdsError
 } from '../errors'
@@ -50,6 +51,7 @@ export const databasesGroup = HttpApiGroup.make('databases')
       .setPayload(UpdateDatabaseRequest)
       .addSuccess(UpdateDatabaseResponse)
       .addError(DatabaseNotFoundError)
+      .addError(DifferentServerError)
   )
   .middleware(Authorization)
   .prefix('/databases')

--- a/src/glue/api/schemas.ts
+++ b/src/glue/api/schemas.ts
@@ -327,6 +327,10 @@ export type SchemaInfoDto = Schema.Schema.Type<typeof SchemaInfoDto>
 
 // --- Connection tests ------------------------------------------------------------
 
+// Only the schema is exported. The route decodes against it and the handler
+// hands the decoded payload straight to DatabaseService.resolveConnection,
+// which takes the borrow-from id and the requested connection as two arguments
+// — so nothing needs to name this request's shape as a type.
 export const ConnectionTestRequest = Schema.Union(
   Schema.Struct({
     ...updateServerConnectionFields,
@@ -337,9 +341,6 @@ export const ConnectionTestRequest = Schema.Union(
     databaseId: Schema.optional(Schema.String)
   })
 )
-export type ConnectionTestRequest = Schema.Schema.Type<
-  typeof ConnectionTestRequest
->
 
 // A failed test is data, not an error — the endpoint always answers 200 so
 // the renderer can show the driver message inline.

--- a/src/server/http/connection-tests.test.ts
+++ b/src/server/http/connection-tests.test.ts
@@ -1,10 +1,14 @@
 import { HttpClient } from '@effect/platform'
+import { eq } from 'drizzle-orm'
 import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
 
+import { databasesTable } from '@/database/schema'
+import { AppDatabase } from '@/server/services/app-database'
 import {
   makeAuthorizedClient,
   makeTestApi,
+  testEncryptionPrefix,
   type TestApiOptions,
   type TestAdapterState
 } from '@/test/effect-test-helper'
@@ -16,8 +20,10 @@ const connectionInfo = {
   username: 'postgres'
 }
 
+type TestContext = AppDatabase | HttpClient.HttpClient
+
 function run<A, E>(
-  effect: Effect.Effect<A, E, HttpClient.HttpClient>,
+  effect: Effect.Effect<A, E, TestContext>,
   options: TestApiOptions = {}
 ): Promise<{ result: A; adapterState: TestAdapterState }> {
   const { adapterState, layer } = makeTestApi(options)
@@ -106,6 +112,114 @@ describe('connection test route', () => {
     expect(adapterState.lastConnectionInfo).toEqual(connectionInfo)
   })
 
+  // A keychain reset makes every stored secret unreadable. The test cannot
+  // borrow what it cannot read, but the row is still the user's to repair, so
+  // this asks for the password instead of failing the request.
+  it('requires a password when the stored secret cannot be read', async () => {
+    const { adapterState, result } = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+        const appDatabase = yield* AppDatabase
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        yield* appDatabase.execute((database) =>
+          database
+            .update(databasesTable)
+            .set({ connectionInfo: `${testEncryptionPrefix}not-json` })
+            .where(eq(databasesTable.id, created.database.id))
+        )
+
+        return yield* client.connectionTests.create({
+          payload: {
+            connectionInfo: { ...connectionInfo, password: '' },
+            databaseId: created.database.id,
+            type: 'postgres'
+          }
+        })
+      })
+    )
+
+    expect(result).toEqual({ message: 'Password is required.', success: false })
+    expect(adapterState.lastConnectionInfo).toEqual(null)
+  })
+
+  // Repairing an unreadable row saves a blank password, and rows predating the
+  // non-empty rule can hold one too. An empty password is no secret to borrow,
+  // so the honest answer is to ask for one — not to hand `undefined` to the
+  // driver, and not to refuse the way a different server is refused.
+  it('requires a password when the stored password is empty', async () => {
+    const { adapterState, result } = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+        const appDatabase = yield* AppDatabase
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        yield* appDatabase.execute((database) =>
+          database
+            .update(databasesTable)
+            .set({
+              connectionInfo: `${testEncryptionPrefix}${JSON.stringify({
+                ...connectionInfo,
+                password: ''
+              })}`
+            })
+            .where(eq(databasesTable.id, created.database.id))
+        )
+
+        return yield* client.connectionTests.create({
+          payload: {
+            connectionInfo: { ...connectionInfo, password: '' },
+            databaseId: created.database.id,
+            type: 'postgres'
+          }
+        })
+      })
+    )
+
+    expect(result).toEqual({ message: 'Password is required.', success: false })
+    expect(adapterState.lastConnectionInfo).toEqual(null)
+  })
+
+  // The same-server check sits below the "did the request bring its own
+  // password" check. Moving it above would refuse every test against a new
+  // host, even one the user typed the password for.
+  it('allows a different host when the request carries its own password', async () => {
+    const { adapterState, result } = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        return yield* client.connectionTests.create({
+          payload: {
+            connectionInfo: {
+              ...connectionInfo,
+              host: 'replica.internal',
+              password: 'typed-again'
+            },
+            databaseId: created.database.id,
+            type: 'postgres'
+          }
+        })
+      })
+    )
+
+    expect(result).toEqual({ success: true })
+    expect(adapterState.lastConnectionInfo).toEqual({
+      ...connectionInfo,
+      host: 'replica.internal',
+      password: 'typed-again'
+    })
+  })
+
   // Otherwise an authenticated caller could aim a saved password at a server
   // they control and read it off the handshake.
   it('refuses to lend the stored password to a different host', async () => {
@@ -132,7 +246,7 @@ describe('connection test route', () => {
     )
 
     expect(result).toEqual({
-      message: 'Enter the password to test a different server.',
+      message: 'Enter the password to test a different server or SSL settings.',
       success: false
     })
 
@@ -160,7 +274,7 @@ describe('connection test route', () => {
     )
 
     expect(result).toEqual({
-      message: 'Enter the password to test a different server.',
+      message: 'Enter the password to test a different server or SSL settings.',
       success: false
     })
   })

--- a/src/server/http/databases.test.ts
+++ b/src/server/http/databases.test.ts
@@ -118,6 +118,65 @@ describe('database routes', () => {
     }
   })
 
+  // The connection-test route already refuses to aim a stored password at
+  // another server. Without the same guard here, a PATCH with a blank password
+  // was the two-step way around it: persist the secret against the new host
+  // first, then let any later connection hand it over.
+  it('answers 400 and stores nothing when an update aims the stored password at another host', async () => {
+    const { layer } = makeTestApi({})
+
+    // One layer for both halves, so the row check reads the same database the
+    // rejected request was aimed at.
+    const { after, before, body, status } = await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+        const http = yield* HttpClient.HttpClient
+        const appDatabase = yield* AppDatabase
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        const [before] = yield* appDatabase.execute((db) =>
+          db.select().from(databasesTable)
+        )
+
+        const response = yield* http.execute(
+          HttpClientRequest.patch(`/databases/${created.database.id}`).pipe(
+            HttpClientRequest.setHeader(
+              'authorization',
+              `Bearer ${testApiToken}`
+            ),
+            HttpClientRequest.bodyUnsafeJson({
+              connectionInfo: {
+                ...connectionInfo,
+                host: 'attacker.example',
+                password: ''
+              },
+              name: 'Renamed',
+              type: 'postgres'
+            })
+          )
+        )
+
+        const body = yield* response.json
+
+        const [after] = yield* appDatabase.execute((db) =>
+          db.select().from(databasesTable)
+        )
+
+        return { after, before, body, status: response.status }
+      }).pipe(Effect.scoped, Effect.provide(layer))
+    )
+
+    expect(status).toEqual(400)
+    expect(body).toEqual({
+      _tag: 'DifferentServerError',
+      message: 'Enter the password to change the server or its SSL settings.'
+    })
+    expect(after).toEqual(before)
+  })
+
   it('deletes a database and empties the list', async () => {
     const { removal, remaining } = await run(
       Effect.gen(function* () {

--- a/src/server/http/handlers/connection-tests.ts
+++ b/src/server/http/handlers/connection-tests.ts
@@ -1,106 +1,13 @@
 import { HttpApiBuilder } from '@effect/platform'
-import { Effect, Option } from 'effect'
+import { Effect } from 'effect'
 
 import { SquealApi } from '@/glue/api/api'
-import type {
-  ConnectionTestRequest,
-  DatabaseConnection
-} from '@/glue/api/schemas'
 import { AdapterFactory } from '@/server/services/adapter-factory'
-import { DatabaseService } from '@/server/services/database-service'
+import {
+  DatabaseService,
+  type ResolvedConnection
+} from '@/server/services/database-service'
 import { orDieInternal } from '../internal-errors'
-
-type ResolvedConnection =
-  | { readonly _tag: 'resolved'; readonly connection: DatabaseConnection }
-  | { readonly _tag: 'differentServer' }
-  | { readonly _tag: 'passwordRequired' }
-
-interface ServerTarget {
-  readonly host: string
-  readonly port?: number | undefined
-}
-
-// The stored password may only be lent back to the server it was saved for.
-// Only host and port are compared, because those decide where the secret is
-// actually sent: editing the username or database name still targets the same
-// trusted server, so requiring a re-typed password there would be friction
-// without a security gain.
-function targetsSameServer(
-  requested: ServerTarget,
-  stored: ServerTarget
-): boolean {
-  return (
-    requested.host === stored.host &&
-    (requested.port ?? undefined) === (stored.port ?? undefined)
-  )
-}
-
-// A test without a password uses the stored one — the renderer never sees
-// passwords, so testing an existing connection sends its databaseId instead.
-const resolveTestConnection = (payload: ConnectionTestRequest) =>
-  Effect.gen(function* () {
-    // SQLite carries no password, so there is nothing to look up.
-    if (payload.type === 'sqlite') {
-      return {
-        _tag: 'resolved',
-        connection: {
-          connectionInfo: payload.connectionInfo,
-          type: payload.type
-        }
-      } as const
-    }
-
-    const { connectionInfo, databaseId, type } = payload
-
-    if (connectionInfo.password) {
-      return {
-        _tag: 'resolved',
-        connection: {
-          connectionInfo: {
-            ...connectionInfo,
-            password: connectionInfo.password
-          },
-          type
-        }
-      } as const
-    }
-
-    if (databaseId === undefined) {
-      return { _tag: 'passwordRequired' } as const
-    }
-
-    const service = yield* DatabaseService
-    const stored = yield* service.getWithSecrets(databaseId)
-
-    if (Option.isNone(stored)) {
-      return { _tag: 'passwordRequired' } as const
-    }
-
-    const storedConnection = stored.value.connection
-
-    // Excluding sqlite also narrows the stored info to the server shape, which
-    // is the only one carrying a password to lend.
-    if (storedConnection.type === 'sqlite' || storedConnection.type !== type) {
-      return { _tag: 'passwordRequired' } as const
-    }
-
-    // Without this an authenticated caller could aim a saved password at a
-    // server they control and have the app hand it over during the handshake.
-    if (!targetsSameServer(connectionInfo, storedConnection.connectionInfo)) {
-      return { _tag: 'differentServer' } as const
-    }
-
-    return {
-      _tag: 'resolved',
-      connection: {
-        connectionInfo: {
-          ...connectionInfo,
-          password: storedConnection.connectionInfo.password
-        },
-        type
-      }
-    } as const
-  })
 
 export const ConnectionTestsLive = HttpApiBuilder.group(
   SquealApi,
@@ -109,9 +16,17 @@ export const ConnectionTestsLive = HttpApiBuilder.group(
     handlers.handle('create', ({ payload }) =>
       Effect.gen(function* () {
         const adapterFactory = yield* AdapterFactory
+        const service = yield* DatabaseService
 
-        const resolved: ResolvedConnection =
-          yield* resolveTestConnection(payload)
+        // A test without a password uses the stored one — the renderer never
+        // sees passwords, so testing a saved connection sends its databaseId
+        // instead. The service decides whether that password may be lent; the
+        // update route asks the same question, and answering it in one place is
+        // what keeps the two from drifting apart.
+        const resolved: ResolvedConnection = yield* service.resolveConnection(
+          payload.databaseId,
+          payload
+        )
 
         if (resolved._tag === 'passwordRequired') {
           return { message: 'Password is required.', success: false }
@@ -119,7 +34,8 @@ export const ConnectionTestsLive = HttpApiBuilder.group(
 
         if (resolved._tag === 'differentServer') {
           return {
-            message: 'Enter the password to test a different server.',
+            message:
+              'Enter the password to test a different server or SSL settings.',
             success: false
           }
         }

--- a/src/server/services/database-service.test.ts
+++ b/src/server/services/database-service.test.ts
@@ -43,6 +43,52 @@ function run<A, E>(
   return Effect.runPromise(Effect.provide(effect, makeLayer()))
 }
 
+const differentServerError = expect.objectContaining({
+  _tag: 'DifferentServerError',
+  message: 'Enter the password to change the server or its SSL settings.'
+})
+
+function storedConnectionInfo(row: { connectionInfo: string }): unknown {
+  return JSON.parse(row.connectionInfo.slice(testEncryptionPrefix.length))
+}
+
+// Every field that decides where the password goes, or how it travels, is
+// tested the same way: save a connection, edit one of those fields with the
+// blank password the renderer sends, and read the row before and after.
+function updateWithBlankPassword(
+  saved: ServerConnectionInfo,
+  changes: Partial<ServerConnectionInfo>
+) {
+  return run(
+    Effect.gen(function* () {
+      const service = yield* DatabaseService
+      const appDatabase = yield* AppDatabase
+
+      const created = yield* service.create('Pagila', {
+        connectionInfo: saved,
+        type: 'postgres'
+      })
+
+      const [before] = yield* appDatabase.execute((client) =>
+        client.select().from(databasesTable)
+      )
+
+      const result = yield* Effect.either(
+        service.update(created.database.id, 'Renamed', {
+          connectionInfo: { ...saved, ...changes, password: '' },
+          type: 'postgres'
+        })
+      )
+
+      const [after] = yield* appDatabase.execute((client) =>
+        client.select().from(databasesTable)
+      )
+
+      return { after, before, result }
+    })
+  )
+}
+
 describe('DatabaseService', () => {
   it('stores connection info encrypted and never returns the password', async () => {
     const { row, result } = await run(
@@ -91,7 +137,123 @@ describe('DatabaseService', () => {
     expect(result.updatedWorksheet?.databaseId).toEqual(result.database.id)
   })
 
-  it('keeps the stored password when an update sends a blank one', async () => {
+  // The stored password is only lent back to the server it was saved for,
+  // reached the same way. Without this an authenticated caller walks around the
+  // connection-test guard in two steps: PATCH the host with a blank password,
+  // and the saved secret is re-encrypted against a server they control, ready
+  // to be handed over on the next connection.
+  it('refuses to lend the stored password to a different host', async () => {
+    const { after, before, result } = await updateWithBlankPassword(
+      connectionInfo,
+      { host: 'attacker.example' }
+    )
+
+    expect(result._tag).toEqual('Left')
+
+    if (result._tag === 'Left') {
+      expect(result.left).toEqual(differentServerError)
+    }
+
+    // Nothing was written: the row still names the original server.
+    expect(after).toEqual(before)
+  })
+
+  it('refuses to lend the stored password to a different port', async () => {
+    const { after, before, result } = await updateWithBlankPassword(
+      connectionInfo,
+      { port: 6000 }
+    )
+
+    expect(result._tag).toEqual('Left')
+
+    if (result._tag === 'Left') {
+      expect(result.left).toEqual(differentServerError)
+    }
+
+    expect(after).toEqual(before)
+  })
+
+  // Turning TLS off keeps the destination but changes who can read the password
+  // on the way there, so it is a different server for lending purposes. Left
+  // unguarded, the same PATCH that may no longer move the host could still
+  // strip `sslMode` and put the stored secret on the wire in the clear.
+  it('refuses to lend the stored password when the SSL mode changes', async () => {
+    const { after, before, result } = await updateWithBlankPassword(
+      { ...connectionInfo, sslMode: 'verify-full' },
+      { sslMode: 'disable' }
+    )
+
+    expect(result._tag).toEqual('Left')
+
+    if (result._tag === 'Left') {
+      expect(result.left).toEqual(differentServerError)
+    }
+
+    expect(after).toEqual(before)
+  })
+
+  // Swapping the pinned certificate is a MITM behind a CA the user never chose,
+  // which the mode alone does not catch.
+  it('refuses to lend the stored password when the SSL root certificate changes', async () => {
+    const { after, before, result } = await updateWithBlankPassword(
+      {
+        ...connectionInfo,
+        sslMode: 'verify-full',
+        sslRootCert: '/etc/ssl/pagila.pem'
+      },
+      { sslRootCert: '/tmp/attacker.pem' }
+    )
+
+    expect(result._tag).toEqual('Left')
+
+    if (result._tag === 'Left') {
+      expect(result.left).toEqual(differentServerError)
+    }
+
+    expect(after).toEqual(before)
+  })
+
+  // Rows written before the SSL fields existed carry neither key, and the form
+  // submits an empty root certificate for "none". Both mean the same transport
+  // as `disable`, so an untouched SSL section must not read as a change.
+  it('keeps the stored password when absent SSL fields come back empty', async () => {
+    const { after, result } = await updateWithBlankPassword(connectionInfo, {
+      sslRootCert: ''
+    })
+
+    expect(result._tag).toEqual('Right')
+    expect(storedConnectionInfo(after)).toEqual({
+      database: 'pagila',
+      host: 'localhost',
+      password: 'secret',
+      sslRootCert: '',
+      username: 'postgres'
+    })
+  })
+
+  // Editing the username or the database name still targets the same trusted
+  // server, so requiring a re-typed password there would be friction without a
+  // security gain.
+  it('keeps the stored password when only the username and database name change', async () => {
+    const { after, result } = await updateWithBlankPassword(connectionInfo, {
+      database: 'other',
+      username: 'reader'
+    })
+
+    expect(result._tag).toEqual('Right')
+    expect(storedConnectionInfo(after)).toEqual({
+      database: 'other',
+      host: 'localhost',
+      password: 'secret',
+      username: 'reader'
+    })
+    expect(after.name).toEqual('Renamed')
+  })
+
+  // The guard sits below the "did the request bring its own password" check, so
+  // moving a connection is still possible — the user just has to type the
+  // password. Tightening the order would lock them out of it entirely.
+  it('allows a host change when the update carries its own password', async () => {
     const row = await run(
       Effect.gen(function* () {
         const service = yield* DatabaseService
@@ -99,12 +261,11 @@ describe('DatabaseService', () => {
 
         const created = yield* service.create('Pagila', connection)
 
-        yield* service.update(created.database.id, 'Renamed', {
+        yield* service.update(created.database.id, 'Moved', {
           connectionInfo: {
-            database: 'pagila',
-            host: 'other-host',
-            password: '',
-            username: 'postgres'
+            ...connectionInfo,
+            host: 'replica.internal',
+            password: 'typed-again'
           },
           type: 'postgres'
         })
@@ -117,15 +278,63 @@ describe('DatabaseService', () => {
       })
     )
 
-    expect(
-      JSON.parse(row.connectionInfo.slice(testEncryptionPrefix.length))
-    ).toEqual({
+    expect(storedConnectionInfo(row)).toEqual({
       database: 'pagila',
-      host: 'other-host',
-      password: 'secret',
+      host: 'replica.internal',
+      password: 'typed-again',
       username: 'postgres'
     })
-    expect(row.name).toEqual('Renamed')
+  })
+
+  // An empty stored password is no secret at all, so there is nothing to
+  // refuse. Reachable without any fixture surgery: repairing a row whose secret
+  // this build cannot read saves a blank password, and the user then has to be
+  // able to move the connection like any other.
+  it('lets an update move a connection whose stored password is empty', async () => {
+    const row = await run(
+      Effect.gen(function* () {
+        const service = yield* DatabaseService
+        const appDatabase = yield* AppDatabase
+
+        const created = yield* service.create('Pagila', connection)
+
+        yield* appDatabase.execute((client) =>
+          client
+            .update(databasesTable)
+            .set({ connectionInfo: 'not-decryptable' })
+            .where(eq(databasesTable.id, created.database.id))
+        )
+
+        // The repair: a blank password against an unreadable secret stores a
+        // blank password.
+        yield* service.update(created.database.id, 'Repaired', {
+          connectionInfo: { ...connectionInfo, password: '' },
+          type: 'postgres'
+        })
+
+        yield* service.update(created.database.id, 'Moved', {
+          connectionInfo: {
+            ...connectionInfo,
+            host: 'replica.internal',
+            password: ''
+          },
+          type: 'postgres'
+        })
+
+        const [row] = yield* appDatabase.execute((client) =>
+          client.select().from(databasesTable)
+        )
+
+        return row
+      })
+    )
+
+    expect(storedConnectionInfo(row)).toEqual({
+      database: 'pagila',
+      host: 'replica.internal',
+      password: '',
+      username: 'postgres'
+    })
   })
 
   it('fails with DatabaseNotFoundError when updating an unknown id', async () => {

--- a/src/server/services/database-service.ts
+++ b/src/server/services/database-service.ts
@@ -4,6 +4,7 @@ import { Effect, Option } from 'effect'
 import { databasesTable, worksheetsTable } from '@/database/schema'
 import {
   DatabaseNotFoundError,
+  DifferentServerError,
   UnknownDatabaseIdsError
 } from '@/glue/api/errors'
 import type {
@@ -12,6 +13,7 @@ import type {
   DatabaseDto,
   DatabaseType,
   PublicConnectionInfo,
+  SslMode,
   UpdateDatabaseConnection,
   WorksheetDto
 } from '@/glue/api/schemas'
@@ -32,6 +34,34 @@ interface DatabaseWithSecrets {
 }
 
 type DatabaseRow = typeof databasesTable.$inferSelect
+
+// What a request asking to reuse a stored password can get back: the connection
+// to open, a refusal because the password would leave the server it was saved
+// for or travel there differently, or a refusal because there is no stored
+// password to reuse.
+export type ResolvedConnection =
+  | { readonly _tag: 'resolved'; readonly connection: DatabaseConnection }
+  | { readonly _tag: 'differentServer' }
+  | { readonly _tag: 'passwordRequired' }
+
+// A ConnectionTarget with every optional field resolved to the one spelling
+// that means what it means, so two of these compare field by field.
+interface CanonicalTarget {
+  readonly host: string
+  readonly port: number | undefined
+  readonly sslMode: SslMode
+  readonly sslRootCert: string
+}
+
+// The fields that decide where a password goes and how it travels — the ones
+// targetsSameServerAndTransport compares. Both the requested and the stored
+// server connection info satisfy this shape.
+interface ConnectionTarget {
+  readonly host: string
+  readonly port?: number | undefined
+  readonly sslMode?: SslMode | undefined
+  readonly sslRootCert?: string | undefined
+}
 
 export class DatabaseService extends Effect.Service<DatabaseService>()(
   'DatabaseService',
@@ -326,68 +356,138 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
         return yield* list()
       })
 
-      // An update without a password means "keep the stored one" — the
-      // renderer never sees passwords, so edits can't send them back.
-      const resolveConnection = (
-        id: string,
-        connection: UpdateDatabaseConnection
-      ) =>
-        Effect.gen(function* () {
-          // SQLite has no password to merge back in.
+      // A request without a password means "use the stored one" — the renderer
+      // never sees passwords, so neither an edit nor a connection test can send
+      // one back. Both callers resolve here so the lending rules are written
+      // once: the update route used to merge the secret in on its own, without
+      // the same-server check, which made a PATCH the two-step way around the
+      // connection test's refusal.
+      const resolveConnection = Effect.fn('DatabaseService.resolveConnection')(
+        function* (
+          databaseId: string | undefined,
+          connection: UpdateDatabaseConnection
+        ) {
+          // SQLite carries no password, so there is nothing to look up. The
+          // pair is rebuilt rather than passed along: a ConnectionTestRequest
+          // arrives here carrying a databaseId as well, and a
+          // DatabaseConnection is meant to be one discriminated value — the
+          // type and the info that goes with it, nothing else.
           if (connection.type === 'sqlite') {
-            return connection
+            return {
+              _tag: 'resolved',
+              connection: {
+                connectionInfo: connection.connectionInfo,
+                type: connection.type
+              }
+            } as const
           }
 
           const { connectionInfo, type } = connection
 
           if (connectionInfo.password) {
             return {
-              connectionInfo: {
-                ...connectionInfo,
-                password: connectionInfo.password
-              },
-              type
-            }
+              _tag: 'resolved',
+              connection: {
+                connectionInfo: {
+                  ...connectionInfo,
+                  password: connectionInfo.password
+                },
+                type
+              }
+            } as const
+          }
+
+          if (databaseId === undefined) {
+            return { _tag: 'passwordRequired' } as const
           }
 
           // A stored secret this build cannot read must not block the edit that
           // repairs it, so an unreadable row behaves like one with no stored
-          // password rather than failing the update.
-          const existing = yield* getWithSecrets(id).pipe(
+          // password rather than failing the request.
+          const stored = yield* getWithSecrets(databaseId).pipe(
             Effect.catchTag('SecretDecryptError', () =>
               Effect.succeed(Option.none<DatabaseWithSecrets>())
             )
           )
-          const storedPassword =
-            Option.isSome(existing) &&
-            existing.value.connection.type === type &&
-            'password' in existing.value.connection.connectionInfo
-              ? existing.value.connection.connectionInfo.password
-              : ''
+
+          if (Option.isNone(stored)) {
+            return { _tag: 'passwordRequired' } as const
+          }
+
+          const storedConnection = stored.value.connection
+
+          // Excluding sqlite also narrows the stored info to the server shape,
+          // which is the only one carrying a password to lend. An empty stored
+          // password is no secret: rows repaired after an unreadable secret
+          // hold one, as do rows written before the field had to be non-empty.
+          // Asking for a password is the honest answer there — refusing the
+          // edit would demand one that does not exist.
+          if (
+            storedConnection.type === 'sqlite' ||
+            storedConnection.type !== type ||
+            !storedConnection.connectionInfo.password
+          ) {
+            return { _tag: 'passwordRequired' } as const
+          }
+
+          // Without this an authenticated caller could aim a saved password at
+          // a server they control, or strip its TLS, and have the app hand it
+          // over during the handshake.
+          if (
+            !targetsSameServerAndTransport(
+              connectionInfo,
+              storedConnection.connectionInfo
+            )
+          ) {
+            return { _tag: 'differentServer' } as const
+          }
 
           return {
-            connectionInfo: { ...connectionInfo, password: storedPassword },
-            type
-          }
-        })
+            _tag: 'resolved',
+            connection: {
+              connectionInfo: {
+                ...connectionInfo,
+                password: storedConnection.connectionInfo.password
+              },
+              type
+            }
+          } as const
+        }
+      )
 
       const update = Effect.fn('DatabaseService.update')(function* (
         id: string,
         name: string,
         connection: UpdateDatabaseConnection
       ) {
-        const resolved: DatabaseConnection = yield* resolveConnection(
+        const resolved: ResolvedConnection = yield* resolveConnection(
           id,
           connection
         )
+
+        if (resolved._tag === 'differentServer') {
+          return yield* new DifferentServerError({
+            message:
+              'Enter the password to change the server or its SSL settings.'
+          })
+        }
+
+        // There is no stored password to keep, so the edit saves a blank one.
+        // That is what repairs a row whose secret this build cannot read: the
+        // user re-enters the password afterwards.
+        const target: DatabaseConnection =
+          resolved._tag === 'passwordRequired'
+            ? withBlankPassword(connection)
+            : resolved.connection
+
         const encrypted = yield* secrets.encrypt(
-          JSON.stringify(resolved.connectionInfo)
+          JSON.stringify(target.connectionInfo)
         )
 
         const [record] = yield* appDatabase.execute((client) =>
           client
             .update(databasesTable)
-            .set({ connectionInfo: encrypted, name, type: resolved.type })
+            .set({ connectionInfo: encrypted, name, type: target.type })
             // Soft-deleted rows are excluded like everywhere else: without this
             // a PATCH would re-encrypt a password onto a row whose secret
             // remove() deliberately purged, and answer 200 for a database that
@@ -414,11 +514,61 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
         list,
         remove,
         reorder,
+        resolveConnection,
         update
       } as const
     })
   }
 ) {}
+
+// The stored password may only be lent back to the server it was saved for,
+// reached the way it was saved to be reached. Host and port decide where the
+// secret is sent; sslMode and sslRootCert decide who else can read it on the
+// way and which certificate is trusted to receive it — `disable` puts it on the
+// wire in the clear (see createSslOptions), and a swapped root certificate is a
+// MITM behind a CA the user never chose. Nothing else is compared: editing the
+// username or database name still targets the same server over the same
+// transport, so requiring a re-typed password there would be friction without a
+// security gain.
+//
+// Any change to the two TLS fields refuses, rather than only a downgrade.
+// sslRootCert has no ordering to downgrade along, so a lattice would only ever
+// cover sslMode, and a half-covered rule is what let this bug exist in the
+// first place. Re-typing the password to tighten TLS is a small, rare cost, and
+// the rule fails closed.
+function targetsSameServerAndTransport(
+  requested: ConnectionTarget,
+  stored: ConnectionTarget
+): boolean {
+  const requestedTarget = toCanonicalTarget(requested)
+  const storedTarget = toCanonicalTarget(stored)
+
+  return (
+    requestedTarget.host === storedTarget.host &&
+    requestedTarget.port === storedTarget.port &&
+    requestedTarget.sslMode === storedTarget.sslMode &&
+    requestedTarget.sslRootCert === storedTarget.sslRootCert
+  )
+}
+
+// The same connection can be written several ways, and comparing the raw fields
+// would refuse edits that change nothing. This is where those spellings are
+// reconciled, so the comparison above is a plain equality check:
+//
+// - An absent sslMode opens the connection in the clear exactly like `disable`,
+//   and rows written before the field existed carry no key at all.
+// - The form submits an empty root certificate for "none", older rows leave the
+//   key off. Both mean nothing is pinned.
+// - A stored blob is JSON.parsed, never schema-decoded, so a port the form once
+//   wrote as null has to read the same as one that was never set.
+function toCanonicalTarget(target: ConnectionTarget): CanonicalTarget {
+  return {
+    host: target.host,
+    port: target.port ?? undefined,
+    sslMode: target.sslMode ?? 'disable',
+    sslRootCert: target.sslRootCert ?? ''
+  }
+}
 
 function toPublicConnectionInfo(
   connectionInfo: ConnectionInfo
@@ -431,4 +581,17 @@ function toPublicConnectionInfo(
   const { password: _password, ...publicInfo } = connectionInfo
 
   return publicInfo
+}
+
+function withBlankPassword(
+  connection: UpdateDatabaseConnection
+): DatabaseConnection {
+  if (connection.type === 'sqlite') {
+    return connection
+  }
+
+  return {
+    connectionInfo: { ...connection.connectionInfo, password: '' },
+    type: connection.type
+  }
 }


### PR DESCRIPTION
Closes #49.

## The bug

Editing a saved connection's host with a blank password re-encrypted the stored password onto the new host, and the app then handed that password to that server on the next connection.

`POST /connection-tests` already refused exactly this, and said why:

> Without this an authenticated caller could aim a saved password at a server they control and have the app hand it over during the handshake.

That guard arrived in `7fb12a2`, whose diffstat touches only `connection-tests.ts` and its test. `DatabaseService.resolveConnection` performed the identical borrow and never got the same check — so **the connection-test guard was bypassable in two steps**: PATCH the host with a blank password, then test or query, at which point the same-server check compares against the host you just stored.

Both sides were pinned by tests, which is how the divergence survived: one asserted the host swap is refused, the other asserted it succeeds.

## The fix

One resolver, owned by `DatabaseService` — the only thing that may see a stored password — returning the union the connection-test handler already declared locally:

```ts
{ _tag: 'resolved'; connection } | { _tag: 'differentServer' } | { _tag: 'passwordRequired' }
```

`update` maps `passwordRequired` to the existing repair behaviour and `differentServer` to a new `DifferentServerError` (400). The handler collapses from 117 lines to a delegation and stops receiving a decrypted connection at all. There is now one place the lending rules are written, so the two paths cannot drift apart again.

## The guard also covers TLS

Review found that comparing only host and port left the invariant walkable: a PATCH with the same host, a blank password, and `sslMode: 'disable'` returned 200, kept the stored password, and dropped TLS — after which the credential goes onto the wire in the clear on the next query. `verify-full → require` is the same class, behind any certificate.

`targetsSameServer` is now `targetsSameServerAndTransport`, comparing `host`, `port`, `sslMode`, and `sslRootCert`.

**Equality rather than downgrade-detection**, deliberately: `sslRootCert` has no ordering to downgrade along — swapping the CA at `verify-full` is a full MITM with no mode change — so a lattice could only ever cover `sslMode` and would leave the other field on the honour system. That is the same half-covered shape that produced this issue. Equality fails closed and has nothing to get subtly wrong. The cost is that *tightening* TLS also asks for the password.

All four fields are normalised before comparison. Absent `sslMode` and `'disable'` are identical to `createSslOptions`, and `DatabaseForm` submits `sslRootCert: ''` for "none" — a naive `===` would have refused every legacy row on an untouched SSL section and locked users out of renaming their own connections.

## Behaviour changes

- Changing a saved connection's **host, port, or SSL settings** with a blank password is now refused with *"Enter the password to change the server or its SSL settings."* Changing the username or database name still borrows the stored password, since those still target the same trusted server.
- A stored password that is the **empty string** now answers `passwordRequired` rather than being run through the same-server check. Previously a connection with no password at all could be refused and told to enter one that does not exist — reachable through the repair path, a `type` change saved blank, or rows predating `password: minLength(1)`.
- An **unreadable stored secret** on the connection-test route now answers `200 { success: false, message: 'Password is required.' }` instead of a 500.

The renderer needs no change: `Schema.TaggedError` extends `YieldableError`, so `DatabaseForm` surfaces the message through its existing toast.

## Tests

The test that asserted the vulnerable behaviour — changed host with a blank password re-encrypts the stored secret — is rewritten to assert the refusal, comparing the whole row before and after so the stored ciphertext is provably untouched.

Added across the service and both routes: refusals for host, port, SSL mode, and SSL root certificate; a host change *with* an explicit password is still allowed (a regression guard against over-tightening that would otherwise lock users out of moving any connection); absent SSL fields coming back empty still borrow; an empty stored password lets the move through; and the two previously-uncovered connection-test behaviours above. Route-level cases assert `adapterState.lastConnectionInfo` to prove nothing reached the driver.

`872` tests pass; typecheck, lint, and prettier are clean.

`CLAUDE.md` described the two borrow paths as one symmetric policy, which is part of why this survived. That paragraph is now true as written — it names all four compared fields and the empty-password rule.