### PR TITLE
fix(results): give each result column its own alignment and identity

### DIFF
--- a/src/app/components/QueryResultTable.test.tsx
+++ b/src/app/components/QueryResultTable.test.tsx
@@ -169,6 +169,103 @@ describe('QueryResultTable', () => {
     expect(screen.getByText('Copy Column Name')).toBeInTheDocument()
     expect(screen.getByText('Copy Row')).toBeInTheDocument()
   })
+
+  describe('alignment', () => {
+    const numericResult = {
+      fields: [{ name: 'name' }, { name: 'total' }],
+      rowCount: 2,
+      rows: [
+        { name: 'Alice', total: 1000 },
+        { name: 'Bob', total: 25 }
+      ],
+      truncated: false
+    }
+
+    it('right-aligns a numeric column header over its values', () => {
+      render(<QueryResultTable result={numericResult} />)
+
+      expect(screen.getByRole('columnheader', { name: 'total' })).toHaveClass(
+        'text-right'
+      )
+    })
+
+    it('leaves a text column header left-aligned', () => {
+      render(<QueryResultTable result={numericResult} />)
+
+      expect(screen.getByRole('columnheader', { name: 'name' })).toHaveClass(
+        'text-left'
+      )
+    })
+
+    // A null used to be aligned on its own type, so it hung off the left edge
+    // of a column of right-aligned numbers.
+    it('aligns a null in a numeric column with the rest of the column', () => {
+      render(
+        <QueryResultTable
+          result={{
+            fields: [{ name: 'total' }],
+            rowCount: 2,
+            rows: [{ total: 1000 }, { total: null }],
+            truncated: false
+          }}
+        />
+      )
+
+      const [, , nullRow] = screen.getAllByRole('row')
+
+      expect(within(nullRow).getAllByRole('cell')[1]).toHaveClass('text-right')
+    })
+  })
+
+  // Two fields can carry one name — `SELECT * FROM a JOIN b` where both have an
+  // `id`. Keying the columns by name collapsed them and gave siblings a
+  // duplicate React key, in a virtualized body that remounts constantly.
+  describe('duplicate column names', () => {
+    const duplicateResult = {
+      fields: [{ name: 'id' }, { name: 'name' }, { name: 'id' }],
+      rowCount: 1,
+      rows: [{ id: 1, name: 'Alice' }],
+      truncated: false
+    }
+
+    it('renders one header per field', () => {
+      render(<QueryResultTable result={duplicateResult} />)
+
+      expect(screen.getAllByRole('columnheader')).toHaveLength(4)
+    })
+
+    // Asserting the count, not the values: the driver's row is keyed by name, so
+    // both `id` columns still show the first one's value. That is a known limit
+    // of fixing the key model without an array row mode in the adapter.
+    it('renders one cell per field', () => {
+      render(<QueryResultTable result={duplicateResult} />)
+
+      const [, firstRow] = screen.getAllByRole('row')
+
+      // Three fields plus the row-number gutter.
+      expect(within(firstRow).getAllByRole('cell')).toHaveLength(4)
+    })
+
+    it('does not warn about duplicate keys', () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined)
+
+      try {
+        render(<QueryResultTable result={duplicateResult} />)
+
+        expect(
+          consoleError.mock.calls.filter((call) =>
+            String(call[0]).includes('same key')
+          )
+        ).toEqual([])
+      } finally {
+        // In a finally so a failure here does not leave console.error stubbed
+        // for every test after it, silently swallowing their warnings.
+        consoleError.mockRestore()
+      }
+    })
+  })
 })
 
 describe('formatRowAsCsv', () => {

--- a/src/app/components/QueryResultTable.tsx
+++ b/src/app/components/QueryResultTable.tsx
@@ -14,7 +14,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger
 } from './ui/context-menu'
-import { getColumnWidths, rowNumberColumnWidth } from './query-result-columns'
+import { getResultColumns, rowNumberColumnWidth } from './query-result-columns'
 import {
   formatCellValue,
   formatRowAsCsv,
@@ -38,17 +38,23 @@ export const QueryResultTable = memo(function QueryResultTable({
 
   // Fall back to the row keys if the adapter returned rows without field
   // metadata, so a fields/rows desync can never blank out the columns.
-  const fieldNames = useMemo(
+  const columns = useMemo(
     () =>
-      result.fields.length > 0
-        ? result.fields.map((field) => field.name)
-        : Object.keys(result.rows[0] ?? {}),
+      getResultColumns({
+        fieldNames:
+          result.fields.length > 0
+            ? result.fields.map((field) => field.name)
+            : Object.keys(result.rows[0] ?? {}),
+        rows: result.rows
+      }),
     [result.fields, result.rows]
   )
 
-  const columnWidths = useMemo(
-    () => getColumnWidths({ fieldNames, rows: result.rows }),
-    [fieldNames, result.rows]
+  // Derived once rather than inside the per-cell CSV closure, which would
+  // rebuild it for every rendered cell.
+  const columnNames = useMemo(
+    () => columns.map((column) => column.name),
+    [columns]
   )
 
   const virtualizer = useVirtualizer({
@@ -78,10 +84,10 @@ export const QueryResultTable = memo(function QueryResultTable({
         <colgroup>
           <col style={{ width: `${rowNumberColumnWidth}px` }} />
 
-          {fieldNames.map((name) => (
+          {columns.map((column) => (
             <col
-              key={name}
-              style={{ width: `${columnWidths[name]}px` }}
+              key={column.key}
+              style={{ width: `${column.width}px` }}
             />
           ))}
         </colgroup>
@@ -90,13 +96,18 @@ export const QueryResultTable = memo(function QueryResultTable({
           <tr>
             <th className="sticky top-0 z-[5] h-[31px] border-b border-border bg-panel2" />
 
-            {fieldNames.map((name) => (
+            {columns.map((column) => (
               <th
-                className="sticky top-0 z-[5] h-[31px] whitespace-nowrap border-b border-border bg-panel2 px-[14px] text-left text-[12px] font-medium text-text2"
-                key={name}
+                className={cn(
+                  'sticky top-0 z-[5] h-[31px] whitespace-nowrap border-b border-border bg-panel2 px-[14px] text-[12px] font-medium text-text2',
+                  // The header sits over its values, so it takes the column's
+                  // alignment rather than always hugging the left edge.
+                  column.align === 'right' ? 'text-right' : 'text-left'
+                )}
+                key={column.key}
                 scope="col"
               >
-                {name}
+                {column.name}
               </th>
             ))}
           </tr>
@@ -106,7 +117,7 @@ export const QueryResultTable = memo(function QueryResultTable({
           {paddingTop > 0 && (
             <tr aria-hidden="true">
               <td
-                colSpan={fieldNames.length + 1}
+                colSpan={columns.length + 1}
                 style={{ height: `${paddingTop}px` }}
               />
             </tr>
@@ -124,16 +135,21 @@ export const QueryResultTable = memo(function QueryResultTable({
                   {virtualRow.index + 1}
                 </td>
 
-                {fieldNames.map((name) => {
-                  const value = row?.[name]
+                {columns.map((column) => {
+                  // Known wrong for a result with two identically-named fields:
+                  // the driver's row is keyed by name, so both columns read the
+                  // first field's value. The columns are at least distinct
+                  // elements now; showing the right value needs an array row
+                  // mode in the adapter.
+                  const value = row?.[column.name]
 
                   return (
-                    <ContextMenu key={`${virtualRow.key}-${name}`}>
+                    <ContextMenu key={`${virtualRow.key}-${column.key}`}>
                       <ContextMenuTrigger asChild>
                         <td
                           className={cn(
                             'h-[var(--row-h)] whitespace-nowrap border-b border-border2 px-[14px] font-mono text-[12px] group-hover:bg-hover',
-                            typeof value === 'number'
+                            column.align === 'right'
                               ? 'text-right'
                               : 'text-left',
                             value === null && 'text-text3 italic'
@@ -157,7 +173,9 @@ export const QueryResultTable = memo(function QueryResultTable({
 
                         <ContextMenuItem
                           className="text-xs"
-                          onSelect={() => navigator.clipboard.writeText(name)}
+                          onSelect={() =>
+                            navigator.clipboard.writeText(column.name)
+                          }
                         >
                           Copy Column Name
                         </ContextMenuItem>
@@ -174,7 +192,7 @@ export const QueryResultTable = memo(function QueryResultTable({
                               className="text-xs"
                               onSelect={() =>
                                 navigator.clipboard.writeText(
-                                  formatRowAsCsv(row ?? {}, fieldNames)
+                                  formatRowAsCsv(row ?? {}, columnNames)
                                 )
                               }
                             >
@@ -204,7 +222,7 @@ export const QueryResultTable = memo(function QueryResultTable({
           {paddingBottom > 0 && (
             <tr aria-hidden="true">
               <td
-                colSpan={fieldNames.length + 1}
+                colSpan={columns.length + 1}
                 style={{ height: `${paddingBottom}px` }}
               />
             </tr>

--- a/src/app/components/query-result-columns.test.ts
+++ b/src/app/components/query-result-columns.test.ts
@@ -1,66 +1,195 @@
 import { describe, expect, it } from 'vitest'
 
-import { columnSampleSize, getColumnWidths } from './query-result-columns'
+import { columnSampleSize, getResultColumns } from './query-result-columns'
 
-describe('getColumnWidths', () => {
-  it('sizes a column from its widest sampled value', () => {
-    const narrow = getColumnWidths({
-      fieldNames: ['id'],
-      rows: [{ id: 1 }, { id: 22 }]
-    })
-    const wide = getColumnWidths({
-      fieldNames: ['id'],
-      rows: [{ id: 1 }, { id: 'a much longer value than the others' }]
+describe('getResultColumns', () => {
+  describe('widths', () => {
+    it('sizes a column from its widest sampled value', () => {
+      const [narrow] = getResultColumns({
+        fieldNames: ['id'],
+        rows: [{ id: 1 }, { id: 22 }]
+      })
+      const [wide] = getResultColumns({
+        fieldNames: ['id'],
+        rows: [{ id: 1 }, { id: 'a much longer value than the others' }]
+      })
+
+      expect(wide.width).toBeGreaterThan(narrow.width)
     })
 
-    expect(wide.id).toBeGreaterThan(narrow.id)
+    it('never sizes a column below the minimum', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['n'],
+        rows: [{ n: 1 }]
+      })
+
+      expect(column.width).toEqual(80)
+    })
+
+    it('caps a very wide column at the maximum', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['blob'],
+        rows: [{ blob: 'x'.repeat(5000) }]
+      })
+
+      expect(column.width).toEqual(420)
+    })
+
+    it('accounts for the header when every value is short', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['a_rather_long_column_name'],
+        rows: [{ a_rather_long_column_name: 'x' }]
+      })
+
+      expect(column.width).toBeGreaterThan(80)
+    })
+
+    it('only samples the first page of rows', () => {
+      const rows = [
+        ...Array.from({ length: columnSampleSize }, () => ({ value: 'short' })),
+        { value: 'a value far beyond the sampled page'.repeat(3) }
+      ]
+
+      const sampled = getResultColumns({ fieldNames: ['value'], rows })
+      const unsampled = getResultColumns({
+        fieldNames: ['value'],
+        rows: [{ value: 'short' }]
+      })
+
+      expect(sampled).toEqual(unsampled)
+    })
+
+    it('returns one column per requested field, in order', () => {
+      const columns = getResultColumns({
+        fieldNames: ['one', 'two'],
+        rows: [{ one: 'a', two: 'b' }]
+      })
+
+      expect(columns.map((column) => column.name)).toEqual(['one', 'two'])
+    })
   })
 
-  it('never sizes a column below the minimum', () => {
-    const widths = getColumnWidths({ fieldNames: ['n'], rows: [{ n: 1 }] })
+  // The header has to sit over its values, and a column has no single cell to
+  // copy an alignment from — so the column owns it, derived from the rows.
+  describe('alignment', () => {
+    it('right-aligns a column whose sampled values are all numbers', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['total'],
+        rows: [{ total: 1 }, { total: 22 }]
+      })
 
-    expect(widths.n).toEqual(80)
-  })
-
-  it('caps a very wide column at the maximum', () => {
-    const widths = getColumnWidths({
-      fieldNames: ['blob'],
-      rows: [{ blob: 'x'.repeat(5000) }]
+      expect(column).toEqual({
+        align: 'right',
+        key: '0:total',
+        name: 'total',
+        width: 80
+      })
     })
 
-    expect(widths.blob).toEqual(420)
-  })
+    // Postgres hands `bigint`, `numeric`, `decimal` and `money` over as strings,
+    // so `count(*)` and money columns stay left-aligned — header and cells
+    // together. Right-aligning them needs the declared column type, which the
+    // adapter drops today.
+    it('left-aligns a column of numbers the driver returned as strings', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['count'],
+        rows: [{ count: '1000' }, { count: '25' }]
+      })
 
-  it('accounts for the header when every value is short', () => {
-    const widths = getColumnWidths({
-      fieldNames: ['a_rather_long_column_name'],
-      rows: [{ a_rather_long_column_name: 'x' }]
+      expect(column).toEqual({
+        align: 'left',
+        key: '0:count',
+        name: 'count',
+        width: 80
+      })
     })
 
-    expect(widths.a_rather_long_column_name).toBeGreaterThan(80)
-  })
+    it('right-aligns a numeric column that also holds nulls', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['total'],
+        rows: [{ total: 1 }, { total: null }, { total: 3 }]
+      })
 
-  it('only samples the first page of rows', () => {
-    const rows = [
-      ...Array.from({ length: columnSampleSize }, () => ({ value: 'short' })),
-      { value: 'a value far beyond the sampled page'.repeat(3) }
-    ]
-
-    const sampled = getColumnWidths({ fieldNames: ['value'], rows })
-    const unsampled = getColumnWidths({
-      fieldNames: ['value'],
-      rows: [{ value: 'short' }]
+      expect(column.align).toEqual('right')
     })
 
-    expect(sampled).toEqual(unsampled)
-  })
+    it('left-aligns a column of strings', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['name'],
+        rows: [{ name: 'Alice' }, { name: 'Bob' }]
+      })
 
-  it('sizes every requested column', () => {
-    const widths = getColumnWidths({
-      fieldNames: ['one', 'two'],
-      rows: [{ one: 'a', two: 'b' }]
+      expect(column.align).toEqual('left')
     })
 
-    expect(Object.keys(widths)).toEqual(['one', 'two'])
+    it('left-aligns a column that mixes numbers and strings', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['mixed'],
+        rows: [{ mixed: 1 }, { mixed: 'two' }]
+      })
+
+      expect(column.align).toEqual('left')
+    })
+
+    it('left-aligns a column with nothing but nulls', () => {
+      const [column] = getResultColumns({
+        fieldNames: ['empty'],
+        rows: [{ empty: null }, { empty: null }]
+      })
+
+      expect(column.align).toEqual('left')
+    })
+
+    it('left-aligns a column with no rows to judge from', () => {
+      const [column] = getResultColumns({ fieldNames: ['unknown'], rows: [] })
+
+      expect(column.align).toEqual('left')
+    })
+
+    // Deliberate consequence of one alignment per column, judged from one page:
+    // values past the sample cannot change it. Pinned in both directions so a
+    // change here is a decision rather than a surprise.
+    it('judges alignment from the sampled page only', () => {
+      const numericBelowSample = [
+        ...Array.from({ length: columnSampleSize }, () => ({ value: null })),
+        { value: 42 }
+      ]
+      const textBelowSample = [
+        ...Array.from({ length: columnSampleSize }, () => ({ value: 1 })),
+        { value: 'not a number' }
+      ]
+
+      const [nullSampled] = getResultColumns({
+        fieldNames: ['value'],
+        rows: numericBelowSample
+      })
+      const [numberSampled] = getResultColumns({
+        fieldNames: ['value'],
+        rows: textBelowSample
+      })
+
+      expect({
+        nullSampled: nullSampled.align,
+        numberSampled: numberSampled.align
+      }).toEqual({ nullSampled: 'left', numberSampled: 'right' })
+    })
+  })
+
+  // `SELECT * FROM a JOIN b` where both carry an `id`, or `SELECT 1 AS x, 2 AS
+  // x`, produces two fields with one name. Keying by name collapsed them into a
+  // single entry and gave sibling elements a duplicate React key.
+  describe('duplicate field names', () => {
+    it('returns one column per field, each with its own identity', () => {
+      const columns = getResultColumns({
+        fieldNames: ['id', 'name', 'id'],
+        rows: [{ id: 1, name: 'Alice' }]
+      })
+
+      expect(columns).toEqual([
+        { align: 'right', key: '0:id', name: 'id', width: 80 },
+        { align: 'left', key: '1:name', name: 'name', width: 80 },
+        { align: 'right', key: '2:id', name: 'id', width: 80 }
+      ])
+    })
   })
 })

--- a/src/app/components/query-result-columns.ts
+++ b/src/app/components/query-result-columns.ts
@@ -15,9 +15,19 @@ const cellPadding = 28
 
 export const rowNumberColumnWidth = 44
 
-export interface ColumnWidthInput {
+interface ResultColumnsInput {
   fieldNames: string[]
   rows: Record<string, unknown>[]
+}
+
+export interface ResultColumn {
+  align: 'left' | 'right'
+  // Position, not name: a result can carry two fields with one name (`SELECT *
+  // FROM a JOIN b` where both have an `id`), and nothing upstream forbids it —
+  // so the name is not usable as an identity or a React key.
+  key: string
+  name: string
+  width: number
 }
 
 function widthForCharacters(characters: number): number {
@@ -27,31 +37,61 @@ function widthForCharacters(characters: number): number {
 }
 
 /**
- * Pins a pixel width per column, measured from the header and the first page of
- * rows. Values further down the result can be wider than the sample — those
- * cells are clipped by `whitespace-nowrap` rather than being allowed to reflow
- * every other column mid-scroll.
+ * Describes each column of a result: its identity, its pinned pixel width, and
+ * the alignment its header and cells share.
+ *
+ * The width is measured from the header and the first page of rows. Values
+ * further down the result can be wider than the sample — those cells are
+ * clipped by `whitespace-nowrap` rather than being allowed to reflow every
+ * other column mid-scroll. The alignment is inferred from that same page for
+ * the same reason, so a column holding numbers throughout the sample and text
+ * further down keeps the alignment the sample implied, and a column whose whole
+ * sample is null is left-aligned even if numbers appear later.
+ *
+ * Only values the driver hands over as JS numbers count. Postgres returns
+ * `bigint`, `numeric`, `decimal` and `money` as strings, so those columns stay
+ * left-aligned — header and cells together, which is the mismatch this exists to
+ * remove. Right-aligning them needs the column's declared type, which the
+ * adapter currently drops.
  */
-export function getColumnWidths({
+export function getResultColumns({
   fieldNames,
   rows
-}: ColumnWidthInput): Record<string, number> {
+}: ResultColumnsInput): ResultColumn[] {
   const sample = rows.slice(0, columnSampleSize)
-  const widths: Record<string, number> = {}
 
-  for (const fieldName of fieldNames) {
+  return fieldNames.map((fieldName, index) => {
+    let everyValueIsNumeric = true
     let longest = fieldName.length
+    let sawValue = false
 
     for (const row of sample) {
-      const length = formatCellValue(row[fieldName]).length
+      const value = row[fieldName]
+      const length = formatCellValue(value).length
 
       if (length > longest) {
         longest = length
       }
+
+      // Nulls do not vote on alignment: a numeric column keeps its alignment
+      // through them, which is what stops a null from hanging off the left edge
+      // of a column of right-aligned numbers.
+      if (value === null || value === undefined) {
+        continue
+      }
+
+      sawValue = true
+
+      if (typeof value !== 'number') {
+        everyValueIsNumeric = false
+      }
     }
 
-    widths[fieldName] = widthForCharacters(longest)
-  }
-
-  return widths
+    return {
+      align: sawValue && everyValueIsNumeric ? 'right' : 'left',
+      key: `${index}:${fieldName}`,
+      name: fieldName,
+      width: widthForCharacters(longest)
+    }
+  })
 }


### PR DESCRIPTION
Closes #48
Closes #63

## The defect

The header `<th>` hardcoded `text-left`, while the body `<td>` picked alignment **per value** (`typeof value === 'number' ? 'text-right' : 'text-left'`). So a numeric column's header floated at the far left with every value at the far right and the full column width in between, and a `NULL` inside a numeric column hung off the left edge of a column of right-aligned numbers.

Alignment cannot be copied from a cell, because the header has no cell of its own. The column has to own it — which required replacing the name-keyed `Record<string, number>` that `getColumnWidths` returned. That record also *is* #63: two fields can share a name (`SELECT * FROM a JOIN b` where both carry an `id`; `SELECT 1 AS x, 2 AS x`), which collapsed them to one entry, and the same name was the React key for `<col>`, `<th>` and every cell in a virtualized body.

## The failing tests that pin it

`getResultColumns` did not exist, so all 14 unit cases failed. In the component: the `total` header asserting `text-right`, and a `NULL` in a numeric column asserting `text-right`, both failed against the hardcoded `text-left`. The duplicate-name render test failed with **5 real React "same key" warnings**, which is the direct evidence #63 is reachable rather than theoretical.

## The fix

One `ResultColumn[]` of `{ align, key, name, width }`, built in the single pass that already walks the sampled rows. `key` is `` `${index}:${name}` `` — position is the column's identity here. A column is right-aligned when every non-null sampled value is a number; nulls do not vote, so they follow their column instead of aligning on their own type.

## Two limits, deliberate and marked at the code

**Postgres numerics stay left-aligned.** `pg` returns `bigint`, `numeric`, `decimal` and `money` as JS *strings* and the adapter sets no type parsers, so `count(*)` and money columns are not seen as numeric. Header and cells agree — the mismatch this PR is about is gone — but right-aligning them at all needs the declared column type, and `toQueryResult` receives `field.dataTypeID` and throws it away. That is a separate change to the adapter and the contract. There is a test pinning the current behaviour so it is a decision, not an accident.

**Duplicate-named columns still show the same value.** The adapter's rows are `Record<string, unknown>`, so the two fields already collapsed upstream; the lookup is still by name and is commented as known-wrong at the call site. The columns are at least distinct elements with distinct keys now. Showing the right value needs an array row mode in the adapter.

**Alignment comes from the first 100 rows**, the same sample the pinned widths already use, so values past it cannot change it — including an all-null sample followed by numbers. Pinned in both directions by a test.