### PR TITLE
fix(sql-parser): clamp token end to the end of the input

### DIFF
--- a/src/app/sql-parser/parser.test.ts
+++ b/src/app/sql-parser/parser.test.ts
@@ -193,6 +193,25 @@ DELETE FROM users`
       })
     })
 
+    // A statement takes its end from its last token, so a token running past
+    // the input would put the statement past it too.
+    it('ends an unterminated string literal at the end of the input', () => {
+      const sql = "SELECT 'abc"
+
+      const result = createAstFromSql(sql)
+
+      expect(result).toEqual({
+        statements: [
+          {
+            end: sql.length,
+            start: 0,
+            text: "SELECT 'abc",
+            type: 'select'
+          }
+        ]
+      })
+    })
+
     it('handles just a keyword', () => {
       const result = createAstFromSql('SELECT')
 

--- a/src/app/sql-parser/tokenizer.test.ts
+++ b/src/app/sql-parser/tokenizer.test.ts
@@ -512,13 +512,73 @@ describe('tokenize', () => {
       })
     })
 
+    // The three fields of a token have to agree: `value` is what the slice
+    // says, and `end` is where the slice stopped. Nothing downstream should have
+    // to defend against a token pointing past its own input, and `tokenize`
+    // advances by `end`, so a token has to consume at least one character.
     it('positions match the original string indices', () => {
-      const sql = 'SELECT id'
+      const inputs = [
+        'SELECT id',
+        'SELECT * FROM users WHERE id = 1',
+        "SELECT 'abc",
+        "SELECT 'abc''def",
+        "SELECT 'abc''",
+        '/*abc',
+        '/*abc*',
+        '/*/',
+        '"abc',
+        '`abc',
+        '-- trailing comment',
+        "SELECT * FROM t WHERE name = 'a"
+      ]
+
+      for (const sql of inputs) {
+        for (const token of tokenize(sql)) {
+          expect({
+            end: token.end,
+            sliced: sql.slice(token.start, token.end)
+          }).toEqual({
+            end: Math.min(token.end, sql.length),
+            sliced: token.value
+          })
+
+          expect(token.end).toBeGreaterThan(token.start)
+        }
+      }
+    })
+  })
+
+  // An unterminated string, comment or quoted identifier exists on every
+  // keystroke while the user is still typing one, and the parse runs on every
+  // keystroke — so these are the common case, not an edge case.
+  describe('unterminated input', () => {
+    it('does not run a string past the end of the input', () => {
+      const sql = "SELECT 'abc"
       const tokens = tokenize(sql)
 
-      for (const token of tokens) {
-        expect(sql.slice(token.start, token.end)).toEqual(token.value)
-      }
+      expect(tokens).toEqual([
+        { end: 6, start: 0, type: 'keyword', value: 'SELECT' },
+        { end: 7, start: 6, type: 'whitespace', value: ' ' },
+        { end: sql.length, start: 7, type: 'string', value: "'abc" }
+      ])
+    })
+
+    it('does not run a block comment past the end of the input', () => {
+      const sql = '/*abc'
+      const tokens = tokenize(sql)
+
+      expect(tokens).toEqual([
+        { end: sql.length, start: 0, type: 'comment', value: '/*abc' }
+      ])
+    })
+
+    it('does not run a quoted identifier past the end of the input', () => {
+      const sql = '"abc'
+      const tokens = tokenize(sql)
+
+      expect(tokens).toEqual([
+        { end: sql.length, start: 0, type: 'identifier', value: '"abc' }
+      ])
     })
   })
 

--- a/src/app/sql-parser/tokenizer.ts
+++ b/src/app/sql-parser/tokenizer.ts
@@ -1,3 +1,5 @@
+import invariant from 'tiny-invariant'
+
 export type TokenType =
   | 'comment'
   | 'identifier'
@@ -30,6 +32,15 @@ export function tokenize(sql: string): Token[] {
       continue
     }
 
+    // Every reader must consume at least one character. A zero-width token
+    // would leave `position` where it is and spin here forever, freezing the
+    // renderer with no error — and this runs on every keystroke, so the loop
+    // says so rather than trusting it.
+    invariant(
+      token.end > position,
+      `Tokenizer made no progress at position ${position}.`
+    )
+
     tokens.push(token)
     position = token.end
   }
