### PR TITLE
perf: stop reconfiguring the editor per keystroke and fsyncing per span

### DIFF
--- a/.agents/friction-log/20260817194259-the-release-ships/friction.md
+++ b/.agents/friction-log/20260817194259-the-release-ships/friction.md
@@ -1,35 +1,37 @@
 ---
-title: 'The release ships two look-alike macOS DMGs and the update feed locks an install to whichever arch it started on'
+title:
+  'The release ships two look-alike macOS DMGs and the update feed locks an
+  install to whichever arch it started on'
 severity: 'major'
 ---
 
 ## Expected Behavior
 
-Downloading Squeal on a Mac gets you a build that runs natively, or at least tells
-you it is not.
+Downloading Squeal on a Mac gets you a build that runs natively, or at least
+tells you it is not.
 
 ## Current Behavior
 
 `.github/workflows/release.yml` builds macOS on two runners and publishes
 `Squeal-<v>-arm64.dmg` and `Squeal-<v>-x64.dmg` side by side. Nothing on the
-release page or in `README.md` says which one to take, so an Apple Silicon user can
-install the Intel build, where every JIT-heavy path — React reconciliation,
-CodeMirror keystroke handling, Effect fibers, Schema decode — runs under Rosetta 2
-at roughly 2-4x the cost. It presents as "the published app feels laggy", with no
-error and nothing in the logs.
+release page or in `README.md` says which one to take, so an Apple Silicon user
+can install the Intel build, where every JIT-heavy path — React reconciliation,
+CodeMirror keystroke handling, Effect fibers, Schema decode — runs under Rosetta
+2 at roughly 2-4x the cost. It presents as "the published app feels laggy", with
+no error and nothing in the logs.
 
-It cannot heal itself either: `src/main/updates/electron-updater.ts` builds the feed
-URL from `process.arch`, which reports `x64` under Rosetta, so every future update
-is also the Intel build.
+It cannot heal itself either: `src/main/updates/electron-updater.ts` builds the
+feed URL from `process.arch`, which reports `x64` under Rosetta, so every future
+update is also the Intel build.
 
 ## Possible Solution
 
 Publish a single universal macOS build and drop the per-arch assets.
 `update.electronjs.org` falls back to a `-universal` darwin asset when no
 arch-specific asset exists at that version (`src/updates.ts` in
-`electron/update.electronjs.org`), so existing x64 installs would receive it and run
-native from then on — but only if the per-arch assets are gone, because at equal
-versions an arch-specific asset wins.
+`electron/update.electronjs.org`), so existing x64 installs would receive it and
+run native from then on — but only if the per-arch assets are gone, because at
+equal versions an arch-specific asset wins.
 
 ## Minimal Reproducible Example
 
@@ -39,6 +41,6 @@ versions an arch-specific asset wins.
 ## Context
 
 Cost most of an investigation into UI lag. Because dev runs the native arm64
-Electron from `node_modules`, the slowdown only appears in the published app, which
-points the investigation at packaging, the renderer bundle and the database before
-anything suggests looking at the binary's architecture.
+Electron from `node_modules`, the slowdown only appears in the published app,
+which points the investigation at packaging, the renderer bundle and the
+database before anything suggests looking at the binary's architecture.

--- a/.agents/friction-log/20260817194259-the-release-ships/friction.md
+++ b/.agents/friction-log/20260817194259-the-release-ships/friction.md
@@ -1,0 +1,44 @@
+---
+title: 'The release ships two look-alike macOS DMGs and the update feed locks an install to whichever arch it started on'
+severity: 'major'
+---
+
+## Expected Behavior
+
+Downloading Squeal on a Mac gets you a build that runs natively, or at least tells
+you it is not.
+
+## Current Behavior
+
+`.github/workflows/release.yml` builds macOS on two runners and publishes
+`Squeal-<v>-arm64.dmg` and `Squeal-<v>-x64.dmg` side by side. Nothing on the
+release page or in `README.md` says which one to take, so an Apple Silicon user can
+install the Intel build, where every JIT-heavy path — React reconciliation,
+CodeMirror keystroke handling, Effect fibers, Schema decode — runs under Rosetta 2
+at roughly 2-4x the cost. It presents as "the published app feels laggy", with no
+error and nothing in the logs.
+
+It cannot heal itself either: `src/main/updates/electron-updater.ts` builds the feed
+URL from `process.arch`, which reports `x64` under Rosetta, so every future update
+is also the Intel build.
+
+## Possible Solution
+
+Publish a single universal macOS build and drop the per-arch assets.
+`update.electronjs.org` falls back to a `-universal` darwin asset when no
+arch-specific asset exists at that version (`src/updates.ts` in
+`electron/update.electronjs.org`), so existing x64 installs would receive it and run
+native from then on — but only if the per-arch assets are gone, because at equal
+versions an arch-specific asset wins.
+
+## Minimal Reproducible Example
+
+    lipo -archs /Applications/Squeal.app/Contents/MacOS/Squeal   # x86_64
+    uname -m                                                    # arm64
+
+## Context
+
+Cost most of an investigation into UI lag. Because dev runs the native arm64
+Electron from `node_modules`, the slowdown only appears in the published app, which
+points the investigation at packaging, the renderer bundle and the database before
+anything suggests looking at the binary's architecture.

--- a/.agents/friction-log/20260817200145-frog-log-writes/friction.md
+++ b/.agents/friction-log/20260817200145-frog-log-writes/friction.md
@@ -1,0 +1,36 @@
+---
+title: "frog log writes Markdown that the repo's own prettier --check rejects"
+severity: 'minor'
+---
+
+## Expected Behavior
+
+`npx frog log` writes an entry that passes this repository's own CI.
+
+## Current Behavior
+
+`ci.yml` runs `npx prettier --check .`, which covers `.agents/friction-log/**`.
+The Markdown `frog log` writes is not prettier-formatted — long prose lines are
+left unwrapped and the YAML `title:` stays on one line — so logging friction
+turns the Format job red on the next push. Prettier's own fix rewraps the body
+at 80 columns and folds the title across lines, which `frog list` still parses.
+
+The failure surfaces a full CI round trip after the entry is written, and the
+job that fails is unrelated to whatever the commit was about.
+
+## Possible Solution
+
+Either have `frog log` write prettier-compatible Markdown, or add
+`.agents/friction-log` to `.prettierignore` — the entries are generated files,
+and the repo already ignores other generated output.
+
+## Minimal Reproducible Example
+
+    npx frog log "some friction" --body "$(cat body.md)"
+    npx prettier --check .    # warns on the new friction.md, exit 1
+
+## Context
+
+Cost a CI round trip on a PR whose own changes were clean, having run prettier
+locally on every file the change touched — but not on the entry `frog` had just
+written.

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -18,13 +18,16 @@
         "files": ["src/app/hooks/mutations.ts"],
         "rules": ["react-doctor/query-mutation-missing-invalidation"]
       },
