### PR TITLE
feat(explorer): refresh the database tree without restarting

### DIFF
--- a/.agents/friction-log/20260817182013-electron-s-default/friction.md
+++ b/.agents/friction-log/20260817182013-electron-s-default/friction.md
@@ -1,0 +1,39 @@
+---
+title: 'Electron''s default menu owns ⌘R and ⌘⇧R, so renderer refresh shortcuts silently reload the window'
+severity: 'minor'
+---
+
+### Expected Behavior
+
+Binding an app shortcut like `mod+shift+r` in the renderer (react-hotkeys-hook)
+fires the app's own handler.
+
+### Current Behavior
+
+`src/main.ts` never calls `Menu.setApplicationMenu`, so Electron installs its
+default application menu. Its View submenu binds ⌘R to Reload and ⌘⇧R to Force
+Reload, and those accelerators win over anything the renderer registers — the
+whole window reloads instead. Nothing about the window suggests a menu exists:
+it is frameless with `titleBarStyle: 'hidden'`, and on macOS the menu bar is
+off-window entirely.
+
+The obvious fix — `Menu.setApplicationMenu(null)` — is worse on macOS: the
+standard Edit menu is what supplies ⌘C/⌘V/⌘X/⌘A/⌘Z to the renderer, so removing
+the menu breaks copy and paste app-wide.
+
+### Possible Solution
+
+Either document the reserved accelerators next to the hotkeys we do register, or
+install a trimmed custom menu (keep the Edit roles, drop Reload and Force
+Reload) so the renderer can own ⌘R the way other database clients do.
+
+### Minimal Reproducible Example
+
+1. `useHotkeys('mod+shift+r', handler)` anywhere in `src/app`.
+2. `yarn start`, press ⌘⇧R.
+3. The renderer reloads; `handler` never runs.
+
+### Context
+
+Hit while adding the Databases refresh button. Cost a design round-trip: the
+shortcut had to move to ⌘⌥R, which is not what anyone reaches for to refresh.

--- a/.agents/friction-log/20260817182013-electron-s-default/friction.md
+++ b/.agents/friction-log/20260817182013-electron-s-default/friction.md
@@ -1,5 +1,7 @@
 ---
-title: 'Electron''s default menu owns ⌘R and ⌘⇧R, so renderer refresh shortcuts silently reload the window'
+title:
+  "Electron's default menu owns ⌘R and ⌘⇧R, so renderer refresh shortcuts
+  silently reload the window"
 severity: 'minor'
 ---
 

--- a/src/app/components/DatabaseExplorer.test.tsx
+++ b/src/app/components/DatabaseExplorer.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../api-client', () => ({
     createQuery: vi.fn(),
     createWorksheet: vi.fn(),
     deleteDatabase: vi.fn(),
+    getDatabaseSchema: vi.fn(),
     getDatabases: vi.fn(async () => []),
     getQueries: vi.fn(async () => []),
     getWorksheets: vi.fn(async () => []),
