### PR TITLE
fix(ui): keep the window controls reachable behind first-run screens

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,5 +1,6 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { ReactElement } from 'react'
+import invariant from 'tiny-invariant'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DatabaseDto } from '@/glue/databases'
@@ -205,6 +206,51 @@ describe('running a query', () => {
   })
 })
 
+// `title-bar` is the class `index.css` hangs `-webkit-app-region: no-drag` off,
+// so it is a contract rather than a styling detail.
+function getTitleBar(): HTMLElement {
+  const titleBar = document.querySelector<HTMLElement>('.title-bar')
+
+  invariant(titleBar, 'The title bar is not in the document.')
+
+  return titleBar
+}
+
+// The single slot every screen shares, found by where it sits rather than by
+// what it is called: the element directly after the title bar.
+function getScreenSlot(): HTMLElement {
+  const slot = getTitleBar().nextElementSibling
+
+  invariant(
+    slot instanceof HTMLElement,
+    'Nothing follows the title bar, so there is no screen slot.'
+  )
+
+  return slot
+}
+
+/**
+ * What issue #60 is actually about: the title bar is painted above `element`
+ * and cannot be covered by it. Two separate things make that true, and both are
+ * asserted because either can be deleted without the other noticing.
+ *
+ * - `element` lives in the slot that follows the title bar, so it cannot reach
+ *   the title bar through the flow. A `fixed inset-0` screen — what #60 was —
+ *   fails this.
+ * - That slot is a positioned containing block, so an `absolute inset-0` child
+ *   of it cannot reach the title bar around the flow either. This is a class
+ *   check only because jsdom loads no CSS, which leaves `position` unobservable
+ *   any other way; without it, dropping `relative` from the slot silently
+ *   reopens #60 for the editor screen.
+ */
+function expectTitleBarAbove(element: HTMLElement): void {
+  const slot = getScreenSlot()
+
+  expect(getTitleBar().contains(element)).toEqual(false)
+  expect(slot.contains(element)).toEqual(true)
+  expect(slot).toHaveClass('relative')
+}
+
 describe('App', () => {
   it('shows the getting started screen when there are no databases', () => {
     renderWithProviders(<App />, { databases: [], queries: [], worksheets: [] })
@@ -245,5 +291,88 @@ describe('App', () => {
 
     expect(screen.getByText('Connect a database')).toBeInTheDocument()
     expect(screen.queryByText('Welcome to Squeal')).not.toBeInTheDocument()
+  })
+
+  // The window is frameless, so the title bar is the only minimize, maximize,
+  // close and drag region Windows and Linux have. A first-run screen that
+  // covers it leaves the window unmovable and unclosable.
+  it('leaves the window controls uncovered while the getting started screen shows', () => {
+    renderWithProviders(<App />, { databases: [], queries: [], worksheets: [] })
+
+    // Scoped to the title bar because the getting started screen has an X of
+    // its own with the same accessible name.
+    const windowControls = within(getTitleBar())
+
+    expect(
+      windowControls.getByRole('button', { name: 'Close' })
+    ).toBeInTheDocument()
+    expect(
+      windowControls.getByRole('button', { name: 'Maximize' })
+    ).toBeInTheDocument()
+    expect(
+      windowControls.getByRole('button', { name: 'Minimize' })
+    ).toBeInTheDocument()
+
+    expectTitleBarAbove(screen.getByText('Connect a database'))
+  })
+
+  // The editor screen's scrim is translucent, so it left the title bar visible
+  // but unclickable and its drag region dead — the same defect, harder to see.
+  it('leaves the window controls uncovered while the editor screen shows', () => {
+    renderWithProviders(<App />, {
+      databases: [testDatabase],
+      queries: [],
+      ui: { editorScreen: { databaseId: 'database-1', type: 'edit-database' } },
+      worksheets: []
+    })
+
+    expect(
+      within(getTitleBar()).getByRole('button', { name: 'Close' })
+    ).toBeInTheDocument()
+
+    expectTitleBarAbove(screen.getByText('Edit database'))
+  })
+
+  // Every workspace hook and poller used to run behind an opaque first-run
+  // screen, keyboard-reachable with nothing trapping focus.
+  it('does not mount the workspace behind the getting started screen', () => {
+    renderWithProviders(<App />, { databases: [], queries: [], worksheets: [] })
+
+    expect(screen.getByText('Connect a database')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Resize sidebar')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Open traces')).not.toBeInTheDocument()
+  })
+
+  // A stored editor screen and a first run were both representable at once,
+  // which stacked two panels with two live connection forms in them.
+  it('shows a single add-database form when the editor screen is open on first run', () => {
+    renderWithProviders(<App />, {
+      databases: [],
+      queries: [],
+      ui: { editorScreen: { type: 'create-database' } },
+      worksheets: []
+    })
+
+    expect(screen.getByText('Connect a database')).toBeInTheDocument()
+    expect(screen.queryByText('Add database')).not.toBeInTheDocument()
+    expect(screen.getAllByLabelText('Name')).toHaveLength(1)
+  })
+
+  // Reachable: delete the last connection while its "Add database" modal is
+  // open, and the first-run screen takes the slot with the modal still stored.
+  // Leaving the screen then popped a modal nobody asked for.
+  it('drops a stale editor screen while the getting started screen shows', () => {
+    const { store } = renderWithProviders(<App />, {
+      databases: [],
+      queries: [],
+      ui: { editorScreen: { type: 'create-database' } },
+      worksheets: []
+    })
+
+    expect(store.getState().ui.editorScreen).toBeUndefined()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }))
+
+    expect(screen.queryByText('Add database')).not.toBeInTheDocument()
   })
 })

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,6 +3,7 @@ import {
   ReactElement,
   Suspense,
   useCallback,
+  useEffect,
   useMemo,
   useState
 } from 'react'
