### PR TITLE
fix(postgres): report a canceled query as canceled on any server locale

### DIFF
--- a/src/databases/adapter.ts
+++ b/src/databases/adapter.ts
@@ -2,8 +2,17 @@
 // off at the driver and flagged as truncated.
 export const maxResultRows = 10_000
 
-// Thrown by adapters when a query is canceled before it ever reaches the
-// server — for example while the connection is still being established.
+// Thrown by adapters when a query was canceled rather than failed: either
+// before it ever reached the server — while the connection was still being
+// established, say — or by the server acknowledging a cancel this app asked
+// for. Adapters raise it in place of the driver error so callers can tell a
+// cancellation from a failure by type.
+//
+// Callers still fall back to matching the server's message, and that fallback
+// is not dead yet: an adapter raises this only for a cancel it requested and
+// recognised, so one arriving by a route it does not cover still surfaces as a
+// driver error. The aim is for the fallback to become redundant — it is not
+// redundant today, and deleting it would bring the localized-message bug back.
 export class QueryCanceledError extends Error {
   constructor() {
     super('Query canceled.')

--- a/src/databases/postgres-adapter.test.ts
+++ b/src/databases/postgres-adapter.test.ts
@@ -3,6 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 interface CursorFixture {
   error?: Error
   fields: { name: string }[]
+
+  // Runs at the top of every read, before the callback. Lets a test act while
+  // the statement is in flight — cancelling it, for instance — which is the
+  // only way to reach the paths that depend on a cancel already being
+  // requested.
+  onRead?: () => void
+
   rowCount?: number | null
   rows: Record<string, unknown>[]
 }
@@ -11,12 +18,7 @@ const { cursorState, mockConnect, mockEnd, mockQuery } = vi.hoisted(() => ({
   cursorState: {
     closeCount: 0,
     createdWith: [] as string[],
-    fixtures: [] as {
-      error?: Error
-      fields: { name: string }[]
-      rowCount?: number | null
-      rows: Record<string, unknown>[]
-    }[],
+    fixtures: [] as CursorFixture[],
     readRequests: [] as number[]
   },
   mockConnect: vi.fn(),
@@ -65,6 +67,8 @@ vi.mock('pg-cursor', () => {
       ) => void
     ): void {
       cursorState.readRequests.push(count)
+
+      this.fixture.onRead?.()
 
       if (this.fixture.error) {
         callback(this.fixture.error, [])
@@ -127,6 +131,13 @@ const connectionInfo = {
   password: 'secret',
   port: 5432,
   username: 'testuser'
+}
+
+// pg rejects with a DatabaseError: an Error carrying the SQLSTATE on `code`.
+// The cursor fixture only promises an Error, so the code rides along on the
+// instance rather than widening the fixture type for a driver detail.
+function driverError(message: string, code: string): Error {
+  return Object.assign(new Error(message), { code })
 }
 
 describe('PostgresAdapter', () => {
@@ -450,6 +461,81 @@ describe('PostgresAdapter', () => {
       expect(cursorState.closeCount).toEqual(2)
     })
 
+    // A real driver rejection carries a SQLSTATE, and only 57014 means the
+    // statement was canceled. An ordinary 42P01 must still reach the rewrite.
+    it('retries with quoted identifiers when the missing relation carries SQLSTATE 42P01', async () => {
+      cursorState.fixtures.push(
+        {
+          error: driverError('relation "users" does not exist', '42P01'),
+          fields: [],
+          rows: []
+        },
+        { fields: [{ name: 'id' }], rows: [{ id: 1 }] }
+      )
+
+      mockQuery.mockImplementation((input: unknown) => {
+        if (typeof input === 'string') {
+          return Promise.resolve({
+            rows: input.includes('referenced')
+              ? []
+              : [
+                  {
+                    column_default: null,
+                    column_name: 'id',
+                    data_type: 'integer',
+                    is_nullable: 'NO',
+                    is_primary_key: true,
+                    ordinal_position: 1,
+                    table_name: 'Users',
+                    table_schema: 'public'
+                  }
+                ]
+          })
+        }
+
+        return input
+      })
+
+      const adapter = new PostgresAdapter(connectionInfo)
+      const result = await adapter.runQuery('SELECT * FROM users')
+
+      expect(cursorState.createdWith).toEqual([
+        'SELECT * FROM users',
+        'SELECT * FROM "public"."Users"'
+      ])
+      expect(result).toEqual({
+        fields: [{ name: 'id' }],
+        rowCount: 1,
+        rows: [{ id: 1 }],
+        truncated: false
+      })
+    })
+
+    it('propagates a SQLSTATE 42P01 error the schema cannot rewrite', async () => {
+      const missingRelation = driverError(
+        'relation "ghosts" does not exist',
+        '42P01'
+      )
+
+      cursorState.fixtures.push({
+        error: missingRelation,
+        fields: [],
+        rows: []
+      })
+
+      mockQuery.mockImplementation((input: unknown) =>
+        typeof input === 'string' ? Promise.resolve({ rows: [] }) : input
+      )
+
+      const adapter = new PostgresAdapter(connectionInfo)
+
+      // The whole error, SQLSTATE included: the property under test is that
+      // the driver's own error reaches the caller unwrapped.
+      await expect(adapter.runQuery('SELECT * FROM ghosts')).rejects.toEqual(
+        missingRelation
+      )
+    })
+
     it('closes the cursor and connection even when the query fails', async () => {
       cursorState.fixtures.push({
         error: new Error('Query failed'),
@@ -720,6 +806,90 @@ describe('PostgresAdapter cancellation', () => {
     rejectConnect?.(new Error('Connection terminated'))
 
     await expect(runPromise).rejects.toEqual(new QueryCanceledError())
+  })
+
+  // pg_cancel_backend makes the in-flight read reject with the server's own
+  // prose, and Postgres translates that prose through lc_messages. Only the
+  // SQLSTATE reads the same on every server, so only the SQLSTATE can be read.
+  it('reports a canceled statement as canceled on a German server', async () => {
+    const adapter = new PostgresAdapter(connectionInfo)
+
+    let cancelPromise: Promise<void> | undefined
+
+    cursorState.fixtures.push({
+      error: driverError(
+        'Anweisung wegen Benutzeranforderung abgebrochen',
+        '57014'
+      ),
+      fields: [],
+      // The user hits Cancel with the statement running, and the read then
+      // rejects with the server's acknowledgement.
+      onRead: () => {
+        cancelPromise ??= adapter.cancel()
+      },
+      rows: []
+    })
+
+    await expect(adapter.runQuery('SELECT pg_sleep(60)')).rejects.toEqual(
+      new QueryCanceledError()
+    )
+    expect(cursorState.closeCount).toEqual(1)
+    expect(mockEnd).toHaveBeenCalled()
+
+    await cancelPromise
+  })
+
+  // 57014 says a statement stopped early, not who stopped it. A server-side
+  // statement_timeout raises it too — ALTER ROLE ... SET, postgresql.conf, and
+  // the default on most managed Postgres — and so does a standby recovery
+  // conflict. Nobody asked for those, so the server's own message is all the
+  // user has to go on and it has to survive.
+  it('propagates a statement timeout rather than claiming the user canceled', async () => {
+    const timeout = driverError(
+      'canceling statement due to statement timeout',
+      '57014'
+    )
+
+    cursorState.fixtures.push({ error: timeout, fields: [], rows: [] })
+
+    const adapter = new PostgresAdapter(connectionInfo)
+
+    await expect(adapter.runQuery('SELECT id FROM big_table')).rejects.toEqual(
+      timeout
+    )
+  })
+
+  // The mixed-case retry fetches the catalog on the same connection the query
+  // runs on, and on a heavily multi-schema database those two scans are slow —
+  // which makes this exactly the moment a user gives up and hits Cancel.
+  it('reports a cancel that lands while the schema is being fetched', async () => {
+    const adapter = new PostgresAdapter(connectionInfo)
+
+    let cancelPromise: Promise<void> | undefined
+
+    cursorState.fixtures.push({
+      error: new Error('relation "users" does not exist'),
+      fields: [],
+      rows: []
+    })
+
+    mockQuery.mockImplementation((input: unknown) => {
+      if (typeof input !== 'string') {
+        return input
+      }
+
+      cancelPromise ??= adapter.cancel()
+
+      return Promise.reject(
+        driverError('Anweisung wegen Benutzeranforderung abgebrochen', '57014')
+      )
+    })
+
+    await expect(adapter.runQuery('SELECT * FROM users')).rejects.toEqual(
+      new QueryCanceledError()
+    )
+
+    await cancelPromise
   })
 
   it('does nothing when no query is running', async () => {

--- a/src/databases/postgres-adapter.ts
+++ b/src/databases/postgres-adapter.ts
@@ -136,42 +136,17 @@ export class PostgresAdapter implements DatabaseAdapter {
     this.activeClient = client
 
     try {
-      // Postgres folds unquoted identifiers to lowercase, so a query written
-      // with the real mixed-case table or column names fails. Retry with those
-      // identifiers quoted, rewriting one at a time — Postgres only reports the
-      // first offending identifier — until the query runs or nothing is left to
-      // fix. The schema is fetched once and reused; the attempted set stops the
-      // loop the moment a rewrite makes no progress.
-      let currentQuery = query
-      let schema: SchemaInfo | undefined
-      const attempted = new Set<string>()
-
-      for (;;) {
-        try {
-          return await this.executeQuery(client, currentQuery)
-        } catch (error) {
-          if (!isMissingIdentifierError(error)) {
-            throw error
-          }
-
-          schema ??= await this.getSchemaWithClient(client)
-
-          const rewritten = rewriteForMissingIdentifier(
-            currentQuery,
-            schema,
-            error
-          )
-
-          if (!rewritten || attempted.has(rewritten)) {
-            throw error
-          }
-
-          log.debug('Retrying with quoted identifiers')
-
-          attempted.add(rewritten)
-          currentQuery = rewritten
-        }
+      return await this.executeWithIdentifierRetry(client, query)
+    } catch (error) {
+      // Wraps the whole attempt rather than the statement alone, so it also
+      // covers the catalog fetch the rewrite retry runs on this same
+      // connection — a slow scan on a multi-schema database is one of the
+      // likelier moments to be canceled.
+      if (this.canceled && isCanceledStatementError(error)) {
+        throw new QueryCanceledError()
       }
+
+      throw error
     } finally {
       this.activeClient = null
 
@@ -275,6 +250,48 @@ export class PostgresAdapter implements DatabaseAdapter {
     return toQueryResult(rows, lastResult)
   }
 
+  // Postgres folds unquoted identifiers to lowercase, so a query written with
+  // the real mixed-case table or column names fails. Retry with those
+  // identifiers quoted, rewriting one at a time — Postgres only reports the
+  // first offending identifier — until the query runs or nothing is left to
+  // fix. The schema is fetched once and reused; the attempted set stops the
+  // loop the moment a rewrite makes no progress.
+  private async executeWithIdentifierRetry(
+    client: Client,
+    query: string
+  ): Promise<QueryResult> {
+    let currentQuery = query
+    let schema: SchemaInfo | undefined
+    const attempted = new Set<string>()
+
+    for (;;) {
+      try {
+        return await this.executeQuery(client, currentQuery)
+      } catch (error) {
+        if (!isMissingIdentifierError(error)) {
+          throw error
+        }
+
+        schema ??= await this.getSchemaWithClient(client)
+
+        const rewritten = rewriteForMissingIdentifier(
+          currentQuery,
+          schema,
+          error
+        )
+
+        if (!rewritten || attempted.has(rewritten)) {
+          throw error
+        }
+
+        log.debug('Retrying with quoted identifiers')
+
+        attempted.add(rewritten)
+        currentQuery = rewritten
+      }
+    }
+  }
+
   private async getSchemaWithClient(client: Client): Promise<SchemaInfo> {
     const [columnsResult, foreignKeysResult] = await Promise.all([
       client.query(postgresColumnsQuery),
@@ -362,6 +379,38 @@ export async function connectWithRetry<Connection>(
       await sleep(options.delays[attempt])
     }
   }
+}
+
+// SQLSTATE 57014 is query_canceled — the only part of a cancel acknowledgement
+// that reads the same on every server. Postgres translates the message prose
+// through lc_messages, so matching the English wording loses the cancel the
+// moment the server speaks something else.
+const canceledSqlState = '57014'
+
+// The code says a statement stopped early. It does not say who stopped it: an
+// expiring statement_timeout raises 57014 too, and that is usually set on the
+// server, where our client config has no say — ALTER ROLE/DATABASE SET,
+// postgresql.conf, and by default on most managed Postgres. A standby recovery
+// conflict is 57014 as well. Only the prose separates them, and the prose is
+// the thing we stopped trusting.
+//
+// So the code is never read alone. runQuery pairs it with this.canceled, which
+// cancel() sets synchronously before it even issues pg_cancel_backend, so the
+// flag is always set by the time the server's answer arrives. Only cancels
+// this app asked for are claimed; a timeout and an administrator's cancel both
+// keep the server's own message, which is the only thing that explains them.
+//
+// The code arrives from the driver, so it is read defensively rather than
+// assumed: pg's DatabaseError carries it as a string, but nothing in the type
+// system promises that.
+function isCanceledStatementError(error: unknown): boolean {
+  if (!(error instanceof Error) || !('code' in error)) {
+    return false
+  }
+
+  const { code } = error
+
+  return typeof code === 'string' && code === canceledSqlState
 }
 
 function isMissingIdentifierError(error: unknown): boolean {


### PR DESCRIPTION
Closes #55.

## The bug

On a Postgres server whose `lc_messages` is not English, cancelling a running query showed a red failure instead of a cancellation.

Only the *pre-connect* cancel was ever typed. The normal path — cancelling while the statement executes — goes through `pg_cancel_backend`, so the in-flight `cursor.read` rejects with the raw driver error, which `runQuery` rethrew untouched. Two layers up, `query-runner.ts` recovered it by substring-matching server prose:

```ts
message.toLowerCase().includes('canceling statement due to user request')
```

Postgres localizes that text via `lc_messages`, and none of the adapter's client configs set a locale. On a German server the match fails, so a deliberate cancel is written to `queriesTable.error` as a failure.

A knowledge inversion: the adapter sets `canceled = true`, issues the cancel, discards both facts, and a service two layers up re-derives them from prose. Nothing in `src/` read the SQLSTATE.

## The fix

Map SQLSTATE `57014` to the existing `QueryCanceledError` — **but only when this app asked for the cancel**:

```ts
if (this.canceled && isCanceledStatementError(error)) {
  throw new QueryCanceledError()
}
```

`query-runner.ts` is untouched: its `isCancellationError` already returns `true` for that type, and the substring check stays as a rollout fallback, so this is strictly additive.

### Why the `this.canceled` gate is load-bearing

`57014` is not synonymous with "the user cancelled". Postgres raises it for `statement_timeout` and for a hot-standby recovery conflict too, distinguished from a real cancel *only by the prose* — the exact thing this change stops trusting.

A first pass at this fix argued the mapping was safe because `runQuery`'s client sets no `statement_timeout`. That is true and irrelevant: `statement_timeout` is overwhelmingly set **server-side** — `ALTER ROLE`, `ALTER DATABASE`, `postgresql.conf`, and by default on most managed Postgres — where the client config has no say. Without the gate, a query the server killed on a timeout would report "Query canceled." to a user who never touched Cancel, with the real cause discarded, unlogged, and the trace span marked ok with no exception. Strictly worse than the bug being fixed.

`cancel()` sets `this.canceled` synchronously before `pg_cancel_backend` is even issued, so it is reliably `true` by the time the server's `57014` arrives. Adapters are per-query, so the flag cannot leak between queries.

### Why the catch wraps the whole attempt

The identifier-rewrite retry fetches the catalog on the same untimed connection. With the check inside the loop, a cancel landing during that fetch escaped unwrapped — and a slow catalog scan on a multi-schema database is one of the likelier moments to reach for Cancel. The catch now sits outside the loop, so it sees every route out of the attempt: the statement, the catalog fetch, and the rewrite.

The retry loop moved verbatim into a private `executeWithIdentifierRetry` — the loop body is unchanged; the extraction keeps `runQuery` under the complexity gate now that it owns an outer catch.

## Behaviour change worth noting

An out-of-band `pg_cancel_backend` issued by a DBA now keeps the server's message rather than reporting as a cancellation, because this app did not request it. That is the more accurate outcome.

## Tests

The string path had zero coverage and nothing drove a `57014` rejection. Added, each mutation-checked so exactly one test pins each half of the guard:

- a cancel issued while the statement is in flight, with a **German** message, is reported as canceled — the locale point stated explicitly, so it cannot pass via the substring path
- **a `statement_timeout` with no cancel requested propagates the server's message** — the test that only becomes expressible once the predicate consults `this.canceled`
- a cancel landing while the schema is being fetched is reported as canceled
- an ordinary `42P01` still reaches the identifier-rewrite retry, and still propagates with its `code` intact when the schema cannot rewrite it

`889` tests pass; typecheck, lint, prettier, and Fallow are clean.

`QueryCanceledError`'s doc comment said it covered only a cancel that never reached the server. It now covers both cases, and says the `query-runner` prose check is *becoming* redundant rather than that it already is — deleting that fallback would reintroduce this bug.