@@ -37,13 +48,25 @@ export function tokenize(sql: string): Token[] {
   return tokens
 }
 
+// The readers that consume a closing delimiter step past it unconditionally, so
+// on unterminated input they ask for an `end` beyond the string. Deriving `end`
+// from the slice clamps it here — the one place every token is built — instead
+// of leaving each consumer to defend against a token that points past its own
+// input.
+//
+// This has to stay a clamp and never a decrement: `tokenize` advances by
+// `token.end`, so a token ending at or before its start would loop forever. It
+// is a clamp because `position < sql.length` on entry guarantees the slice keeps
+// at least one character, and `tokenize` asserts the progress it depends on.
 function createToken(
   sql: string,
   start: number,
   end: number,
   type: TokenType
 ): Token {
-  return { end, start, type, value: sql.slice(start, end) }
+  const value = sql.slice(start, end)
+
+  return { end: start + value.length, start, type, value }
 }
 
 function readBlockComment(sql: string, position: number): Token | null {
@@ -173,10 +196,11 @@ function readWord(sql: string, position: number): Token | null {
   }
 
   const end = scanWhile(sql, position, /[a-zA-Z0-9_]/)
-  const value = sql.slice(position, end)
-  const type = keywords.has(value.toUpperCase()) ? 'keyword' : 'identifier'
+  const type = keywords.has(sql.slice(position, end).toUpperCase())
+    ? 'keyword'
+    : 'identifier'
 
-  return { end, start: position, type, value }
+  return createToken(sql, position, end, type)
 }
 
 function scanWhile(sql: string, position: number, pattern: RegExp): number {


### PR DESCRIPTION
Closes #64

## The defect

`createToken` derived `value` with `sql.slice(start, end)` — which clamps — but passed `end` through untouched. The three readers that consume a closing delimiter (`readBlockComment`, `readQuotedIdentifier`, `readString`) each scan while `end < sql.length` and then apply an **unconditional** `end++` to step past the closer, so on unterminated input they asked for an `end` past the string:

```
tokenize("SELECT 'abc")  // 11 characters
// → { start: 7, end: 12, value: "'abc" }
```

`end > sql.length`, and `sql.slice(start, end) !== value`. That propagated into `Statement.end`, which takes the last token's `end`.

This is the common case, not an edge case: an unterminated string literal exists on **every keystroke** while a user is typing one, and the parse runs on every keystroke.

## The failing tests that pin it

Three cases asserting the whole token array for `SELECT 'abc`, `/*abc` and `"abc`, plus the existing `positions match the original string indices` property test extended to twelve inputs (well-formed and unterminated) asserting `end === Math.min(end, sql.length)`, `sql.slice(start, end) === value`, and `end > start`. In `parser.test.ts`, `createAstFromSql("SELECT 'abc")` now pins `end === 11`.

All five failed against the unfixed tokenizer, each reporting an `end` exactly one past the input length.

## The fix

Derive `end` from the slice at the single construction point. `readWord` — the one reader that built its token by hand — now goes through `createToken` too, so that choke point really is the only place a token is built.

`tokenize` advances by `token.end`, so this must stay a clamp and never become a decrement: a zero-width token would spin the loop forever and freeze the renderer with no error. That invariant is now asserted in the loop rather than only described in a comment.

## Deliberately not in scope

`worksheet-editor-lines.ts`'s `if (endLine === -1)` recovery stays — a stale `content`/`statements` pair can still produce an out-of-range end from a different cause.

Reviewing this turned up four **separate, verified** bugs in the same call chain, none of them in these lines and none fixed here:

1. `readBlockComment` ends at the first `*/` with no nesting, and also lets the opener's `*` serve as the closer's, so `/*/` reads as *closed*. Both turn commented-out SQL into a runnable statement — `/* a /* b */ keep\nDELETE FROM users;\n*/` yields a statement whose text is exactly `DELETE FROM users;`.
2. `readQuotedIdentifier` has no doubled-quote escape, so `"a""b"` splits into two identifier tokens.
3. `createStatement` folds a trailing unterminated comment into the runnable statement text, so `SELECT 1 /*abc` is sent as-is and the server answers `unterminated /* comment`.

Worth their own issues; (1) is the serious one.