@@ -662,6 +663,125 @@ describe('DatabaseExplorer', () => {
 
     expect(store.getState().ui.editorScreen).toEqual({
       type: 'create-database'
+    })
+  })
+
+  describe('refreshing', () => {
+    const firstDatabase = { ...testDatabase, id: 'db-1', name: 'Production' }
+    const secondDatabase = { ...testDatabase, id: 'db-2', name: 'Staging' }
+    const bothDatabases = [firstDatabase, secondDatabase]
+
+    // Seeded caches are never stale (staleTime: Infinity), so nothing is
+    // fetched before the refresh and every recorded call belongs to it.
+    const seededOptions = {
+      databases: bothDatabases,
+      schemas: { 'db-1': testSchema, 'db-2': testSchema }
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      vi.mocked(apiClient.getDatabases).mockResolvedValue(bothDatabases)
+      vi.mocked(apiClient.getDatabaseSchema).mockResolvedValue(testSchema)
+    })
+
+    it('has no refresh button while there are no databases', () => {
+      renderWithProviders(<DatabaseExplorer />, { databases: [] })
+
+      expect(
+        screen.queryByRole('button', { name: 'Refresh databases' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('reloads the connection list and every schema from the header button', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<DatabaseExplorer />, seededOptions)
+
+      await user.click(
+        screen.getByRole('button', { name: 'Refresh databases' })
+      )
+
+      await waitFor(() => {
+        expect(apiClient.getDatabaseSchema).toHaveBeenCalledWith('db-1')
+      })
+
+      expect(apiClient.getDatabaseSchema).toHaveBeenCalledWith('db-2')
+      expect(apiClient.getDatabases).toHaveBeenCalled()
+    })
+
+    it('reloads every schema from the keyboard shortcut', async () => {
+      renderWithProviders(<DatabaseExplorer />, seededOptions)
+
+      // The matcher reads event.code, and `mod` accepts either meta or ctrl.
+      fireEvent.keyDown(document, {
+        altKey: true,
+        code: 'KeyR',
+        key: 'r',
+        metaKey: true
+      })
+
+      await waitFor(() => {
+        expect(apiClient.getDatabaseSchema).toHaveBeenCalledWith('db-1')
+      })
+
+      expect(apiClient.getDatabaseSchema).toHaveBeenCalledWith('db-2')
+    })
+
+    it('reloads one schema from the row context menu', async () => {
+      const user = userEvent.setup()
+
+      renderWithProviders(<DatabaseExplorer />, seededOptions)
+
+      fireEvent.contextMenu(screen.getByText('Staging'))
+
+      await user.click(await screen.findByRole('menuitem', { name: 'Refresh' }))
+
+      await waitFor(() => {
+        expect(apiClient.getDatabaseSchema).toHaveBeenCalledWith('db-2')
+      })
+
+      expect(apiClient.getDatabaseSchema).not.toHaveBeenCalledWith('db-1')
+    })
+
+    it('reports a refresh that failed', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(apiClient.getDatabaseSchema).mockRejectedValue(
+        new Error('Failed to load schema for "Staging": connection refused')
+      )
+
+      renderWithProviders(<DatabaseExplorer />, seededOptions)
+
+      await user.click(
+        screen.getByRole('button', { name: 'Refresh databases' })
+      )
+
+      expect(
+        await screen.findByText('Failed to refresh databases')
+      ).toBeVisible()
+      expect(
+        await screen.findByText(
+          'Failed to load schema for "Staging": connection refused'
+        )
+      ).toBeVisible()
+    })
+
+    it('names the database when a single-connection refresh fails', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(apiClient.getDatabaseSchema).mockRejectedValue(
+        new Error('Failed to load schema for "Staging": connection refused')
+      )
+
+      renderWithProviders(<DatabaseExplorer />, seededOptions)
+
+      fireEvent.contextMenu(screen.getByText('Staging'))
+
+      await user.click(await screen.findByRole('menuitem', { name: 'Refresh' }))
+
+      expect(
+        await screen.findByText('Failed to refresh "Staging"')
+      ).toBeVisible()
     })
   })
 })

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -138,8 +138,8 @@ function useConfirmedDatabaseDeletion(): (database: DatabaseDto) => void {
 
 interface DatabaseTreeRefresh {
   isRefreshing: boolean
-  /** One database, or every database when called with nothing. */
-  refresh: (database?: DatabaseDto) => void
+  refresh: (database: DatabaseDto) => void
+  refreshAll: () => void
 }
 
 // A refresh is the user asking to see the truth, so a failure has to say so
@@ -148,6 +148,11 @@ interface DatabaseTreeRefresh {
 // load schema for "Pagila": connection refused" — so the description carries
 // it. With several connections failing at once the first error speaks for all
 // of them; the ones that answered are updated either way.
+//
+// The shortcut lives here rather than in the component because it is the same
+// concern: refresh everything, from wherever the user is. Enabled on form tags
+// and content-editables so it still fires with focus in the filter input or the
+// SQL editor.
 function useRefreshDatabaseTree(): DatabaseTreeRefresh {
   const refreshDatabases = useRefreshDatabases()
 
@@ -173,7 +178,17 @@ function useRefreshDatabaseTree(): DatabaseTreeRefresh {
     [refreshDatabases]
   )
 
-  return { isRefreshing: refreshDatabases.isPending, refresh }
+  const refreshAll = useCallback(() => {
+    refresh()
+  }, [refresh])
+
+  useHotkeys('mod+alt+r', refreshAll, {
+    enableOnContentEditable: true,
+    enableOnFormTags: true,
+    preventDefault: true
+  })
+
+  return { isRefreshing: refreshDatabases.isPending, refresh, refreshAll }
 }
 
 // Opens a fresh worksheet querying the given table, marks it as the open, most
@@ -309,56 +324,16 @@ export function DatabaseExplorer(): ReactElement {
     dispatch(uiActions.openCreateDatabase())
   }, [dispatch])
 
-  const { isRefreshing, refresh } = useRefreshDatabaseTree()
-
-  const handleRefreshAll = useCallback(() => {
-    refresh()
-  }, [refresh])
-
-  // Enabled on form tags and content-editables so the shortcut still works with
-  // focus in the filter input or the SQL editor.
-  useHotkeys('mod+alt+r', handleRefreshAll, {
-    enableOnContentEditable: true,
-    enableOnFormTags: true,
-    preventDefault: true
-  })
+  const { isRefreshing, refresh, refreshAll } = useRefreshDatabaseTree()
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex flex-none items-center justify-between pt-[10px] pr-3 pb-2 pl-4">
-        <h2 className="text-[11px] font-semibold tracking-[0.08em] text-text3 uppercase">
-          Databases
-        </h2>
-
-        <div className="flex flex-none items-center gap-[2px]">
-          {/* Nothing to reload without a connection, and the empty state below
-              already carries its own call to action. */}
-          {databases.data.length > 0 && (
-            <button
-              aria-label="Refresh databases"
-              className="flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover disabled:opacity-50"
-              disabled={isRefreshing}
-              title={`Refresh databases (${getRefreshShortcut()})`}
-              type="button"
-              onClick={handleRefreshAll}
-            >
-              <RefreshCwIcon
-                className={cn('size-3', isRefreshing && 'animate-spin')}
-              />
-            </button>
-          )}
-
-          <button
-            aria-label="Add connection"
-            className="flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover"
-            title="Add connection"
-            type="button"
-            onClick={handleCreateDatabase}
-          >
-            <Plus className="size-3" />
-          </button>
-        </div>
-      </div>
+      <DatabaseExplorerHeader
+        hasDatabases={databases.data.length > 0}
+        isRefreshing={isRefreshing}
+        onCreate={handleCreateDatabase}
+        onRefresh={refreshAll}
+      />
 
       <div className="mx-3 mb-2 flex-none">
         <SearchInput
@@ -421,6 +396,57 @@ export function DatabaseExplorer(): ReactElement {
               </Button>
             </div>
           ))}