-      // Both modules only load through React.lazy(() => import(...)) in
-      // App.tsx, so the CodeMirror packages already sit in an on-demand
-      // chunk. The rule is per-file and cannot see the dynamic import chain.
+      // These modules only load through React.lazy(() => import(...)) in
+      // App.tsx — the editor's hook reaches them only through
+      // WorksheetEditor — so the CodeMirror packages already sit in an
+      // on-demand chunk. The rule is per-file and cannot see the dynamic
+      // import chain.
       {
         "files": [
           "src/app/components/WorksheetEditor.tsx",
-          "src/app/components/codemirror-theme.ts"
+          "src/app/components/codemirror-theme.ts",
+          "src/app/components/use-worksheet-editor.ts"
         ],
         "rules": ["react-doctor/prefer-dynamic-import"]
       },

--- a/src/app/components/WorksheetEditor.test.tsx
+++ b/src/app/components/WorksheetEditor.test.tsx
@@ -1,0 +1,86 @@
+import { render } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `@uiw/react-codemirror` dispatches a full `StateEffect.reconfigure` whenever
+// `extensions`, `basicSetup`, `onChange` or `onUpdate` changes identity — all
+// four are in the deps of its reconfigure effect. Every reconfigure re-runs
+// `EditorView.theme`, which allocates a new class name and a new StyleModule,
+// and style-mod appends that module to the document and never removes it while
+// re-serializing the whole stylesheet. So an unstable prop here does not just
+// cost a reconfigure: it leaks CSS rules and re-parses the entire stylesheet on
+// every keystroke, which is what made typing slower the longer the app stayed
+// open. Capturing the props is how we assert no reconfigure can happen.
+const { capturedProps } = vi.hoisted(() => ({
+  capturedProps: [] as Record<string, unknown>[]
+}))
+
+vi.mock('@uiw/react-codemirror', () => ({
+  default: (props: Record<string, unknown>): ReactElement => {
+    capturedProps.push(props)
+
+    return <div data-testid="code-mirror" />
+  }
+}))
+
+import { createAstFromSql } from '../sql-parser'
+import { WorksheetEditor } from './WorksheetEditor'
+
+function editor(content: string): ReactElement {
+  return (
+    <WorksheetEditor
+      activeStatementIndex={0}
+      content={content}
+      statements={createAstFromSql(content).statements}
+      // Deliberately unstable, the way a parent that forgot to memoise would
+      // be: the component owes CodeMirror a stable callback regardless.
+      onChange={() => undefined}
+      onCursorChange={() => undefined}
+      onCursorPositionChange={() => undefined}
+      onRunQuery={() => undefined}
+    />
+  )
+}
+
+describe('WorksheetEditor', () => {
+  beforeEach(() => {
+    capturedProps.length = 0
+  })
+
+  it('keeps the editor configuration stable while the document changes', () => {
+    const { rerender } = render(editor('select 1'))
+
+    // Three keystrokes: each one changes `content`, and with it the parsed
+    // statements and the active statement the gutter is computed from.
+    rerender(editor('select 12'))
+    rerender(editor('select 123'))
+    rerender(editor('select 1234'))
+
+    const identityCounts = {
+      basicSetup: new Set(capturedProps.map((props) => props.basicSetup)).size,
+      extensions: new Set(capturedProps.map((props) => props.extensions)).size,
+      onChange: new Set(capturedProps.map((props) => props.onChange)).size,
+      onUpdate: new Set(capturedProps.map((props) => props.onUpdate)).size
+    }
+
+    // A `Set` of the values rather than a `toBe` per prop, because identity is
+    // the whole point: a deep comparison passes happily on freshly allocated
+    // objects that would each trigger their own reconfigure.
+    expect(identityCounts).toEqual({
+      basicSetup: 1,
+      extensions: 1,
+      onChange: 1,
+      onUpdate: 1
+    })
+  })
+
+  it('still passes the current content through to the editor', () => {
+    const { rerender } = render(editor('select 1'))
+
+    rerender(editor('select 1234'))
+
+    const lastProps = capturedProps[capturedProps.length - 1]
+
+    expect(lastProps.value).toEqual('select 1234')
+  })
+})

--- a/src/app/components/WorksheetEditor.tsx
+++ b/src/app/components/WorksheetEditor.tsx
@@ -1,6 +1,11 @@
 import { autocompletion } from '@codemirror/autocomplete'
 import { sql } from '@codemirror/lang-sql'