@@ -27,8 +28,9 @@ import { useCancelQuery } from './hooks/mutations'
 import { useStartQuery } from './hooks/use-start-query'
 import { useWorksheetAutosave } from './hooks/useWorksheetAutosave'
 import type { QueryDto } from '@/glue/api/schemas'
-import { useAppSelector } from './store'
+import { useAppDispatch, useAppSelector } from './store'
 import { selectActiveWorksheetId } from './store/tabs-slice'
+import { uiActions } from './store/ui-slice'
 import { createAstFromSql, type Statement } from './sql-parser'
 import { findActiveStatementIndex } from './sql-parser/active-statement'
 import {
@@ -213,7 +215,6 @@ export function useWorksheetSession(openWorksheetId: string | undefined) {
     handleCancelQuery,
     handleRunQuery,
     handleUpdateContent,
-    hasDatabases: databases.data.length > 0,
     isCancelPending,
     isQueryRunning: Boolean(query && !query.finishedAt),
     query,
@@ -224,97 +225,58 @@ export function useWorksheetSession(openWorksheetId: string | undefined) {
 }
 
 export function App(): ReactElement {
-  const openWorksheetId = useAppSelector(selectActiveWorksheetId)
+  const dispatch = useAppDispatch()
   const editorScreen = useAppSelector((state) => state.ui.editorScreen)
   const gettingStartedDismissed = useAppSelector(
     (state) => state.ui.gettingStartedDismissed
   )
 
-  const [cursorPosition, setCursorPosition] = useState<CursorPosition>()
-
-  const {
-    activeStatement,
-    activeStatementIndex,
-    content,
-    currentDatabase,
-    currentWorksheet,
-    handleCancelQuery,
-    handleRunQuery,
-    handleUpdateContent,
-    hasDatabases,
-    isCancelPending,
-    isQueryRunning,
-    query,
-    saveState,
-    setCursorOffset,
-    statements
-  } = useWorksheetSession(openWorksheetId)
+  // Read here rather than taken from the worksheet session, so the choice of
+  // screen is made before anything the workspace needs is set up. The
+  // collections are already hydrated by AppShell, so this is a cache read.
+  const databases = useDatabases()
 
   // Dismissible so an empty app is not a dead end. Saving a connection hides it
   // for good, and the sidebar's add button reaches the same form afterwards.
-  const showGettingStartedScreen = !hasDatabases && !gettingStartedDismissed
+  const showGettingStartedScreen =
+    databases.data.length === 0 && !gettingStartedDismissed
+
+  // The first-run screen owns the slot, so an editor screen that was already
+  // open when it took over has nowhere to render — deleting the last connection
+  // while its "Add database" form is up gets there. Dropped rather than parked,
+  // because otherwise it pops unasked the moment the screen is left.
+  useEffect(() => {
+    if (showGettingStartedScreen && editorScreen) {
+      dispatch(uiActions.closeEditorScreen())
+    }
+  }, [dispatch, editorScreen, showGettingStartedScreen])
 
   return (
     <main className="w-full h-screen flex flex-col bg-panel2 overflow-hidden text-sm">
-      {showGettingStartedScreen && <GettingStartedScreen />}
-
-      {editorScreen && (
-        <EditorScreen
-          databaseId={editorScreen.databaseId}
-          mode={editorScreen.type === 'create-database' ? 'create' : 'edit'}
-        />
-      )}
-
+      {/* Mounted once, above the slot, and nothing the slot holds can cover it:
+          the window is frameless, so this is the only drag region and the only
+          minimize, maximize and close buttons Windows and Linux get. Not an
+          app-wide promise — the trace dashboard mounts outside App entirely and
+          does overlap the bottom of these buttons. */}
       <TitleBar />
 
-      <div className="flex-1 min-h-0 flex">
-        <AppSidebar />
+      <div className="relative flex-1 min-h-0 flex flex-col">
+        {showGettingStartedScreen ? (
+          <GettingStartedScreen />
+        ) : (
+          <>
+            <Workspace />
 
-        <div className="flex-1 min-w-0 min-h-0 flex flex-col">
-          <WorksheetTabs />
-
-          <WorksheetToolbar
-            activeStatement={activeStatement}
-            isCancelPending={isCancelPending}
-            isQueryRunning={isQueryRunning}
-            onCancelQuery={handleCancelQuery}
-            onRunQuery={handleRunQuery}
-          />
-
-          <div className="flex-1 min-h-0 bg-panel">
-            {currentWorksheet ? (
-              <Suspense fallback={null}>
-                <WorksheetEditor
-                  activeStatementIndex={activeStatementIndex}
-                  content={content}
-                  databaseType={currentDatabase?.type}
-                  statements={statements}
-                  onChange={handleUpdateContent}
-                  onCursorChange={setCursorPosition}
-                  onCursorPositionChange={setCursorOffset}
-                  onRunQuery={handleRunQuery}
-                />
-              </Suspense>
-            ) : (
-              <NoWorksheetOpen />
+            {editorScreen && (
+              <EditorScreen
+                databaseId={editorScreen.databaseId}
+                mode={
+                  editorScreen.type === 'create-database' ? 'create' : 'edit'
+                }
+              />
             )}
-          </div>
-
-          <ResultsPane
-            databaseName={currentDatabase?.name}
-            isQueryRunning={isQueryRunning}
-            query={query}
-            worksheetId={openWorksheetId}
-          />
-
-          <StatusBar
-            cursorPosition={cursorPosition}
-            databaseId={currentWorksheet?.databaseId ?? undefined}
-            databaseName={currentDatabase?.name}
-            query={query}
-            saveState={saveState}
-          />
-        </div>
+          </>
+        )}
       </div>
     </main>
   )
@@ -328,6 +290,86 @@ function NoWorksheetOpen(): ReactElement {
       <p className="text-[12px] text-text3">
         Create a worksheet or pick one from the sidebar.
       </p>
+    </div>
+  )
+}
+
+/**
+ * The app itself: sidebar, tabs, editor, results and status bar. Kept out of
+ * `App` so it — and every hook and poller it owns — only mounts once the user
+ * is past the first-run screen, rather than running behind it.
+ */
+function Workspace(): ReactElement {
+  const openWorksheetId = useAppSelector(selectActiveWorksheetId)
+
+  const [cursorPosition, setCursorPosition] = useState<CursorPosition>()
+
+  const {
+    activeStatement,
+    activeStatementIndex,
+    content,
+    currentDatabase,
+    currentWorksheet,
+    handleCancelQuery,
+    handleRunQuery,
+    handleUpdateContent,
+    isCancelPending,
+    isQueryRunning,
+    query,
+    saveState,
+    setCursorOffset,
+    statements
+  } = useWorksheetSession(openWorksheetId)
+
+  return (
+    <div className="flex-1 min-h-0 flex">
+      <AppSidebar />
+
+      <div className="flex-1 min-w-0 min-h-0 flex flex-col">
+        <WorksheetTabs />
+
+        <WorksheetToolbar
+          activeStatement={activeStatement}
+          isCancelPending={isCancelPending}
+          isQueryRunning={isQueryRunning}
+          onCancelQuery={handleCancelQuery}
+          onRunQuery={handleRunQuery}
+        />
+
+        <div className="flex-1 min-h-0 bg-panel">
+          {currentWorksheet ? (
+            <Suspense fallback={null}>
+              <WorksheetEditor
+                activeStatementIndex={activeStatementIndex}
+                content={content}
+                databaseType={currentDatabase?.type}
+                statements={statements}
+                onChange={handleUpdateContent}
+                onCursorChange={setCursorPosition}
+                onCursorPositionChange={setCursorOffset}
+                onRunQuery={handleRunQuery}
+              />
+            </Suspense>
+          ) : (
+            <NoWorksheetOpen />
+          )}
+        </div>
+
+        <ResultsPane
+          databaseName={currentDatabase?.name}
+          isQueryRunning={isQueryRunning}
+          query={query}
+          worksheetId={openWorksheetId}
+        />
+
+        <StatusBar
+          cursorPosition={cursorPosition}
+          databaseId={currentWorksheet?.databaseId ?? undefined}
+          databaseName={currentDatabase?.name}
+          query={query}
+          saveState={saveState}
+        />
+      </div>
     </div>
   )
 }

--- a/src/app/components/EditorScreen.tsx
+++ b/src/app/components/EditorScreen.tsx
@@ -55,7 +55,7 @@ export function EditorScreen({
 
   if (mode === 'edit' && !database) {
     return (
-      <div className="fixed inset-0 z-100 bg-bg/70 flex justify-center items-center">
+      <div className="absolute inset-0 z-100 bg-bg/70 flex justify-center items-center">
         <div className="rounded-md border border-border bg-panel px-6 py-5 text-text2 shadow-[0_8px_24px_rgba(0,0,0,0.14)]">
           Database not found.
         </div>
@@ -79,9 +79,17 @@ export function EditorScreen({
       }
     : undefined
 
+  // Absolute rather than fixed, so it covers the screen slot App gives it and
+  // not the title bar above it — the frameless window has no other close button
+  // and no other drag region.
+  //
+  // Centered by an auto margin on the card rather than by `items-center`,
+  // because centering something taller than its scroller splits the overflow
+  // across both edges, and `scrollTop` cannot go negative — the top of the form
+  // is then unreachable on a short window.
   return (
-    <div className="fixed inset-0 z-100 bg-bg/70 flex justify-center items-center overflow-y-auto py-10">
-      <div className="w-full max-w-md flex flex-col gap-6 rounded-md border border-border bg-panel p-6 shadow-[0_8px_24px_rgba(0,0,0,0.14)]">
+    <div className="absolute inset-0 z-100 bg-bg/70 flex justify-center items-start overflow-y-auto py-10">
+      <div className="w-full max-w-md my-auto flex flex-col gap-6 rounded-md border border-border bg-panel p-6 shadow-[0_8px_24px_rgba(0,0,0,0.14)]">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">{title}</h1>
 

--- a/src/app/components/GettingStartedScreen.tsx
+++ b/src/app/components/GettingStartedScreen.tsx
@@ -13,8 +13,18 @@ export function GettingStartedScreen(): ReactElement {
     dispatch(uiActions.dismissGettingStarted())
   }
 
+  // Fills the screen slot below the title bar rather than the viewport: the
+  // window is frameless, so covering the title bar would leave Windows and
+  // Linux users with no drag region and no close button while the app is
+  // deliberately unusable.
+  //
+  // Centered by an auto margin on the child rather than by `items-center`,
+  // because centering something taller than its scroller splits the overflow
+  // across both edges, and `scrollTop` cannot go negative — everything above
+  // the scroll origin is then unreachable. Auto margins collapse to zero once
+  // the free space is gone, so all of the overflow lands below instead.
   return (
-    <div className="fixed inset-0 z-100 bg-panel2 flex justify-center items-center overflow-y-auto py-10">
+    <div className="relative flex-1 min-h-0 bg-panel2 flex justify-center items-start overflow-y-auto py-10">
       {/* Both ways out of a screen that is otherwise a dead end until a
           connection is saved: the X for someone who just wants to look around,
           and the link below the form for anyone reading top to bottom. */}
@@ -28,7 +38,7 @@ export function GettingStartedScreen(): ReactElement {
         <XIcon className="size-4" />
       </Button>
 
-      <div className="w-full max-w-md flex flex-col gap-6 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:duration-500">
+      <div className="w-full max-w-md my-auto flex flex-col gap-6 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:duration-500">
         <div>
           <div className="text-lg font-bold tracking-tight text-accent mb-3">
             Squeal


### PR DESCRIPTION
Closes #60.

## The bug

**On Windows and Linux, while the getting-started screen or the add/edit-database screen was up, there was no minimize, maximize, close, or drag region at all.** First run meant a window that could not be moved or closed until the screen was dismissed.

The window is frameless — `frame: false`, `titleBarStyle: 'hidden'`, no `titleBarOverlay` — so `TitleBar` is the only source of both the drag region and the window buttons. macOS escapes because its traffic lights are drawn natively above web content.

Both screens rendered *as well as* the chrome, not instead of it: `GettingStartedScreen` and both `EditorScreen` branches were `fixed inset-0 z-100`, while `TitleBar` had `relative` and no z-index — and `relative` with `z-auto` creates no stacking context, so DOM order could not save it. The editor scrim is translucent, so there the title bar was *visible but not clickable*, which is the subtler half.

This invariant was already written down, in `SecretStorageConsentScreen`:

> A view rather than a `fixed inset-0` overlay: the window is frameless, so covering TitleBar would leave Windows and Linux users with no drag region and no close button while the app is deliberately unusable.

`App` did not honour it.

## The fix

`TitleBar` is mounted once, above one screen slot:

```tsx
<TitleBar />
<div className="relative flex-1 min-h-0 flex flex-col">
  {showGettingStartedScreen ? <GettingStartedScreen /> : (<><Workspace />{editorScreen && <EditorScreen … />}</>)}
</div>
```

The workspace moved into a `Workspace` component, so it — and every hook and poller it owns — only mounts once the user is past the first-run screen, rather than running behind an opaque one, keyboard-reachable with no focus trap. `hasDatabases` is now read directly in `App` (a cache read against the collection `AppShell` already hydrated — verified as exactly one `GET /databases` per reload) instead of coming back from `useWorksheetSession`, so the choice of screen is made before anything the workspace needs is set up.

`showGettingStartedScreen && editorScreen` also stops being representable, so two stacked panels with two mounted `DatabaseForm`s can no longer happen.

## The regression this fix introduced, and closed

Shrinking the slot by the title bar's 40px broke the first screen every new user sees.

Both screens were `items-center` with `overflow-y-auto`. When content is taller than the box, centring pushes the top above the scroll origin where `scrollTop` cannot reach — so **20px more became unreachable at every window size**. Measured live, getting-started at `scrollTop: 0`:

| build | window | unreachable above |
|---|---|---|
| `main` | 1300×500 | 159px |
| first pass at this fix | 1300×500 | **179px** |
| this PR | 1300×500 | **0** |

At 1300×500 that meant the heading, intro copy, the PostgreSQL/MySQL/**SQLite** type selector and "Have a connection string?" were all unreachable — a first-run user on a short window could not select SQLite.

Fixed with `items-start` plus `my-auto` on the child: auto margins centre when there is free space and collapse to zero when there is not, so overflow can only go downward. Verified doing real work rather than silently behaving like `items-start` — 219px computed margins at a 1400px-tall window, 0 at 880 and 500.

## Tests

The first version of these tests asserted a Tailwind class string, `closest('.fixed')`. That has a proven blind spot: injecting `<div class="absolute inset-0 z-100">` into the running app covers the title bar while the assertion returns null and the suite stays green. The whole `EditorScreen` half of the fix also rested on the single word `relative`, which nothing asserted at all.

Replaced with a structural check that finds the slot by position rather than by name — the element after the title bar — and asserts the screen is inside it and not inside the title bar, plus the containing-block contract. Both paths are covered.

- fails on `main`: 5 tests
- fails when `relative` is deleted from the slot: 2 tests

Also added: the workspace does not mount behind the first-run screen; only one add-database surface renders when both states are set; and a stale `editorScreen` is cleared *while* the first-run screen is up rather than on dismissal — saving the first connection is the other exit, and it would otherwise pop an unasked "Add database" modal.

`894` tests pass; typecheck, lint, prettier, and Fallow are clean.

## Verified in a real window

Driven over CDP with `navigator.platform` forced to `Win32` so the window buttons render, against a fresh first-run database. At both 1300×880 and 1300×500: every probe across the 40px band hit-tests to the title bar, Close/Maximize/Minimize are each topmost, and the add-database modal measures `{top: 40, height: 840}` — it stops at the bar.

The comment on `TitleBar` claims only what this slot can deliver. The trace dashboard mounts outside `App` and does overlap the bottom of these buttons; that is untouched and out of scope.