+      </div>
+    </div>
+  )
+}
+
+interface DatabaseExplorerHeaderProps {
+  hasDatabases: boolean
+  isRefreshing: boolean
+  onCreate: () => void
+  onRefresh: () => void
+}
+
+function DatabaseExplorerHeader({
+  hasDatabases,
+  isRefreshing,
+  onCreate,
+  onRefresh
+}: DatabaseExplorerHeaderProps): ReactElement {
+  return (
+    <div className="flex flex-none items-center justify-between pt-[10px] pr-3 pb-2 pl-4">
+      <h2 className="text-[11px] font-semibold tracking-[0.08em] text-text3 uppercase">
+        Databases
+      </h2>
+
+      <div className="flex flex-none items-center gap-[2px]">
+        {/* Nothing to reload without a connection, and the empty state below
+            already carries its own call to action. */}
+        {hasDatabases && (
+          <button
+            aria-label="Refresh databases"
+            className="flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover disabled:opacity-50"
+            disabled={isRefreshing}
+            title={`Refresh databases (${getRefreshShortcut()})`}
+            type="button"
+            onClick={onRefresh}
+          >
+            <RefreshCwIcon
+              className={cn('size-3', isRefreshing && 'animate-spin')}
+            />
+          </button>
+        )}
+
+        <button
+          aria-label="Add connection"
+          className="flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover"
+          title="Add connection"
+          type="button"
+          onClick={onCreate}
+        >
+          <Plus className="size-3" />
+        </button>
       </div>
     </div>
   )

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -7,11 +7,13 @@ import {
   Database,
   Pencil,
   Plus,
+  RefreshCwIcon,
   SearchIcon,
   Table2Icon,
   Trash2
 } from 'lucide-react'
 import { ReactElement, useCallback } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
 
 import { useCollections } from '../collections-context'
@@ -23,8 +25,10 @@ import {
 import {
   useCreateWorksheet,
   useDeleteDatabase,
+  useRefreshDatabases,
   useReorderDatabases
 } from '../hooks/mutations'
+import { getRefreshShortcut } from '../refresh-shortcut'
 import {
   staticListStrategy,
   useDropIndicator,
@@ -130,6 +134,46 @@ function useConfirmedDatabaseDeletion(): (database: DatabaseDto) => void {
     },
     [deleteDatabase]
   )
+}
+
+interface DatabaseTreeRefresh {
+  isRefreshing: boolean
+  /** One database, or every database when called with nothing. */
+  refresh: (database?: DatabaseDto) => void
+}
+
+// A refresh is the user asking to see the truth, so a failure has to say so
+// rather than leaving the stale tree in place looking current. The backend's
+// SchemaLoadFailedError already names the database and the reason — "Failed to
+// load schema for "Pagila": connection refused" — so the description carries
+// it. With several connections failing at once the first error speaks for all
+// of them; the ones that answered are updated either way.
+function useRefreshDatabaseTree(): DatabaseTreeRefresh {
+  const refreshDatabases = useRefreshDatabases()
+
+  const refresh = useCallback(
+    (database?: DatabaseDto) => {
+      refreshDatabases.mutate(
+        { databaseId: database?.id },
+        {
+          onError: (error) => {
+            const message =
+              error instanceof Error ? error.message : 'Unknown error'
+
+            toast.error(
+              database
+                ? `Failed to refresh "${database.name}"`
+                : 'Failed to refresh databases',
+              { description: message }
+            )
+          }
+        }
+      )
+    },
+    [refreshDatabases]
+  )
+
+  return { isRefreshing: refreshDatabases.isPending, refresh }
 }
 
 // Opens a fresh worksheet querying the given table, marks it as the open, most
@@ -265,6 +309,20 @@ export function DatabaseExplorer(): ReactElement {
     dispatch(uiActions.openCreateDatabase())
   }, [dispatch])
 