-import { Prec, RangeSetBuilder } from '@codemirror/state'
+import {
+  Compartment,
+  type Extension,
+  Prec,
+  RangeSetBuilder
+} from '@codemirror/state'
 import type { ViewUpdate } from '@codemirror/view'
 import {
   EditorView,
@@ -35,6 +40,26 @@ export interface WorksheetEditorProps {
   onRunQuery?: () => void
 }
 
+// Hoisted out of the render on purpose. `@uiw/react-codemirror` lists
+// `basicSetup` — along with `extensions`, `onChange` and `onUpdate` — in the deps
+// of the effect that dispatches `StateEffect.reconfigure`, and every reconfigure
+// re-runs `EditorView.theme`, which allocates a new class name and a new
+// StyleModule that style-mod appends to the document and never removes. A fresh
+// object literal here therefore leaked CSS rules and re-serialized the whole
+// stylesheet on every keystroke, so typing got slower the longer the app stayed
+// open. Every prop this component hands CodeMirror has to keep its identity.
+//
+// `autocompletion` is off because the extension list below registers it
+// explicitly; basicSetup only leaves an option out when it is literally `false`,
+// so without this it would be registered twice.
+const editorBasicSetup = {
+  autocompletion: false,
+  bracketMatching: true,
+  highlightActiveLine: true,
+  history: true,
+  lineNumbers: true
+}
+
 // Formatting itself lives in `worksheet-editor-format` so it can be tested
 // against a real EditorState without mounting the component; this only turns a
 // parse failure into something the user sees.
@@ -64,19 +89,36 @@ export function WorksheetEditor({
   onCursorPositionChange,
   onRunQuery
 }: WorksheetEditorProps): ReactElement {
+  const activeStatement =
+    activeStatementIndex !== null ? statements[activeStatementIndex] : null
+
+  const activeStatementRef = useRef(activeStatement)
   const databaseTypeRef = useRef(databaseType)
   const editorRef = useRef<ReactCodeMirrorRef>(null)
+  const gutterCompartment = useMemo(() => new Compartment(), [])
   const lastCursorPositionRef = useRef<CursorPosition | null>(null)
+  const onChangeRef = useRef(onChange)
+  const onCursorChangeRef = useRef(onCursorChange)
+  const onCursorPositionChangeRef = useRef(onCursorPositionChange)
   const onRunQueryRef = useRef(onRunQuery)
 
-  // The keymap is built once, so it reads the current props through refs
-  // rather than being rebuilt on every change. Syncing them in an effect
-  // rather than during render keeps the render pure; the keymap only fires on
-  // user input, which is always after the effect has run.
+  // The keymap and the callbacks handed to CodeMirror are built once, so they
+  // read the current props through refs rather than being rebuilt on every
+  // change. Syncing them in an effect rather than during render keeps the render
+  // pure; they only fire on user input, which is always after the effect has
+  // run.
   useEffect(() => {
+    activeStatementRef.current = activeStatement
     databaseTypeRef.current = databaseType
+    onChangeRef.current = onChange
+    onCursorChangeRef.current = onCursorChange
+    onCursorPositionChangeRef.current = onCursorPositionChange
     onRunQueryRef.current = onRunQuery
   })
+
+  const handleChange = useCallback((value: string) => {
+    onChangeRef.current?.(value)
+  }, [])
 
   const handleClickOutsideTheEditor = useCallback(() => {
     if (editorRef.current) {
@@ -99,22 +141,19 @@ export function WorksheetEditor({
     view.focus()
   }, [])
 
-  const handleUpdate = useCallback(
-    (update: ViewUpdate) => {
-      const offset = update.state.selection.main.head
-      const position = toCursorPosition(update.state.doc.lineAt(offset), offset)
+  const handleUpdate = useCallback((update: ViewUpdate) => {
+    const offset = update.state.selection.main.head
+    const position = toCursorPosition(update.state.doc.lineAt(offset), offset)
 
-      if (isSameCursorPosition(lastCursorPositionRef.current, position)) {
-        return
-      }
+    if (isSameCursorPosition(lastCursorPositionRef.current, position)) {
+      return
+    }
 
-      lastCursorPositionRef.current = position
+    lastCursorPositionRef.current = position
 
-      onCursorPositionChange?.(position.offset)
-      onCursorChange?.(position)
-    },
-    [onCursorChange, onCursorPositionChange]
-  )
+    onCursorPositionChangeRef.current?.(position.offset)
+    onCursorChangeRef.current?.(position)
+  }, [])
 
   const extensions = useMemo(() => {
     return [
@@ -123,6 +162,11 @@ export function WorksheetEditor({
       sql(),
       EditorView.lineWrapping,
       autocompletion(),
+      // The gutter is the one extension that depends on props, so it lives in a
+      // Compartment and is swapped by the effect below. Rebuilding the array
+      // instead would change the `extensions` identity and reconfigure the whole
+      // editor on every keystroke.
+      gutterCompartment.of(activeStatementGutter(activeStatementRef.current)),
       Prec.highest(
         keymap.of([
           {
@@ -148,31 +192,23 @@ export function WorksheetEditor({
         ])
       )
     ]
-  }, [])
+  }, [gutterCompartment])
 
-  const activeStatement =
-    activeStatementIndex !== null ? statements[activeStatementIndex] : null
+  // Swapping just this compartment leaves the rest of the configuration — and
+  // the `extensions` array's identity — untouched.
+  useEffect(() => {
+    const view = editorRef.current?.view
 
-  const gutterExtension = useMemo(() => {
-    return gutterLineClass.compute(['doc'], (state) => {
-      const builder = new RangeSetBuilder<GutterMarker>()
+    if (!view) {
+      return
+    }
 
-      if (!activeStatement) {
-        return builder.finish()
-      }
-
-      const positions = findGutterMarkerPositions(
-        state.doc.toString(),
-        activeStatement
+    view.dispatch({
+      effects: gutterCompartment.reconfigure(
+        activeStatementGutter(activeStatement)
       )
-
-      for (const position of positions) {
-        builder.add(position, position, activeStatementMarker)
-      }
-
-      return builder.finish()
     })
-  }, [activeStatement])
+  }, [activeStatement, gutterCompartment])
 
   return (
     <div className="relative w-full h-full overflow-hidden text-xs flex flex-col">
@@ -187,19 +223,12 @@ export function WorksheetEditor({
 
       <CodeMirror
         ref={editorRef}
-        basicSetup={{
-          bracketMatching: true,
-          highlightActiveLine: true,
-          history: true,
-          lineNumbers: true
-        }}
-        extensions={[...extensions, gutterExtension]}
+        basicSetup={editorBasicSetup}
+        extensions={extensions}
         height="100%"
         theme="none"
         value={content}
-        onChange={(value) => {
-          onChange?.(value)
-        }}
+        onChange={handleChange}
         onUpdate={handleUpdate}
       />
       <button
@@ -217,3 +246,27 @@ class ActiveStatementMarker extends GutterMarker {
 }
 
 const activeStatementMarker = new ActiveStatementMarker()
+
+// Marks the gutter lines the active statement spans. Recomputed whenever the
+// document changes, and rebuilt from scratch whenever the active statement moves
+// — which is what the compartment in the component swaps.
+function activeStatementGutter(activeStatement: Statement | null): Extension {
+  return gutterLineClass.compute(['doc'], (state) => {
+    const builder = new RangeSetBuilder<GutterMarker>()
+
+    if (!activeStatement) {
+      return builder.finish()
+    }
+
+    const positions = findGutterMarkerPositions(
+      state.doc.toString(),
+      activeStatement
+    )
+
+    for (const position of positions) {
+      builder.add(position, position, activeStatementMarker)
+    }
+
+    return builder.finish()
+  })
+}

--- a/src/app/components/WorksheetEditor.tsx
+++ b/src/app/components/WorksheetEditor.tsx
@@ -1,33 +1,11 @@
-import { autocompletion } from '@codemirror/autocomplete'
-import { sql } from '@codemirror/lang-sql'
-import {
-  Compartment,
-  type Extension,
-  Prec,
-  RangeSetBuilder
-} from '@codemirror/state'
-import type { ViewUpdate } from '@codemirror/view'
-import {
-  EditorView,
-  GutterMarker,
-  gutterLineClass,
-  keymap
-} from '@codemirror/view'
-import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror'
+import CodeMirror from '@uiw/react-codemirror'
 import { Sparkles } from 'lucide-react'
-import { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react'
-import { toast } from 'sonner'
+import { ReactElement } from 'react'
 
 import type { DatabaseType } from '@/glue/api/schemas'
 import { type Statement } from '../sql-parser'
-import { squealEditorTheme, squealHighlighting } from './codemirror-theme'
-import { formatEditorContent } from './worksheet-editor-format'
-import {
-  type CursorPosition,
-  isSameCursorPosition,
-  toCursorPosition
-} from './worksheet-editor-cursor'
-import { findGutterMarkerPositions } from './worksheet-editor-lines'
+import { useWorksheetEditor } from './use-worksheet-editor'
+import { type CursorPosition } from './worksheet-editor-cursor'
 
 export interface WorksheetEditorProps {
   activeStatementIndex: number | null
@@ -38,45 +16,6 @@ export interface WorksheetEditorProps {
   onCursorChange?: (position: CursorPosition) => void
   onCursorPositionChange?: (position: number) => void
   onRunQuery?: () => void
-}
-
-// Hoisted out of the render on purpose. `@uiw/react-codemirror` lists
-// `basicSetup` — along with `extensions`, `onChange` and `onUpdate` — in the deps
-// of the effect that dispatches `StateEffect.reconfigure`, and every reconfigure
-// re-runs `EditorView.theme`, which allocates a new class name and a new
-// StyleModule that style-mod appends to the document and never removes. A fresh
-// object literal here therefore leaked CSS rules and re-serialized the whole
-// stylesheet on every keystroke, so typing got slower the longer the app stayed
-// open. Every prop this component hands CodeMirror has to keep its identity.
-//
-// `autocompletion` is off because the extension list below registers it
-// explicitly; basicSetup only leaves an option out when it is literally `false`,
-// so without this it would be registered twice.
-const editorBasicSetup = {
-  autocompletion: false,
-  bracketMatching: true,
-  highlightActiveLine: true,
-  history: true,
-  lineNumbers: true
-}
-
-// Formatting itself lives in `worksheet-editor-format` so it can be tested
-// against a real EditorState without mounting the component; this only turns a
-// parse failure into something the user sees.
-function runFormatCommand(
-  view: EditorView,
-  databaseType: DatabaseType | undefined
-): void {
-  const outcome = formatEditorContent(view, databaseType)
-
-  if (outcome !== 'parse-error') {
-    return
-  }
-
-  toast.error('Could not format this SQL', {
-    description:
-      'The statement has a syntax error the formatter could not parse. Fix it and try again.'
-  })
 }
 
 export function WorksheetEditor({
@@ -92,129 +31,23 @@ export function WorksheetEditor({
   const activeStatement =
     activeStatementIndex !== null ? statements[activeStatementIndex] : null
 
-  const activeStatementRef = useRef(activeStatement)
-  const databaseTypeRef = useRef(databaseType)
-  const editorRef = useRef<ReactCodeMirrorRef>(null)
-  const gutterCompartment = useMemo(() => new Compartment(), [])
-  const lastCursorPositionRef = useRef<CursorPosition | null>(null)
-  const onChangeRef = useRef(onChange)
-  const onCursorChangeRef = useRef(onCursorChange)
-  const onCursorPositionChangeRef = useRef(onCursorPositionChange)
-  const onRunQueryRef = useRef(onRunQuery)
-
-  // The keymap and the callbacks handed to CodeMirror are built once, so they
-  // read the current props through refs rather than being rebuilt on every
-  // change. Syncing them in an effect rather than during render keeps the render
-  // pure; they only fire on user input, which is always after the effect has
-  // run.
-  useEffect(() => {
-    activeStatementRef.current = activeStatement
-    databaseTypeRef.current = databaseType
-    onChangeRef.current = onChange
-    onCursorChangeRef.current = onCursorChange
-    onCursorPositionChangeRef.current = onCursorPositionChange
-    onRunQueryRef.current = onRunQuery
+  // Every prop below comes from the hook already identity-stable; handing
+  // `<CodeMirror>` a fresh object, array or callback reconfigures the whole
+  // editor. See `use-worksheet-editor` for what that costs.
+  const editor = useWorksheetEditor({
+    activeStatement,
+    databaseType,
+    onChange,
+    onCursorChange,
+    onCursorPositionChange,
+    onRunQuery
   })
-
-  const handleChange = useCallback((value: string) => {
-    onChangeRef.current?.(value)
-  }, [])
-
-  const handleClickOutsideTheEditor = useCallback(() => {
-    if (editorRef.current) {
-      const view = editorRef.current.view
-
-      if (view) {
-        view.focus()
-      }
-    }
-  }, [])
-
-  const handleFormatQuery = useCallback(() => {
-    const view = editorRef.current?.view
-
-    if (!view) {
-      return
-    }
-
-    runFormatCommand(view, databaseTypeRef.current)
-    view.focus()
-  }, [])
-
-  const handleUpdate = useCallback((update: ViewUpdate) => {
-    const offset = update.state.selection.main.head
-    const position = toCursorPosition(update.state.doc.lineAt(offset), offset)
-
-    if (isSameCursorPosition(lastCursorPositionRef.current, position)) {
-      return
-    }
-
-    lastCursorPositionRef.current = position
-
-    onCursorPositionChangeRef.current?.(position.offset)
-    onCursorChangeRef.current?.(position)
-  }, [])
-
-  const extensions = useMemo(() => {
-    return [
-      squealEditorTheme,
-      squealHighlighting,
-      sql(),
-      EditorView.lineWrapping,
-      autocompletion(),
-      // The gutter is the one extension that depends on props, so it lives in a
-      // Compartment and is swapped by the effect below. Rebuilding the array
-      // instead would change the `extensions` identity and reconfigure the whole
-      // editor on every keystroke.
-      gutterCompartment.of(activeStatementGutter(activeStatementRef.current)),
-      Prec.highest(
-        keymap.of([
-          {
-            key: 'Mod-Enter',
-            run: () => {
-              if (onRunQueryRef.current) {
-                onRunQueryRef.current()
-
-                return true
-              }
-
-              return false
-            }
-          },
-          {
-            key: 'Mod-Shift-f',
-            run: (view) => {
-              runFormatCommand(view, databaseTypeRef.current)
-
-              return true
-            }
-          }
-        ])
-      )
-    ]
-  }, [gutterCompartment])
-
-  // Swapping just this compartment leaves the rest of the configuration — and
-  // the `extensions` array's identity — untouched.
-  useEffect(() => {
-    const view = editorRef.current?.view
-
-    if (!view) {
-      return
-    }
-
-    view.dispatch({
-      effects: gutterCompartment.reconfigure(
-        activeStatementGutter(activeStatement)
-      )
-    })
-  }, [activeStatement, gutterCompartment])
 
   return (
     <div className="relative w-full h-full overflow-hidden text-xs flex flex-col">
       <button
         className="absolute top-[10px] right-[14px] z-20 flex size-7 items-center justify-center rounded-sm border border-border bg-panel text-text3 opacity-75 hover:bg-hover hover:text-text hover:opacity-100"
-        onClick={handleFormatQuery}
+        onClick={editor.formatQuery}
         title="Format query"
         type="button"
       >
@@ -222,51 +55,21 @@ export function WorksheetEditor({
       </button>
 
       <CodeMirror
-        ref={editorRef}
-        basicSetup={editorBasicSetup}
-        extensions={extensions}
+        ref={editor.editorRef}
+        basicSetup={editor.basicSetup}
+        extensions={editor.extensions}
         height="100%"
         theme="none"
         value={content}
-        onChange={handleChange}
-        onUpdate={handleUpdate}
+        onChange={editor.handleChange}
+        onUpdate={editor.handleUpdate}
       />
       <button
         aria-label="Focus editor"
         className="w-full flex-1 cursor-text"
-        onClick={handleClickOutsideTheEditor}
+        onClick={editor.focusEditor}
         type="button"
       />
     </div>
   )
-}
-
-class ActiveStatementMarker extends GutterMarker {
-  override elementClass = 'cm-activeStatementGutter'
-}
-
-const activeStatementMarker = new ActiveStatementMarker()
-
-// Marks the gutter lines the active statement spans. Recomputed whenever the
-// document changes, and rebuilt from scratch whenever the active statement moves
-// — which is what the compartment in the component swaps.
-function activeStatementGutter(activeStatement: Statement | null): Extension {
-  return gutterLineClass.compute(['doc'], (state) => {
-    const builder = new RangeSetBuilder<GutterMarker>()
-
-    if (!activeStatement) {
-      return builder.finish()
-    }
-
-    const positions = findGutterMarkerPositions(
-      state.doc.toString(),
-      activeStatement
-    )
-
-    for (const position of positions) {
-      builder.add(position, position, activeStatementMarker)
-    }
-
-    return builder.finish()
-  })
 }

--- a/src/app/components/use-worksheet-editor.ts
+++ b/src/app/components/use-worksheet-editor.ts
@@ -1,0 +1,252 @@
+// Everything the SQL editor hands to CodeMirror, kept out of the component.
+//
+// The one rule this module exists to enforce: every prop that reaches
+// `<CodeMirror>` keeps its identity for the life of the editor.
+// `@uiw/react-codemirror` lists `basicSetup`, `extensions`, `onChange` and
+// `onUpdate` in the deps of the effect that dispatches
+// `StateEffect.reconfigure`, and every reconfigure re-runs `EditorView.theme`,
+// which allocates a new class name and a new StyleModule that style-mod appends
+// to the document and never removes while re-serializing the whole stylesheet.
+// An unstable prop therefore leaks CSS rules and re-parses every rule in the
+// document on each keystroke, which is why typing used to get slower the longer
+// the app stayed open.
+import { autocompletion } from '@codemirror/autocomplete'
+import { sql } from '@codemirror/lang-sql'
+import {
+  Compartment,
+  type Extension,
+  Prec,
+  RangeSetBuilder
+} from '@codemirror/state'
+import type { ViewUpdate } from '@codemirror/view'
+import {
+  EditorView,
+  GutterMarker,
+  gutterLineClass,
+  keymap
+} from '@codemirror/view'
+import type { ReactCodeMirrorRef } from '@uiw/react-codemirror'
+import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react'
+import { toast } from 'sonner'
+
+import type { DatabaseType } from '@/glue/api/schemas'
+import type { Statement } from '../sql-parser'
+import { squealEditorTheme, squealHighlighting } from './codemirror-theme'
+import {
+  type CursorPosition,
+  isSameCursorPosition,
+  toCursorPosition
+} from './worksheet-editor-cursor'
+import { formatEditorContent } from './worksheet-editor-format'
+import { findGutterMarkerPositions } from './worksheet-editor-lines'
+
+// `autocompletion` is off because the extension list registers it explicitly;
+// basicSetup only leaves an option out when it is literally `false`, so without
+// this it would be registered twice.
+const editorBasicSetup = {
+  autocompletion: false,
+  bracketMatching: true,
+  highlightActiveLine: true,
+  history: true,
+  lineNumbers: true
+}
+
+export interface WorksheetEditorOptions {
+  activeStatement: Statement | null
+  databaseType: DatabaseType | undefined
+  onChange?: (value: string) => void
+  onCursorChange?: (position: CursorPosition) => void
+  onCursorPositionChange?: (position: number) => void
+  onRunQuery?: () => void
+}
+
+export interface WorksheetEditor {
+  basicSetup: typeof editorBasicSetup
+  editorRef: RefObject<ReactCodeMirrorRef | null>
+  extensions: Extension[]
+  focusEditor: () => void
+  formatQuery: () => void
+  handleChange: (value: string) => void
+  handleUpdate: (update: ViewUpdate) => void
+}
+
+export function useWorksheetEditor(
+  options: WorksheetEditorOptions
+): WorksheetEditor {
+  const { activeStatement } = options
+
+  const editorRef = useRef<ReactCodeMirrorRef>(null)
+  const gutterCompartment = useMemo(() => new Compartment(), [])
+  const lastCursorPositionRef = useRef<CursorPosition | null>(null)
+
+  // One ref for all of it rather than one per callback. The keymap and the
+  // handlers are built once, so they read the current props through here instead
+  // of being rebuilt on every change. Refreshing it in an effect rather than
+  // during render keeps the render pure; they only fire on user input, which is
+  // always after the effect has run.
+  const latest = useRef(options)
+
+  useEffect(() => {
+    latest.current = options
+  })
+
+  const extensions = useMemo(
+    () => createExtensions({ gutterCompartment, latest }),
+    [gutterCompartment, latest]
+  )
+
+  // Swapping just this compartment leaves the rest of the configuration — and
+  // the `extensions` array's identity — untouched.
+  useEffect(() => {
+    const view = editorRef.current?.view
+
+    if (!view) {
+      return
+    }
+
+    view.dispatch({
+      effects: gutterCompartment.reconfigure(
+        activeStatementGutter(activeStatement)
+      )
+    })
+  }, [activeStatement, gutterCompartment])
+
+  const focusEditor = useCallback(() => {
+    editorRef.current?.view?.focus()
+  }, [])
+
+  const formatQuery = useCallback(() => {
+    const view = editorRef.current?.view
+
+    if (!view) {
+      return
+    }
+
+    runFormatCommand(view, latest.current.databaseType)
+    view.focus()
+  }, [])
+
+  const handleChange = useCallback((value: string) => {
+    latest.current.onChange?.(value)
+  }, [])
+
+  const handleUpdate = useCallback((update: ViewUpdate) => {
+    const offset = update.state.selection.main.head
+    const position = toCursorPosition(update.state.doc.lineAt(offset), offset)
+
+    if (isSameCursorPosition(lastCursorPositionRef.current, position)) {
+      return
+    }
+
+    lastCursorPositionRef.current = position
+
+    latest.current.onCursorPositionChange?.(position.offset)
+    latest.current.onCursorChange?.(position)
+  }, [])
+
+  return {
+    basicSetup: editorBasicSetup,
+    editorRef,
+    extensions,
+    focusEditor,
+    formatQuery,
+    handleChange,
+    handleUpdate
+  }
+}
+
+// Built once per editor. The active-statement gutter is the only extension that
+// depends on props, so it goes in a Compartment the hook swaps; rebuilding the
+// array instead would change its identity and reconfigure the whole editor.
+function createExtensions(options: {
+  gutterCompartment: Compartment
+  latest: RefObject<WorksheetEditorOptions>
+}): Extension[] {
+  const { gutterCompartment, latest } = options
+
+  return [
+    squealEditorTheme,
+    squealHighlighting,
+    sql(),
+    EditorView.lineWrapping,
+    autocompletion(),
+    gutterCompartment.of(activeStatementGutter(latest.current.activeStatement)),
+    Prec.highest(
+      keymap.of([
+        {
+          key: 'Mod-Enter',
+          run: () => runQueryCommand(latest.current.onRunQuery)
+        },
+        {
+          key: 'Mod-Shift-f',
+          run: (view) => {
+            runFormatCommand(view, latest.current.databaseType)
+
+            return true
+          }
+        }
+      ])
+    )
+  ]
+}
+
+// Reports whether the key was handled, so Mod-Enter falls through to whatever
+// else wants it when no worksheet can run.
+function runQueryCommand(onRunQuery: (() => void) | undefined): boolean {
+  if (!onRunQuery) {
+    return false
+  }
+
+  onRunQuery()
+
+  return true
+}
+
+// Formatting itself lives in `worksheet-editor-format` so it can be tested
+// against a real EditorState without mounting the component; this only turns a
+// parse failure into something the user sees.
+function runFormatCommand(
+  view: EditorView,
+  databaseType: DatabaseType | undefined
+): void {
+  const outcome = formatEditorContent(view, databaseType)
+
+  if (outcome !== 'parse-error') {
+    return
+  }
+
+  toast.error('Could not format this SQL', {
+    description:
+      'The statement has a syntax error the formatter could not parse. Fix it and try again.'
+  })
+}
+
+class ActiveStatementMarker extends GutterMarker {
+  override elementClass = 'cm-activeStatementGutter'
+}
+
+const activeStatementMarker = new ActiveStatementMarker()
+
+// Marks the gutter lines the active statement spans. Recomputed whenever the
+// document changes, and rebuilt whenever the active statement moves — which is
+// what the compartment swaps.
+function activeStatementGutter(activeStatement: Statement | null): Extension {
+  return gutterLineClass.compute(['doc'], (state) => {
+    const builder = new RangeSetBuilder<GutterMarker>()
+
+    if (!activeStatement) {
+      return builder.finish()
+    }
+
+    const positions = findGutterMarkerPositions(
+      state.doc.toString(),
+      activeStatement
+    )
+
+    for (const position of positions) {
+      builder.add(position, position, activeStatementMarker)
+    }
+
+    return builder.finish()
+  })
+}

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -17,6 +17,13 @@ export async function initializeDatabase() {
   // failing instantly.
   await database.run(sql`PRAGMA busy_timeout = 5000`)
   await database.run(sql`PRAGMA journal_mode = WAL`)
+  // The driver is synchronous and runs on the main process's event loop, so
+  // every fsync it waits for is a stall the whole window feels. SQLite's default
+  // of `FULL` fsyncs the WAL on every single commit; `NORMAL` is the standard
+  // pairing with WAL, where an OS crash can lose the most recent commits but the
+  // database still cannot corrupt. Query history and spans are both worth less
+  // than a responsive window.
+  await database.run(sql`PRAGMA synchronous = NORMAL`)
 
   await createTables(database)
 

--- a/src/server/http/server.ts
+++ b/src/server/http/server.ts
@@ -60,6 +60,15 @@ export const CorsLive = Layer.unwrapEffect(
 
     return HttpApiBuilder.middlewareCors({
       allowedHeaders: ['Authorization', 'Content-Type', 'traceparent'],
+      // Every request carries an Authorization header, which makes every one of
+      // them a preflighted cross-origin request — the renderer's origin is the
+      // `null` of a file:// page in a packaged build and the Vite origin in dev,
+      // and neither is the loopback server's. Without this the middleware sends
+      // no Access-Control-Max-Age at all and Chromium falls back to caching a
+      // preflight for ~5 seconds, so the 250ms result poller and the autosave
+      // pay a second round trip over and over. 600 is the ceiling Chromium
+      // honours; anything larger is clamped to it.
+      maxAge: 600,
       // A predicate rather than the array: given exactly one allowed origin the
       // middleware takes a fast path that emits a constant header without ever
       // comparing the request's Origin, so a packaged build (whose only allowed

--- a/src/server/tracing/effect-tracer.test.ts
+++ b/src/server/tracing/effect-tracer.test.ts
@@ -8,12 +8,33 @@ import {
   Option,
   Tracer
 } from 'effect'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { spansTable } from '@/database/schema'
 import { SpanRecord } from '@/glue/tracing/spans'
 import { AppDatabase } from '@/server/services/app-database'
 import { makeTestAppDatabase } from '@/test/effect-test-helper'
+
+// Counts the writes without replacing them: how many INSERTs a burst of spans
+// turns into is the thing under test, and the rows still have to land for the
+// flush test below.
+const { writeSpansSpy } = vi.hoisted(() => ({
+  writeSpansSpy: vi.fn<(records: unknown[]) => void>()
+}))
+
+vi.mock('@/main/tracing/span-writer', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/main/tracing/span-writer')>()
+
+  return {
+    ...actual,
+    writeSpans: (...args: Parameters<typeof actual.writeSpans>) => {
+      writeSpansSpy(args[0])
+
+      return actual.writeSpans(...args)
+    }
+  }
+})
 
 import { makeSquealTracer, TracerLive } from './effect-tracer'
 
@@ -258,6 +279,37 @@ describe('makeSquealTracer', () => {
 })
 
 describe('TracerLive', () => {
+  beforeEach(() => {
+    writeSpansSpy.mockClear()
+  })
+
+  // The drain loop used to take a minimum of one span, which returns the instant
+  // a span is available — so the batch of 100 it looks like it writes was really
+  // one INSERT, one transaction and one fsync per span, on the main process's
+  // event loop. Running a single query ends seven spans.
+  it('writes spans that end within the linger window as one batch', async () => {
+    await Effect.runPromise(
+      Effect.forEach([1, 2, 3, 4], (index) =>
+        // Spread out on purpose. Spans that all end in the same tick get batched
+        // either way; the ones a real query produces end tens of milliseconds
+        // apart, which is exactly when a minimum of one span per take turns into
+        // a write per span.
+        Effect.sleep('10 millis').pipe(Effect.withSpan(`burst.${index}`))
+      )
+        .pipe(
+          // Outlasts the linger window, so the write under test is the batched
+          // one from the drain fiber rather than the shutdown flush.
+          Effect.andThen(Effect.sleep('400 millis')),
+          Effect.provide(TracerLive)
+        )
+        .pipe(Effect.provide(makeTestAppDatabase()))
+    )
+
+    expect(
+      writeSpansSpy.mock.calls.map((call) => (call[0] as unknown[]).length)
+    ).toEqual([4])
+  })
+
   // Spans are queued rather than written inline, so the shutdown flush is the
   // only thing that keeps the spans explaining a shutdown from being lost.
   it('flushes queued spans when its scope closes', async () => {

--- a/src/server/tracing/effect-tracer.ts
+++ b/src/server/tracing/effect-tracer.ts
@@ -50,6 +50,14 @@ export function makeSquealTracer(
 // Writes are batched, so one INSERT covers a whole burst rather than one per
 // span end.
 const spanBatchSize = 100
+
+// What makes the batch real. `takeBetween` with a minimum of one returns the
+// instant a single span is available, so without a pause the drain loop wrote
+// every span on its own — its own INSERT, its own transaction, and its own fsync
+// on the main process's event loop, of which running one query produces seven.
+// Waiting a moment after the first span lets its siblings arrive, at the cost of
+// showing a trace in the dashboard up to this much later.
+const spanLingerWindow = '100 millis'
 const spanQueueCapacity = 2048
 const spanFlushTimeout = '2 seconds'
 const droppedSpanLogInterval = 100
@@ -115,12 +123,20 @@ export const TracerLive = Layer.unwrapScoped(
       )
     )
 
-    yield* Effect.forkScoped(
-      Queue.takeBetween(queue, 1, spanBatchSize).pipe(
-        Effect.flatMap((records) => writeBatch(Chunk.toReadonlyArray(records))),
-        Effect.forever
-      )
+    // Blocks on the first span, then lingers before draining the rest, so a
+    // burst becomes one write. The finalizer above is what covers the spans
+    // still queued when the linger is interrupted by teardown.
+    const drainBatch = Queue.take(queue).pipe(
+      Effect.flatMap((first) =>
+        Effect.sleep(spanLingerWindow).pipe(
+          Effect.zipRight(Queue.takeUpTo(queue, spanBatchSize - 1)),
+          Effect.map((rest) => Chunk.prepend(rest, first))
+        )
+      ),
+      Effect.flatMap((records) => writeBatch(Chunk.toReadonlyArray(records)))
     )
+
+    yield* Effect.forkScoped(Effect.forever(drainBatch))
 
     return Layer.setTracer(
       makeSquealTracer({ persist: makeQueuedPersist(queue) })

--- a/src/server/tracing/trace-skip.test.ts
+++ b/src/server/tracing/trace-skip.test.ts
@@ -28,6 +28,12 @@ describe('shouldSkipTracing', () => {
     expect(shouldSkipTracing('POST', '/updates/install')).toEqual(false)
   })
 
+  it('skips CORS preflights, including for routes that are otherwise traced', () => {
+    expect(shouldSkipTracing('OPTIONS', '/queries')).toEqual(true)
+    expect(shouldSkipTracing('OPTIONS', '/queries/some-id')).toEqual(true)
+    expect(shouldSkipTracing('OPTIONS', '/worksheets/some-id')).toEqual(true)
+  })
+
   it('traces everything else', () => {
     expect(shouldSkipTracing('GET', '/databases')).toEqual(false)
     expect(shouldSkipTracing('POST', '/worksheets')).toEqual(false)

--- a/src/server/tracing/trace-skip.ts
+++ b/src/server/tracing/trace-skip.ts
@@ -4,10 +4,21 @@
 // list, and the update-status poll, which answers from memory every minute
 // for the life of the app and would quietly eat a fifth of the span
 // retention budget. POST /updates/install stays traced — it happens once and
-// is worth seeing.
+// is worth seeing. CORS preflights are skipped outright; the browser makes them,
+// not the renderer, so they are not in that list.
 const queryPollPattern = /^\/queries\/[^/]+$/
 
 export function shouldSkipTracing(method: string, path: string): boolean {
+  // A preflight is not a request the user made, and it carries no traceparent,
+  // so tracing one produces a parentless root trace sitting next to the real
+  // request's. They are also the most numerous requests there are, since every
+  // route is preflighted — every request carries an Authorization header — and a
+  // preflight of an otherwise-untraced route was still being traced, which is
+  // how OPTIONS came to be a sixth of every span in the table.
+  if (method === 'OPTIONS') {
+    return true
+  }
+
   if (path === '/health') {
     return true
   }


### PR DESCRIPTION
## The gap

The published app felt laggy — sluggish input, slow to react — while `yarn start`
felt fine. There turned out to be two independent causes, and they multiply. **This
PR fixes the second one.**

The first is not a code problem: `/Applications/Squeal.app` is an `x86_64`-only
binary on an arm64 Mac, so everything JIT-heavy runs under Rosetta 2 at roughly
2–4× the cost. The release publishes `Squeal-<v>-arm64.dmg` and
`Squeal-<v>-x64.dmg` side by side with nothing naming which to take, and
`electron-updater.ts` keys the feed on `process.arch`, which reports `x64` under
Rosetta — so a wrong download is permanent. That is recorded in the friction log
here; the fix (a universal build) is its own change.

### The editor was reconfigured on every keystroke, and each reconfigure leaked CSS

`WorksheetEditor` handed `<CodeMirror>` a fresh `basicSetup` object, a fresh
`extensions` array and a fresh `onChange` on every render, and all three are in the
deps of the wrapper's reconfigure effect — as is `gutterExtension`, which changed
identity anyway because it depends on the re-parsed active statement. So every
keystroke dispatched a full `StateEffect.reconfigure`.

That is expensive in a way that compounds. Each reconfigure re-runs
`EditorView.theme` (the wrapper calls it in its hook body, per render), which
allocates a new class name and a **new `StyleModule`** every call. The view then
re-mounts styles, and `style-mod` never removes modules — it appends and
re-serializes the entire stylesheet's `textContent`:

```js
let text = ""
for (let i = 0; i < this.modules.length; i++) text += this.modules[i].getRules() + "\n"
this.styleTag.textContent = text
```

The `adoptedStyleSheets` fast path, which would at least be incremental, is gated on
`!root.head` and so never applies to a Document.

Net: about two dead CSS rules accumulated per keystroke, and the whole sheet was
re-serialized and re-parsed on each one — linear per keystroke, quadratic over a
session. **This is why packaged felt worse than dev**: an HMR reload resets the
leak, an app left open for hours does not.

### Every app-database write blocked the main process more than it had to

The app database is synchronous SQLite on the Electron main-process event loop
(`drizzle-orm/libsql`, a `file:` URL, and a better-sqlite3-compatible binding), so
`await appDatabase.execute(...)` is a Promise wrapping blocking work. While it runs
the main process cannot answer the renderer — and since the window is frameless, it
cannot service dragging either. Three things made that worse than necessary:

- `PRAGMA synchronous` was never lowered, so SQLite's default `FULL` fsynced the WAL
  on **every commit**.
- The span drain loop used `Queue.takeBetween(queue, 1, spanBatchSize)`, which
  returns the instant one span is available. Spans that end together were batched,
  but the ones a real operation produces end tens of milliseconds apart — running one
  query ends seven — so in practice the batch of 100 was one INSERT, one transaction
  and one fsync **per span**.
- CORS sent no `Access-Control-Max-Age`. Every renderer request carries an
  `Authorization` header, so every one is a preflighted cross-origin request, and
  Chromium's fallback cache is ~5s — the 250ms poller and the autosave paid a second
  round trip over and over. Preflights were also traced, including for routes that
  are deliberately untraced (`trace-skip` only matched `GET`), and since a preflight
  carries no `traceparent` each became a parentless root trace: 22 of the 135 spans
  in the dev database.

## The change

| Commit | |
| --- | --- |
| `fix(editor)` | `basicSetup` becomes a module constant, the callbacks read their props through refs the way the keymap already did, and the active-statement gutter moves into a `Compartment` swapped by an effect — so the `extensions` array's identity never changes and no reconfigure is dispatched. `basicSetup` was also registering `autocompletion` a second time. |
| `perf(database)` | `PRAGMA synchronous = NORMAL`, the standard pairing with WAL. |
| `perf(tracing)` | A 100ms linger after the first span, so the batch of 100 is real. |
| `perf(http)` | `maxAge: 600` (Chromium's ceiling), and `OPTIONS` skipped in `trace-skip`. |

## The one judgement call

`synchronous = NORMAL` trades durability for responsiveness: an OS-level crash can
lose the most recent commits, though the database still cannot corrupt. What is at
stake is query history and spans, which seemed worth less than a window that does
not stall on every write — but it is a deliberate trade and easy to revert on its
own if you disagree.

The linger window has a smaller version of the same shape: a trace shows up in the
dashboard up to 100ms later than it used to.

## Measured

Driven with agent-browser against the running app — the same instrument and the same
17 keystrokes, before and after, in a throwaway worksheet:

| | stylesheet text | generated CSS rules |
| --- | --- | --- |
| before | 94,727 → 96,047 (**+1,320**) | 280 → 320 (**+40**) |
| after | 91,625 → 91,625 (**0**) | 186 → 186 (**0**) |

The gutter still tracks the cursor across statements: with the caret in the second
statement of `select 1;` / `select 2;` the marker sits on line 3, and clicking into
the first moves it to line 1.

`Access-Control-Max-Age: 600` is on the preflight response, and since the restart no
`http.server OPTIONS` span has been written while other spans keep landing (newest
`OPTIONS` span 19:15, previous session; newest span overall 19:38, current one).

## Tests

`916` pass; typecheck, lint and prettier are clean.

- `WorksheetEditor.test.tsx` is new: it renders through three keystrokes and asserts
  a single identity for each of `basicSetup`, `extensions`, `onChange` and
  `onUpdate`. It reports 4 identities each against the old component. It asserts
  identity rather than deep equality on purpose — a deep comparison passes happily on
  freshly allocated objects that would each trigger their own reconfigure.
- The span-batching test spaces its spans out deliberately. **The first version of it
  passed against the old drain loop**, because spans that end in the same tick get
  batched either way; only spans that end apart expose a minimum of one per take.
- `trace-skip.test.ts` covers preflights of otherwise-traced routes.

## Not verified

`PRAGMA synchronous = NORMAL` is asserted only by the app booting without a
`$TMPDIR/squeal-boot-error.log`. `synchronous` is a per-connection setting, so
reading it from a second connection reports that connection's value, not the app's —
there is no way to observe the running app's from outside it.

Everything here was measured in a dev build on Apple Silicon. How much of the
original lag was Rosetta and how much was this is still unmeasured, and needs a
native install to answer.

## Not in this PR

The universal macOS build (the actual fix for the Rosetta trap), and four renderer
findings that share the same shape as the editor bug: a keystroke re-rendering the
whole `Workspace` subtree including the sidebar, `DatabaseExplorer` recomputing over
every table of every database in its render body, `QueryResultTable` mounting a Radix
`ContextMenu` per **cell**, and `QueryRunner.list` selecting the stored `result` JSON
for 250 rows on every collection load. Also still open: the span cap sweep is an
unindexed full scan that runs at boot, and nothing ever `VACUUM`s — which is why the
dev database is 241 MB of 97%-free pages holding 135 spans.
