### PR TITLE
fix(explorer): let a click collapse a row the search forced open

### DIFF
--- a/src/app/components/DatabaseExplorer.test.tsx
+++ b/src/app/components/DatabaseExplorer.test.tsx
@@ -162,7 +162,9 @@ describe('DatabaseExplorer', () => {
 
   it('shows tables when a database is already expanded', () => {
     renderWithProviders(<DatabaseExplorer />, {
-      databaseExplorer: { expandedDatabases: { 'db-123': true } },
+      databaseExplorer: {
+        expandedDatabases: { 'db-123': { isExpanded: true, query: '' } }
+      },
       databases: [testDatabase],
       schemas: { 'db-123': testSchema }
     })
@@ -178,7 +180,9 @@ describe('DatabaseExplorer', () => {
     const user = userEvent.setup()
 
     renderWithProviders(<DatabaseExplorer />, {
-      databaseExplorer: { expandedDatabases: { 'db-123': true } },
+      databaseExplorer: {
+        expandedDatabases: { 'db-123': { isExpanded: true, query: '' } }
+      },
       databases: [testDatabase],
       schemas: { 'db-123': testSchema }
     })
@@ -201,7 +205,9 @@ describe('DatabaseExplorer', () => {
     ]
 
     renderWithProviders(<DatabaseExplorer />, {
-      databaseExplorer: { expandedDatabases: { 'db-123': true } },
+      databaseExplorer: {
+        expandedDatabases: { 'db-123': { isExpanded: true, query: '' } }
+      },
       databases: [testDatabase],
       schemas: {
         'db-123': { ...testSchema, tables: multiSchemaTables }
@@ -220,7 +226,9 @@ describe('DatabaseExplorer', () => {
     ]
 
     renderWithProviders(<DatabaseExplorer />, {
-      databaseExplorer: { expandedDatabases: { 'db-123': true } },
+      databaseExplorer: {
+        expandedDatabases: { 'db-123': { isExpanded: true, query: '' } }
+      },
       databases: [testDatabase],
       schemas: {
         'db-123': { ...testSchema, tables: duplicatedTables }
@@ -241,7 +249,9 @@ describe('DatabaseExplorer', () => {
     const user = userEvent.setup()
 
     renderWithProviders(<DatabaseExplorer />, {
-      databaseExplorer: { expandedDatabases: { 'db-123': true } },
+      databaseExplorer: {
+        expandedDatabases: { 'db-123': { isExpanded: true, query: '' } }
+      },
       databases: [testDatabase],
       schemas: { 'db-123': testSchema }
     })
@@ -251,6 +261,195 @@ describe('DatabaseExplorer', () => {
     await user.click(screen.getByText('Test Database'))
 
     expect(screen.queryByText('users')).not.toBeInTheDocument()
+  })
+
+  it('collapses a database the search forced open', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    // "users" matches, so the row is forced open by the search.
+    await user.type(screen.getByPlaceholderText('Filter tables'), 'user')
+
+    expect(screen.getByText('users')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Test Database'))
+
+    expect(screen.queryByText('users')).not.toBeInTheDocument()
+  })
+
+  it('keeps a database expanded after the search is cleared', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    const searchInput = screen.getByPlaceholderText('Filter tables')
+
+    // Only the name matches "test", so the search proposes a collapsed row and
+    // expanding it is the user's own decision.
+    await user.type(searchInput, 'test')
+    await user.click(screen.getByText('Test Database'))
+
+    expect(screen.getByText('users')).toBeInTheDocument()
+
+    await user.clear(searchInput)
+
+    // Back to the unfiltered tree, their decision is still the latest thing
+    // they said about this database.
+    expect(screen.getByText('users')).toBeInTheDocument()
+    expect(screen.getByText('posts')).toBeInTheDocument()
+  })
+
+  it('keeps a database collapsed after the search is cleared', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    const searchInput = screen.getByPlaceholderText('Filter tables')
+
+    await user.type(searchInput, 'user')
+    await user.click(screen.getByText('Test Database'))
+    await user.clear(searchInput)
+
+    expect(screen.getByText('Test Database')).toBeInTheDocument()
+    expect(screen.queryByText('users')).not.toBeInTheDocument()
+    expect(screen.queryByText('posts')).not.toBeInTheDocument()
+  })
+
+  it('lets a search expand a database the user collapsed while browsing', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    // The ordinary browsing loop: expand a database, look at it, close it
+    // again. No search is involved, so this says nothing about any query.
+    await user.click(screen.getByText('Test Database'))
+
+    expect(screen.getByText('users')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Test Database'))
+
+    expect(screen.queryByText('users')).not.toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText('Filter tables'), 'user')
+
+    expect(screen.getByText('users')).toBeInTheDocument()
+  })
+
+  it('follows a new query after collapsing a row the previous one forced open', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    const searchInput = screen.getByPlaceholderText('Filter tables')
+
+    await user.type(searchInput, 'user')
+    await user.click(screen.getByText('Test Database'))
+
+    expect(screen.queryByText('users')).not.toBeInTheDocument()
+
+    // A different query is a different question, so the collapse that answered
+    // the last one has nothing to say about this one.
+    await user.clear(searchInput)
+    await user.type(searchInput, 'post')
+
+    expect(screen.getByText('posts')).toBeInTheDocument()
+  })
+
+  it('keeps a manually expanded database open when only its name matches', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    await user.click(screen.getByText('Test Database'))
+
+    expect(screen.getByText('users')).toBeInTheDocument()
+
+    // Only the database name matches "test", so the query said nothing about
+    // this database's tables. That is the absence of an instruction, not an
+    // instruction to hide a row the user opened themselves — and the match
+    // keeps the full table list precisely so it can still be shown.
+    await user.type(screen.getByPlaceholderText('Filter tables'), 'test')
+
+    expect(screen.getByText('users')).toBeInTheDocument()
+    expect(screen.getByText('posts')).toBeInTheDocument()
+  })
+
+  it('keeps a database the user expanded during this query open', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    // No table is named after "test", so only the database name matches and
+    // the search proposes a collapsed row.
+    await user.type(screen.getByPlaceholderText('Filter tables'), 'test')
+
+    expect(screen.queryByText('users')).not.toBeInTheDocument()
+
+    await user.click(screen.getByText('Test Database'))
+
+    // Expanding answers this query, so the whole table list stays revealed.
+    expect(screen.getByText('users')).toBeInTheDocument()
+    expect(screen.getByText('posts')).toBeInTheDocument()
+  })
+
+  it('reports expansion to assistive technology', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    const header = screen.getByRole('button', { name: 'Test Database' })
+
+    expect(header).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(header)
+
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('button', { name: 'users' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+  })
+
+  it('reports a search-forced expansion to assistive technology', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    await user.type(screen.getByPlaceholderText('Filter tables'), 'user')
+
+    // The chevron rotation is a visual-only cue, so a row the search opened
+    // has to announce itself as open too.
+    expect(
+      screen.getByRole('button', { name: 'Test Database' })
+    ).toHaveAttribute('aria-expanded', 'true')
   })
 
   describe('querying a table from the context menu', () => {
@@ -287,7 +486,9 @@ describe('DatabaseExplorer', () => {
     // without this.
     async function renderExplorer(schema: SchemaInfo = testSchema) {
       const rendered = renderWithProviders(<DatabaseExplorer />, {
-        databaseExplorer: { expandedDatabases: { 'db-123': true } },
+        databaseExplorer: {
+          expandedDatabases: { 'db-123': { isExpanded: true, query: '' } }
+        },
         databases: [testDatabase],
         schemas: { 'db-123': schema },
         queries: [],

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -37,7 +37,11 @@ import { tabsActions } from '../store/tabs-slice'
 import { uiActions } from '../store/ui-slice'
 import { cn } from '../lib/utils'
 import { useAppDispatch, useAppSelector } from '../store'
-import { expandDatabase, expandTable } from '../store/database-explorer-slice'
+import {
+  DatabaseExpansion,
+  expandTable,
+  setDatabaseExpanded
+} from '../store/database-explorer-slice'
 import { computeDatabaseMatch, DatabaseMatch } from './database-explorer-search'
 import { SearchInput } from './SearchInput'
 import { buildTableQuery } from './table-query'
@@ -205,7 +209,12 @@ export function DatabaseExplorer(): ReactElement {
     (state) => state.editor.databaseSearchQuery ?? ''
   )
 
-  const isSearching = databaseSearchQuery.trim().length > 0
+  // Normalized the way `computeDatabaseMatch` normalizes, because it is what
+  // an expansion is scoped to: a decision answers the question the user asked,
+  // so adding a trailing space must not count as asking a new one.
+  const normalizedSearchQuery = databaseSearchQuery.trim().toLowerCase()
+
+  const isSearching = normalizedSearchQuery.length > 0
 
   // Prefetch every schema in the background so search and expansion are instant,
   // and reuse those results as the source for matching tables and columns.
@@ -303,10 +312,11 @@ export function DatabaseExplorer(): ReactElement {
                 key={row.database.id}
                 database={row.database}
                 dropIndicator={dropIndicatorFor(index)}
+                expansion={expandedDatabases[row.database.id]}
                 hasMultipleSchemas={row.hasMultipleSchemas}
-                isExpanded={Boolean(expandedDatabases[row.database.id])}
                 isSortingDisabled={isSortingDisabled}
                 searchMatch={row.searchMatch}
+                searchQuery={normalizedSearchQuery}
                 onDelete={handleDeleteDatabase}
                 onEdit={handleEditDatabase}
               />
@@ -341,33 +351,86 @@ export function DatabaseExplorer(): ReactElement {
 interface DatabaseRowProps {
   database: DatabaseDto
   dropIndicator: DropIndicator
+  /** The user's own decision, or `undefined` if they have never made one. */
+  expansion: DatabaseExpansion | undefined
   hasMultipleSchemas: boolean
-  isExpanded: boolean
   isSortingDisabled: boolean
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
   searchMatch?: DatabaseMatch
+  /** Normalized, so trailing whitespace does not count as a new question. */
+  searchQuery: string
 }
 
-// While searching, a matching row is forced open to reveal its tables.
+// A decision only speaks for the context it was made in:
+//
+//   not searching                       → their decision, absent → collapsed
+//   decided under *this* query          → what they decided
+//   stale decision, table match         → open: the match wins
+//   stale decision, name-only match     → their decision
+//
+// The two search outcomes are deliberately not symmetric, because the search's
+// two proposals are not the same kind of thing. `expandDatabase: true` is an
+// active instruction — reveal these matching tables — so it has to beat a
+// stale decision: otherwise one collapse made while browsing would veto every
+// later search for that database, leaving the row listed as a match with its
+// matches missing, and silently, because the filter still looks like it ran.
+// `expandDatabase: false` is not an instruction at all, only the absence of
+// one — the query matched the database's name and said nothing about its
+// tables — so it has nothing to say against a row the user opened themselves.
+// Merging the two with `||` instead — the original bug — made a click on a
+// forced-open row unrepresentable: it flipped a bit nothing read, so it moved
+// nothing.
 function isRowExpanded(
+  expansion: DatabaseExpansion | undefined,
   searchMatch: DatabaseMatch | undefined,
-  isExpanded: boolean
+  searchQuery: string
 ): boolean {
-  return searchMatch ? searchMatch.expandDatabase || isExpanded : isExpanded
+  const expandedByUser = expansion?.isExpanded ?? false
+
+  // No test can tell this branch from the fall-through below, because callers
+  // pass no match while not searching, and that path lands on the same value.
+  // It stays because it makes the rule true here rather than true by a
+  // caller's habit: if a match ever outlived its query, the fall-through would
+  // start consulting a proposal for a search that is no longer running.
+  if (searchQuery.length === 0) {
+    return expandedByUser
+  }
+
+  if (expansion?.query === searchQuery) {
+    return expandedByUser
+  }
+
+  return searchMatch?.expandDatabase === true ? true : expandedByUser
 }
 
 function DatabaseRow({
   database,
   dropIndicator,
+  expansion,
   hasMultipleSchemas,
-  isExpanded,
   isSortingDisabled,
   onDelete,
   onEdit,
-  searchMatch
+  searchMatch,
+  searchQuery
 }: DatabaseRowProps): ReactElement {
-  const isDatabaseExpanded = isRowExpanded(searchMatch, isExpanded)
+  const dispatch = useAppDispatch()
+
+  const isDatabaseExpanded = isRowExpanded(expansion, searchMatch, searchQuery)
+
+  // Stamped with the query it answers, and derived from the resolved state —
+  // what the user is actually looking at — so the write always matches what
+  // they just clicked.
+  const handleToggle = useCallback(() => {
+    dispatch(
+      setDatabaseExpanded({
+        databaseId: database.id,
+        isExpanded: !isDatabaseExpanded,
+        query: searchQuery
+      })
+    )
+  }, [database.id, dispatch, isDatabaseExpanded, searchQuery])
 
   const {
     attributes,
@@ -402,6 +465,7 @@ function DatabaseRow({
         sortableProps={isSortingDisabled ? {} : { ...attributes, ...listeners }}
         onDelete={onDelete}
         onEdit={onEdit}
+        onToggle={handleToggle}
       />
 
       {isDatabaseExpanded && (
@@ -420,6 +484,7 @@ interface DatabaseRowHeaderProps {
   isExpanded: boolean
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
+  onToggle: () => void
   sortableProps: Record<string, unknown>
 }
 
@@ -428,18 +493,18 @@ function DatabaseRowHeader({
   isExpanded,
   onDelete,
   onEdit,
+  onToggle,
   sortableProps
 }: DatabaseRowHeaderProps): ReactElement {
-  const dispatch = useAppDispatch()
-
   return (
     <ContextMenu>
       <ContextMenuTrigger>
         <button
           {...sortableProps}
+          aria-expanded={isExpanded}
           className="flex h-[var(--item-h)] w-full cursor-default items-center gap-[6px] rounded-[6px] px-[6px] text-left text-text2 hover:bg-hover"
           type="button"
-          onClick={() => dispatch(expandDatabase(database.id))}
+          onClick={onToggle}
         >
           <ChevronRight
             className={cn(
@@ -545,6 +610,7 @@ function DatabaseTableRow({
       <ContextMenu>
         <ContextMenuTrigger>
           <button
+            aria-expanded={isExpanded}
             className="flex h-[26px] w-full cursor-default items-center gap-[6px] rounded-[6px] pr-[6px] pl-5 text-left text-text2 hover:bg-hover"
             type="button"
             onClick={onToggle}

--- a/src/app/store/database-explorer-slice.test.ts
+++ b/src/app/store/database-explorer-slice.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import reducer, {
   DatabaseExplorerState,
-  expandDatabase,
-  expandTable
+  expandTable,
+  setDatabaseExpanded
 } from './database-explorer-slice'
 
 describe('databaseExplorerSlice', () => {
@@ -12,38 +12,121 @@ describe('databaseExplorerSlice', () => {
     expandedTables: {}
   }
 
-  describe('expandDatabase', () => {
-    it('should set database as expanded when not expanded', () => {
-      const state = reducer(initialState, expandDatabase('db-123'))
+  describe('setDatabaseExpanded', () => {
+    it('should record an explicit expand for a database with no entry', () => {
+      const state = reducer(
+        initialState,
+        setDatabaseExpanded({
+          databaseId: 'db-123',
+          isExpanded: true,
+          query: ''
+        })
+      )
 
-      expect(state.expandedDatabases).toEqual({ 'db-123': true })
+      expect(state.expandedDatabases).toEqual({
+        'db-123': { isExpanded: true, query: '' }
+      })
     })
 
-    it('should toggle database to collapsed when already expanded', () => {
+    it('should record an explicit collapse for a database with no entry', () => {
+      const state = reducer(
+        initialState,
+        setDatabaseExpanded({
+          databaseId: 'db-123',
+          isExpanded: false,
+          query: ''
+        })
+      )
+
+      // Absent means "follow the search"; a stored collapse is the user saying
+      // no, so the two must stay distinguishable.
+      expect(state.expandedDatabases).toEqual({
+        'db-123': { isExpanded: false, query: '' }
+      })
+    })
+
+    it('should stamp the query the decision was made under', () => {
+      const state = reducer(
+        initialState,
+        setDatabaseExpanded({
+          databaseId: 'db-123',
+          isExpanded: false,
+          query: 'user'
+        })
+      )
+
+      expect(state.expandedDatabases).toEqual({
+        'db-123': { isExpanded: false, query: 'user' }
+      })
+    })
+
+    it('should overwrite a stored expand with a collapse', () => {
       const expandedState: DatabaseExplorerState = {
-        expandedDatabases: { 'db-123': true },
+        expandedDatabases: { 'db-123': { isExpanded: true, query: '' } },
         expandedTables: {}
       }
 
-      const state = reducer(expandedState, expandDatabase('db-123'))
+      const state = reducer(
+        expandedState,
+        setDatabaseExpanded({
+          databaseId: 'db-123',
+          isExpanded: false,
+          query: ''
+        })
+      )
 
-      expect(state.expandedDatabases).toEqual({ 'db-123': false })
+      expect(state.expandedDatabases).toEqual({
+        'db-123': { isExpanded: false, query: '' }
+      })
+    })
+
+    it('should overwrite a stored collapse with an expand', () => {
+      const collapsedState: DatabaseExplorerState = {
+        expandedDatabases: { 'db-123': { isExpanded: false, query: 'user' } },
+        expandedTables: {}
+      }
+
+      const state = reducer(
+        collapsedState,
+        setDatabaseExpanded({
+          databaseId: 'db-123',
+          isExpanded: true,
+          query: 'user'
+        })
+      )
+
+      expect(state.expandedDatabases).toEqual({
+        'db-123': { isExpanded: true, query: 'user' }
+      })
     })
 
     it('should handle multiple databases independently', () => {
-      let state = reducer(initialState, expandDatabase('db-1'))
-      state = reducer(state, expandDatabase('db-2'))
+      let state = reducer(
+        initialState,
+        setDatabaseExpanded({ databaseId: 'db-1', isExpanded: true, query: '' })
+      )
+      state = reducer(
+        state,
+        setDatabaseExpanded({ databaseId: 'db-2', isExpanded: true, query: '' })
+      )
 
       expect(state.expandedDatabases).toEqual({
-        'db-1': true,
-        'db-2': true
+        'db-1': { isExpanded: true, query: '' },
+        'db-2': { isExpanded: true, query: '' }
       })
 
-      state = reducer(state, expandDatabase('db-1'))
+      state = reducer(
+        state,
+        setDatabaseExpanded({
+          databaseId: 'db-1',
+          isExpanded: false,
+          query: ''
+        })
+      )
 
       expect(state.expandedDatabases).toEqual({
-        'db-1': false,
-        'db-2': true
+        'db-1': { isExpanded: false, query: '' },
+        'db-2': { isExpanded: true, query: '' }
       })
     })
   })

--- a/src/app/store/database-explorer-slice.ts
+++ b/src/app/store/database-explorer-slice.ts
@@ -1,7 +1,25 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
+/** One database's expansion, plus the context the user decided it in. */
+export interface DatabaseExpansion {
+  isExpanded: boolean
+  /**
+   * The normalized search query that was active when the user clicked, or `''`
+   * when they were browsing the unfiltered tree. A decision only speaks for
+   * the question it answered: while a different query is active, the search's
+   * own proposal wins instead. Stamping the query rather than clearing stale
+   * entries on every keystroke keeps this slice independent of the editor
+   * slice, and means a decision survives round-tripping back to its query.
+   */
+  query: string
+}
+
 export interface DatabaseExplorerState {
-  expandedDatabases: Record<string, boolean>
+  // Absent means the user has never decided for this database, so the search
+  // decides. A stored entry is their own decision, scoped to `query`. A future
+  // "collapse all" therefore has to write an entry per database rather than
+  // delete the keys — deleting them would hand every row back to the search.
+  expandedDatabases: Record<string, DatabaseExpansion | undefined>
   expandedTables: Record<string, boolean>
 }
 
@@ -14,19 +32,37 @@ const databaseExplorerSlice = createSlice({
   name: 'databaseExplorer',
   initialState,
   reducers: {
-    expandDatabase: (state, action: PayloadAction<string>) => {
-      const databaseId = action.payload
-
-      state.expandedDatabases[databaseId] = !state.expandedDatabases[databaseId]
-    },
+    // Deliberately a plain toggle, unlike `setDatabaseExpanded` below: nothing
+    // ever forces a table open, because matching is on database and table
+    // names only and never column names (see `computeDatabaseMatch`), so a
+    // table row's rendered state is always the stored one and flipping it is
+    // safe. If matching ever reaches columns, search would want to force
+    // tables open too and this toggle would reproduce the swallowed click of
+    // #61 one level down — it would then need the same query-scoped treatment.
     expandTable: (state, action: PayloadAction<string>) => {
       const tableKey = action.payload
 
       state.expandedTables[tableKey] = !state.expandedTables[tableKey]
+    },
+    // Writes the value the caller means rather than flipping the stored one.
+    // While a search forces a row open, the stored value and what the user
+    // sees can differ, so a blind flip would move a bit nobody is looking at.
+    setDatabaseExpanded: (
+      state,
+      action: PayloadAction<{
+        databaseId: string
+        isExpanded: boolean
+        query: string
+      }>
+    ) => {
+      const { databaseId, isExpanded, query } = action.payload
+
+      state.expandedDatabases[databaseId] = { isExpanded, query }
     }
   }
 })
 
-export const { expandDatabase, expandTable } = databaseExplorerSlice.actions
+export const { expandTable, setDatabaseExpanded } =
+  databaseExplorerSlice.actions
 
 export default databaseExplorerSlice.reducer


### PR DESCRIPTION
Closes #61.

## The bug

Clicking a database header while a search was active did nothing visible.

Type `user` in the explorer filter. Database `shop` has a table `users`, so the search forces the row open. Click the `shop` header to collapse it — the row does not move. The click *did* dispatch, flipping a stored bit nothing was reading, so clearing the search showed the row **open**, even though the user's last interaction was an attempt to close it, and it then took two more clicks to close.

Expansion was stored in one place and decided in another, merged with `||`:

```ts
return searchMatch ? searchMatch.expandDatabase || isExpanded : isExpanded
```

`||` cannot express "the user overrode the search's proposal", so while `expandDatabase` was true the user's intent was unrepresentable. The stored map was also flattened with `Boolean(...)` before it reached the row, collapsing "absent" and "explicitly false" into one value, and the action was an unconditional toggle.

## The fix

The stored value becomes a decision *stamped with the query it answers* — `{ isExpanded, query }` — and the action writes what the caller means instead of flipping what is stored:

```ts
const expandedByUser = expansion?.isExpanded ?? false

if (searchQuery.length === 0) { return expandedByUser }
if (expansion?.query === searchQuery) { return expandedByUser }

return searchMatch?.expandDatabase === true ? true : expandedByUser
```

The header writes `!isDatabaseExpanded` from the **resolved** value — what the user is actually looking at — so the write always matches what they clicked.

| situation | result |
|---|---|
| not searching | the user's stored bit, absent → collapsed |
| searching, decision made under **this** query | what they decided |
| searching, stale decision, **table** match | open — the match wins |
| searching, stale decision, **name-only** match | the user's stored bit |

## Why the decision is scoped to its query

A first pass stored a plain three-state and resolved `expandedByUser ?? searchMatch?.expandDatabase ?? false`. That let one collapse click veto *every* later search, permanently — and the failure was silent, which is worse than the bug being fixed: the row still appeared in the filtered list, so the filter looked like it ran; the matching tables were simply absent.

It did not even need a search to trigger. Expand a database while browsing, collapse it, then type a filter matching one of its tables — `main` shows the matches, that version hid them. `expand → browse → collapse` is the ordinary browsing loop.

The two directions are deliberately **not** symmetric. `expandDatabase: true` (a table matched) is an active instruction to reveal matches, so it beats a stale decision. `expandDatabase: false` (only the database name matched) is merely the absence of an instruction, so the user's own expand survives it — which is what issue #61 asks for and what `database-explorer-search.ts` already assumes when it keeps the full table list on that branch.

## Also

- `expandDatabase` → **`setDatabaseExpanded`**. An action named "expand" that collapses is a self-contradicting sentence, in the one file whose entire bug history is people misreading what the stored bit means. Nothing switches on the action type and the slice is not persisted, so the rename is mechanical.
- `expandTable` stays a toggle — table rows are never force-expanded — with a comment recording why the two shapes differ, and what would have to change if matching ever reached column names.
- `aria-expanded` on the database header and the table row. The chevron rotation was the only expansion signal.

## Tests

The defect was entirely uncovered: 18 tests existed and none clicked a header while a search was active.

Each branch of the rule is mutation-checked — dropping the query scoping fails 3 tests, removing the table-match win fails 5, and both fallback mutations fail 1 each. One branch is provably unpinnable, because callers pass no match while not searching so it lands on the same value as the fall-through; rather than manufacture a test that fakes a pin, it carries a comment explaining why it stays.

`896` tests pass; typecheck, lint, prettier, and Fallow are clean.

## Visible change

Clicking a search-forced row now actually collapses it, and a decision made under one query no longer governs a different one.