+  const { isRefreshing, refresh } = useRefreshDatabaseTree()
+
+  const handleRefreshAll = useCallback(() => {
+    refresh()
+  }, [refresh])
+
+  // Enabled on form tags and content-editables so the shortcut still works with
+  // focus in the filter input or the SQL editor.
+  useHotkeys('mod+alt+r', handleRefreshAll, {
+    enableOnContentEditable: true,
+    enableOnFormTags: true,
+    preventDefault: true
+  })
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex flex-none items-center justify-between pt-[10px] pr-3 pb-2 pl-4">
@@ -272,15 +330,34 @@ export function DatabaseExplorer(): ReactElement {
           Databases
         </h2>
 
-        <button
-          aria-label="Add connection"
-          className="flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover"
-          title="Add connection"
-          type="button"
-          onClick={handleCreateDatabase}
-        >
-          <Plus className="size-3" />
-        </button>
+        <div className="flex flex-none items-center gap-[2px]">
+          {/* Nothing to reload without a connection, and the empty state below
+              already carries its own call to action. */}
+          {databases.data.length > 0 && (
+            <button
+              aria-label="Refresh databases"
+              className="flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover disabled:opacity-50"
+              disabled={isRefreshing}
+              title={`Refresh databases (${getRefreshShortcut()})`}
+              type="button"
+              onClick={handleRefreshAll}
+            >
+              <RefreshCwIcon
+                className={cn('size-3', isRefreshing && 'animate-spin')}
+              />
+            </button>
+          )}
+
+          <button
+            aria-label="Add connection"
+            className="flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover"
+            title="Add connection"
+            type="button"
+            onClick={handleCreateDatabase}
+          >
+            <Plus className="size-3" />
+          </button>
+        </div>
       </div>
 
       <div className="mx-3 mb-2 flex-none">
@@ -319,6 +396,7 @@ export function DatabaseExplorer(): ReactElement {
                 searchQuery={normalizedSearchQuery}
                 onDelete={handleDeleteDatabase}
                 onEdit={handleEditDatabase}
+                onRefresh={refresh}
               />
             ))}
           </SortableContext>
@@ -357,6 +435,7 @@ interface DatabaseRowProps {
   isSortingDisabled: boolean
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
+  onRefresh: (database: DatabaseDto) => void
   searchMatch?: DatabaseMatch
   /** Normalized, so trailing whitespace does not count as a new question. */
   searchQuery: string
@@ -412,6 +491,7 @@ function DatabaseRow({
   isSortingDisabled,
   onDelete,
   onEdit,
+  onRefresh,
   searchMatch,
   searchQuery
 }: DatabaseRowProps): ReactElement {
@@ -465,6 +545,7 @@ function DatabaseRow({
         sortableProps={isSortingDisabled ? {} : { ...attributes, ...listeners }}
         onDelete={onDelete}
         onEdit={onEdit}
+        onRefresh={onRefresh}
         onToggle={handleToggle}
       />
 
@@ -484,6 +565,7 @@ interface DatabaseRowHeaderProps {
   isExpanded: boolean
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
+  onRefresh: (database: DatabaseDto) => void
   onToggle: () => void
   sortableProps: Record<string, unknown>
 }
@@ -493,6 +575,7 @@ function DatabaseRowHeader({
   isExpanded,
   onDelete,
   onEdit,
+  onRefresh,
   onToggle,
   sortableProps
 }: DatabaseRowHeaderProps): ReactElement {
@@ -522,6 +605,14 @@ function DatabaseRowHeader({
       </ContextMenuTrigger>
 
       <ContextMenuContent>
+        <ContextMenuItem
+          className="flex items-center gap-2 min-w-32 text-xs"
+          onClick={() => onRefresh(database)}
+        >
+          <RefreshCwIcon className="size-3" />
+          Refresh
+        </ContextMenuItem>
+
         <ContextMenuItem
           className="flex items-center gap-2 min-w-32 text-xs"
           onClick={() => onEdit(database.id)}

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -180,6 +180,40 @@ export function useInstallUpdate() {
   })
 }
 
+interface RefreshDatabasesRequest {
+  /** One connection's schema, or every connection's when omitted. */
+  databaseId?: string
+}
+
+// Not a server mutation: schemas are cached with staleTime: Infinity, so
+// nothing ever refetches them on its own and this marks them stale to let the
+// mounted queries reload. `useMutation` is here for the pending state the
+// spinner reads. `throwOnError` is load-bearing — invalidateQueries swallows
+// refetch failures by default, which would leave a stale tree looking freshly
+// loaded.
+export function useRefreshDatabases() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ databaseId }: RefreshDatabasesRequest) => {
+      const schemaKey = databaseId
+        ? queryKeys.schema(databaseId)
+        : queryKeys.schemas
+
+      await Promise.all([
+        queryClient.invalidateQueries(
+          { queryKey: queryKeys.databases },
+          { throwOnError: true }
+        ),
+        queryClient.invalidateQueries(
+          { queryKey: schemaKey },
+          { throwOnError: true }
+        )
+      ])
+    }
+  })
+}
+
 export function useReorderDatabases() {
   const { databases } = useCollections()
   const queryClient = useQueryClient()

--- a/src/app/query-keys.ts
+++ b/src/app/query-keys.ts
@@ -1,8 +1,14 @@
+// Every per-database schema key hangs off this prefix, so a refresh can
+// invalidate all of them in one call. `schema` derives from it so the two
+// cannot drift apart.
+const schemasKey = ['schema'] as const
+
 export const queryKeys = {
   databases: ['databases'] as const,
   queries: ['queries'] as const,
   query: (id: string) => ['query', id] as const,
-  schema: (databaseId: string) => ['schema', databaseId] as const,
+  schema: (databaseId: string) => [...schemasKey, databaseId] as const,
+  schemas: schemasKey,
   secretStorage: ['secret-storage'] as const,
   traces: (filters: { errorOnly: boolean; search: string }) =>
     ['traces', filters] as const,

--- a/src/app/refresh-shortcut.ts
+++ b/src/app/refresh-shortcut.ts
@@ -1,0 +1,10 @@
+/**
+ * The Refresh shortcut as the user's platform spells it. Read at call time
+ * rather than cached in a module constant so tests can stand in a platform.
+ *
+ * Deliberately not ⌘R or ⌘⇧R: Electron's default application menu, which this
+ * app never replaces, binds those to Reload and Force Reload.
+ */
+export function getRefreshShortcut(): string {
+  return navigator.platform.toLowerCase().includes('mac') ? '⌘⌥R' : 'Ctrl+Alt+R'
+}


### PR DESCRIPTION
## The gap

A schema was read once per app launch and then kept forever.
`useDatabaseSchema` / `useDatabaseSchemas` set `staleTime: Infinity`, and the
client turns off `refetchOnWindowFocus`. The server caches nothing —
`GET /databases/:id/schema` introspects live on every call — so the stale tree
was entirely the renderer's doing.

Add a table in `psql`, and the sidebar (and the filter that searches its tables
and columns) does not know about it until you edit the connection, which
invalidates that one schema as a side effect, or restart the app.

## The change

Three ways in, one behaviour:

- a refresh icon in the **Databases** header — spins and disables while in
  flight, hidden when there are no connections
- **Refresh** at the top of a database row's context menu, for one connection
- **⌘⌥R** / Ctrl+Alt+R

All three call `useRefreshDatabases`, which invalidates the connection list plus
either one schema or every schema. Invalidation refetches the queries that have
mounted observers and marks the rest stale, and React Query keeps the previous
data on screen while refetching, so the tree updates in place instead of
blanking out.

## Why `throwOnError`

```ts
queryClient.invalidateQueries({ queryKey: schemaKey }, { throwOnError: true })
```

`invalidateQueries` catches refetch failures by default. That is the right
default for a background refresh and the wrong one here: a refresh is the user
asking to see the truth, so a server that did not answer has to say so rather
than leave the previous tree on screen looking freshly loaded.

The description is the backend's own message, which already names the database
and the reason:

> **Failed to refresh databases**
> Failed to load schema for "Pagila": connection refused

Connections that did answer are still updated. With several failing at once the
first error speaks for them.

## Why not ⌘R

Every other database client puts refresh on ⌘R, and this one cannot.
`src/main.ts` never calls `Menu.setApplicationMenu`, so Electron installs its
default menu, whose View submenu owns ⌘R (Reload) and ⌘⇧R (Force Reload). Those
accelerators beat anything the renderer registers, so a binding on either
silently reloads the window — and nothing about the window suggests a menu
exists: it is frameless, with the macOS menu bar off-window entirely.

`Menu.setApplicationMenu(null)` is worse than the problem: on macOS the standard
Edit menu is what supplies ⌘C/⌘V/⌘X/⌘A/⌘Z to the renderer. So the shortcut is
⌘⌥R, and the reserved accelerators are recorded as friction
(`.agents/friction-log/20260817182013-electron-s-default/`) rather than worked
around here. Reclaiming ⌘R means a trimmed custom menu, which is its own change.

`enableOnFormTags` and `enableOnContentEditable` are set so the shortcut still
fires with focus in the filter input or the SQL editor.

## Deliberately not

- **No polling and no timer-driven invalidation.** Re-introspecting on a
  schedule would open a connection per configured database behind the user's
  back. Refreshing stays an explicit act.
- **No new endpoint.** The schema route already introspects live; only the
  renderer's cache was in the way.

## Also

- `queryKeys.schema(id)` now derives from a `queryKeys.schemas` prefix, so the
  one-schema key and the all-schemas key cannot drift apart.
- `src/app/refresh-shortcut.ts` spells the shortcut the way the user's platform
  spells it, mirroring the existing `run-shortcut.ts`.
- The header is now `DatabaseExplorerHeader`, and the shortcut is registered
  inside `useRefreshDatabaseTree` next to the callback it fires. Fallow's
  cognitive score is dominated by hook density, and three more hook calls in
  `DatabaseExplorer` put it at 18 against a threshold of 15; the whole feature
  now costs the component one hook call and one element.

## Tests

Six new cases in `DatabaseExplorer.test.tsx` — the header button, the hotkey,
the context menu, both failure toasts, and the empty-list case. The api-client
mock in that file had no `getDatabaseSchema` at all before this.

Seeded caches are never stale, so nothing is fetched before the click and every
recorded call belongs to the refresh. `912` tests pass; typecheck, lint and
prettier are clean.

## Not verified

The live app. A packaged Squeal was holding port 7847 (and the single-instance
lock) on the machine this was written on, and the port is hardcoded, so a
`yarn start` dev build could not come up alongside it. The end-to-end path —
create a table, refresh, watch it appear, and confirm one
`GET /databases/:id/schema` trace per connection — has not been run against a
real database.
