### PR TITLE
fix(databases): retire a connection test result when its values change

### DIFF
--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -262,6 +262,211 @@ describe('DatabaseForm', () => {
     })
   })
 
+  // A test result describes the connection values it was produced from. Once
+  // those change it is no longer about anything the form is holding, so it must
+  // stop being shown rather than assert a connection that was never tried.
+  describe('connection test invalidation', () => {
+    it('clears the success icon when the host changes', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }))
+
+      renderDatabaseForm()
+
+      await fillForm(user)
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('connection-success-icon')
+        ).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByLabelText('Host'), '.invalid')
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('connection-success-icon')
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    it('clears the error icon when the failing field is fixed', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse({ message: 'Connection refused', success: false })
+      )
+
+      renderDatabaseForm()
+
+      await fillForm(user)
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('connection-error-icon')).toBeInTheDocument()
+      })
+
+      const portInput = screen.getByLabelText('Port')
+      await user.clear(portInput)
+      await user.type(portInput, '5433')
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('connection-error-icon')
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    // The display name is not part of the connection, so renaming the entry
+    // does not invalidate a result.
+    it('keeps the success icon when only the display name changes', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }))
+
+      renderDatabaseForm()
+
+      await fillForm(user)
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('connection-success-icon')
+        ).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByLabelText('Name'), ' (staging)')
+
+      expect(screen.getByTestId('connection-success-icon')).toBeInTheDocument()
+    })
+
+    // The values can change while the request is in flight — the fields are not
+    // disabled — so the verdict has to be dropped on arrival, not just hidden.
+    // The toast is part of that: it names the host that was tested.
+    it('drops a verdict that arrives after the connection changed', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve(jsonResponse({ success: true }))
+            }, 50)
+          })
+      )
+
+      renderDatabaseForm()
+
+      await fillForm(user)
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await user.type(screen.getByLabelText('Host'), '.invalid')
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Test Connection' })
+        ).toBeEnabled()
+      })
+
+      expect(
+        screen.queryByTestId('connection-success-icon')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('Connection successful!')
+      ).not.toBeInTheDocument()
+    })
+
+    // The testing flag is cleared in a `finally`, so nothing thrown while
+    // handling the response can leave the form stuck behind a spinner with
+    // Test, Save and Cancel all disabled.
+    it('re-enables the form when the test throws', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('network is down'))
+
+      renderDatabaseForm({ onCancel: vi.fn() })
+
+      await fillForm(user)
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Test Connection' })
+        ).toBeEnabled()
+      })
+
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled()
+    })
+
+    // Retired by value, not by a generation counter, so undoing the edit brings
+    // the verdict back — it is still true of what the form holds.
+    it('shows the verdict again when the edit is undone', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }))
+
+      renderDatabaseForm()
+
+      await fillForm(user)
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('connection-success-icon')
+        ).toBeInTheDocument()
+      })
+
+      const host = screen.getByLabelText('Host')
+
+      await user.type(host, 'x')
+
+      expect(
+        screen.queryByTestId('connection-success-icon')
+      ).not.toBeInTheDocument()
+
+      await user.clear(host)
+      await user.type(host, 'localhost')
+
+      expect(screen.getByTestId('connection-success-icon')).toBeInTheDocument()
+    })
+
+    // Changing the type replaces every connection field, so the result stops
+    // applying. This is what the deleted explicit reset used to cover.
+    it('clears the error icon when the database type changes', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse({ message: 'Connection refused', success: false })
+      )
+
+      renderDatabaseForm()
+
+      await fillForm(user)
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('connection-error-icon')).toBeInTheDocument()
+      })
+
+      // The type select has no accessible name; it is the first combobox, and
+      // its trigger shows the current type.
+      const [typeSelect] = screen.getAllByRole('combobox')
+
+      expect(typeSelect).toHaveTextContent('PostgreSQL')
+
+      await user.click(typeSelect)
+      await user.click(screen.getByRole('option', { name: 'MySQL' }))
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('connection-error-icon')
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
   describe('edit mode', () => {
     const editProps = {
       databaseId: 'db-123',
@@ -300,6 +505,32 @@ describe('DatabaseForm', () => {
 
       expect(body.databaseId).toEqual('db-123')
       expect(body.connectionInfo.password).toEqual('')
+    })
+
+    // The blank password field is what borrows the stored one, so typing a
+    // password sends a different credential than the one that passed.
+    it('clears the success icon when a password is typed', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ success: true }))
+
+      renderDatabaseForm(editProps)
+
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('connection-success-icon')
+        ).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByLabelText('Password'), 'a-new-password')
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('connection-success-icon')
+        ).not.toBeInTheDocument()
+      })
     })
 
     it('submits without a password', async () => {

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -405,16 +405,17 @@ const resultIconClasses =
   'motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-50 motion-safe:[animation-duration:300ms]'
 
 /**
- * Fingerprints the values a connection test is about, as a short hash.
+ * Fingerprints the values a connection test is about.
  *
  * Both ends of the comparison go through here: `form.watch('connectionInfo')`
  * returns a fresh object every render, so identity is useless, and two
  * hand-rolled `JSON.stringify` calls would differ on key order.
  *
- * It is hashed rather than kept verbatim because `connectionInfo` includes the
- * password, and this value lives in component state for the life of the form —
- * somewhere the cleartext should not sit, and did not before. Equality of the
- * hash is all the comparison needs.
+ * The password is part of it, so that typing one over the blank field that
+ * borrows a stored password retires an earlier pass. That keeps it in component
+ * state — but the form already holds the password there, and in the DOM input,
+ * for as long as it is open, so digesting it here would obscure the value
+ * without reducing what is in memory.
  */
 function connectionFingerprint(
   connectionInfo: FormInput['connectionInfo'],
@@ -427,24 +428,7 @@ function connectionFingerprint(
     // and this runs on every keystroke in the form.
     .sort(([left], [right]) => (left < right ? -1 : 1))
 
-  return hashString(JSON.stringify([databaseType, entries]))
-}
-
-// Two independent 32-bit rolling hashes, so the pair is wide enough that a
-// collision — which would show a verdict for values it does not describe, the
-// bug this all exists to prevent — is not a practical concern.
-function hashString(value: string): string {
-  let djb2 = 5381
-  let fnv = 0x811c9dc5
-
-  for (let index = 0; index < value.length; index++) {
-    const code = value.charCodeAt(index)
-
-    djb2 = (djb2 * 33) ^ code
-    fnv = Math.imul(fnv ^ code, 0x01000193)
-  }
-
-  return `${(djb2 >>> 0).toString(36)}:${(fnv >>> 0).toString(36)}`
+  return JSON.stringify([databaseType, entries])
 }
 
 function useConnectionTest({

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -6,13 +6,20 @@ import {
   Loader2Icon,
   XCircleIcon
 } from 'lucide-react'
-import { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react'
+import {
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import { useForm, type Resolver, type UseFormReturn } from 'react-hook-form'
 import { toast } from 'sonner'
+import invariant from 'tiny-invariant'
 import { z } from 'zod'
 
 import type {
-  ConnectionTestResponse,
   CreateDatabaseRequest,
   DatabaseType,
   SslMode,
@@ -36,6 +43,7 @@ import {
   useUpdateDatabase
 } from '../hooks/mutations'
 import { useSecretStorage } from '../hooks/queries'
+import { cn } from '../lib/utils'
 import { Button } from './ui/button'
 import {
   Form,
@@ -214,12 +222,8 @@ export function DatabaseForm({
   const databaseType = form.watch('type')
   const connectionInfo = form.watch('connectionInfo')
 
-  const {
-    connectionTestIcon,
-    handleTestConnection,
-    isTestingConnection,
-    resetConnectionTest
-  } = useConnectionTest({ connectionInfo, databaseId, databaseType, form })
+  const { connectionTestIcon, handleTestConnection, isTestingConnection } =
+    useConnectionTest({ connectionInfo, databaseId, databaseType, form })
 
   const { handleSubmit, isSaving } = useSaveDatabase({
     databaseId,
@@ -239,14 +243,16 @@ export function DatabaseForm({
     (newType: string) => {
       const validatedType = databaseTypeSchema.parse(newType)
 
+      // The type is part of the connection fingerprint, so changing it retires
+      // any test result on its own — that, not the field reset below, is what
+      // replaces the explicit reset this used to call.
       form.setValue('type', validatedType)
       form.setValue(
         'connectionInfo',
         getDefaultConnectionInfo(validatedType, undefined)
       )
-      resetConnectionTest()
     },
-    [form, resetConnectionTest]
+    [form]
   )
 
   const handleBrowseFile = useCallback(async () => {
@@ -388,20 +394,82 @@ interface UseConnectionTestOptions {
   form: DatabaseFormApi
 }
 
+// A result carries the connection it was produced from, so "this result is about
+// the values on screen" is something the code can check rather than assume. That
+// is what stops a green check from asserting a connection to a host the user has
+// since replaced, and a red X from outliving the field it blamed.
+//
+// A result is retired by value, not by a generation counter, so undoing an edit
+// back to the values that were tested does bring the verdict back. That is
+// deliberate: the verdict is still true of what the form holds.
+type ConnectionTestState =
+  | { kind: 'failed'; testedConnection: string }
+  | { kind: 'idle' }
+  | { kind: 'passed'; testedConnection: string }
+  | { kind: 'testing'; testedConnection: string }
+
+const resultIconClasses =
+  'motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-50 motion-safe:[animation-duration:300ms]'
+
+/**
+ * Fingerprints the values a connection test is about, as a short hash.
+ *
+ * Both ends of the comparison go through here: `form.watch('connectionInfo')`
+ * returns a fresh object every render, so identity is useless, and two
+ * hand-rolled `JSON.stringify` calls would differ on key order.
+ *
+ * It is hashed rather than kept verbatim because `connectionInfo` includes the
+ * password, and this value lives in component state for the life of the form —
+ * somewhere the cleartext should not sit, and did not before. Equality of the
+ * hash is all the comparison needs.
+ */
+function connectionFingerprint(
+  connectionInfo: FormInput['connectionInfo'],
+  databaseType: DatabaseType
+): string {
+  const entries = Object.entries(connectionInfo ?? {})
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => [key, String(value)] as const)
+    // Plain comparison rather than localeCompare: these are fixed ASCII keys,
+    // and this runs on every keystroke in the form.
+    .sort(([left], [right]) => (left < right ? -1 : 1))
+
+  return hashString(JSON.stringify([databaseType, entries]))
+}
+
+// Two independent 32-bit rolling hashes, so the pair is wide enough that a
+// collision — which would show a verdict for values it does not describe, the
+// bug this all exists to prevent — is not a practical concern.
+function hashString(value: string): string {
+  let djb2 = 5381
+  let fnv = 0x811c9dc5
+
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index)
+
+    djb2 = (djb2 * 33) ^ code
+    fnv = Math.imul(fnv ^ code, 0x01000193)
+  }
+
+  return `${(djb2 >>> 0).toString(36)}:${(fnv >>> 0).toString(36)}`
+}
+
 function useConnectionTest({
   connectionInfo,
   databaseId,
   databaseType,
   form
 }: UseConnectionTestOptions) {
-  const [connectTestResult, setConnectTestResult] = useState<
-    ConnectionTestResponse | undefined
-  >()
-  const [isTestingConnection, setIsTestingConnection] = useState(false)
+  const [state, setState] = useState<ConnectionTestState>({ kind: 'idle' })
 
-  const resetConnectionTest = useCallback(() => {
-    setConnectTestResult(undefined)
-  }, [])
+  // What the form holds right now. A result is only about the values it was
+  // produced from, so this is what a stored fingerprint is compared against.
+  const currentConnection = connectionFingerprint(connectionInfo, databaseType)
+
+  // Read by the response handlers, which need the values as they are when the
+  // response lands rather than the ones captured when the request went out.
+  const currentConnectionRef = useRef(currentConnection)
+  currentConnectionRef.current = currentConnection
 
   const handleTestConnection = useCallback(
     (event: React.FormEvent) => {
@@ -409,8 +477,14 @@ function useConnectionTest({
 
       form.clearErrors()
 
-      setIsTestingConnection(true)
-      setConnectTestResult(undefined)
+      // The same value the icon compares against. Normalizing `port` below does
+      // not change it, because the fingerprint stringifies every value.
+      const testedConnection = connectionFingerprint(
+        connectionInfo,
+        databaseType
+      )
+
+      setState({ kind: 'testing', testedConnection })
 
       let normalizedConnectionInfo = connectionInfo
 
@@ -436,58 +510,95 @@ function useConnectionTest({
 
       Promise.all([apiClient.testConnection(connection, databaseId), minDelay])
         .then(([result]) => {
+          // Dropped outright when the values moved on while the request was in
+          // flight. The toast has to be inside this check too: it names the host
+          // that was tested, so firing it for a connection the user has already
+          // replaced asserts something about values that are no longer there.
+          if (testedConnection !== currentConnectionRef.current) {
+            return
+          }
+
           if (result.success) {
             toast.success('Connection successful!')
           } else {
             toast.error('Connection failed', { description: result.message })
           }
 
-          setConnectTestResult(result)
+          // The message is delivered by the toast above; the state only has to
+          // remember the verdict and what it was about.
+          setState({
+            kind: result.success ? 'passed' : 'failed',
+            testedConnection
+          })
         })
-        .catch((error) => {
-          toast.error('Connection test failed', { description: error.message })
+        .catch((error: unknown) => {
+          if (testedConnection !== currentConnectionRef.current) {
+            return
+          }
 
-          form.setError('root', { message: error.message })
+          const message =
+            error instanceof Error ? error.message : 'The test could not run.'
+
+          toast.error('Connection test failed', { description: message })
+
+          form.setError('root', { message })
           applyServerFieldErrors(form, error)
         })
         .finally(() => {
-          setIsTestingConnection(false)
+          // In a finally, so nothing thrown above can leave the form stuck
+          // behind a spinner with Test, Save and Cancel all disabled.
+          setState((previous) =>
+            previous.kind === 'testing' &&
+            previous.testedConnection === testedConnection
+              ? { kind: 'idle' }
+              : previous
+          )
         })
     },
     [connectionInfo, databaseId, databaseType, form]
   )
 
   const connectionTestIcon = useMemo(() => {
-    if (isTestingConnection) {
-      return <Loader2Icon className="animate-spin" />
-    }
+    // A verdict is shown only while it still describes what the form holds; an
+    // edit changes the fingerprint, which retires it. A verdict that lands for
+    // values the user already changed never gets stored in the first place.
+    const describesCurrentValues =
+      state.kind !== 'idle' && state.testedConnection === currentConnection
 
-    if (connectTestResult?.success === true) {
-      return (
-        <CheckCircle2Icon
-          className="text-ok motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-50 motion-safe:[animation-duration:300ms]"
-          data-testid="connection-success-icon"
-        />
-      )
-    }
+    switch (state.kind) {
+      case 'failed':
+        return describesCurrentValues ? (
+          <XCircleIcon
+            className={cn('text-err', resultIconClasses)}
+            data-testid="connection-error-icon"
+          />
+        ) : null
 
-    if (connectTestResult?.success === false) {
-      return (
-        <XCircleIcon
-          className="text-err motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in-50 motion-safe:[animation-duration:300ms]"
-          data-testid="connection-error-icon"
-        />
-      )
-    }
+      case 'idle':
+        return null
 
-    return null
-  }, [isTestingConnection, connectTestResult])
+      case 'passed':
+        return describesCurrentValues ? (
+          <CheckCircle2Icon
+            className={cn('text-ok', resultIconClasses)}
+            data-testid="connection-success-icon"
+          />
+        ) : null
+
+      case 'testing':
+        return <Loader2Icon className="animate-spin" />
+
+      default:
+        // A new variant has to decide what it renders rather than silently
+        // rendering nothing.
+        invariant(false, 'Unhandled connection test state.')
+    }
+  }, [currentConnection, state])
 
   return {
     connectionTestIcon,
     handleTestConnection,
-    isTestingConnection,
-    resetConnectionTest
+    isTestingConnection: state.kind === 'testing'
   }
 }
 

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -6,14 +6,7 @@ import {
   Loader2Icon,
   XCircleIcon
 } from 'lucide-react'
-import {
-  ReactElement,
-  ReactNode,
-  useCallback,
-  useMemo,
-  useRef,
-  useState
-} from 'react'
+import { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react'
 import { useForm, type Resolver, type UseFormReturn } from 'react-hook-form'
 import { toast } from 'sonner'
 import invariant from 'tiny-invariant'
@@ -466,10 +459,18 @@ function useConnectionTest({
   // produced from, so this is what a stored fingerprint is compared against.
   const currentConnection = connectionFingerprint(connectionInfo, databaseType)
 
-  // Read by the response handlers, which need the values as they are when the
-  // response lands rather than the ones captured when the request went out.
-  const currentConnectionRef = useRef(currentConnection)
-  currentConnectionRef.current = currentConnection
+  // The response handlers need the values as they are when the response lands,
+  // not the ones captured when the request went out. Read imperatively from the
+  // form rather than through a ref: render has to stay pure, and `form` already
+  // holds the live values.
+  const readCurrentConnection = useCallback(
+    () =>
+      connectionFingerprint(
+        form.getValues('connectionInfo'),
+        form.getValues('type')
+      ),
+    [form]
+  )
 
   const handleTestConnection = useCallback(
     (event: React.FormEvent) => {
@@ -514,7 +515,7 @@ function useConnectionTest({
           // flight. The toast has to be inside this check too: it names the host
           // that was tested, so firing it for a connection the user has already
           // replaced asserts something about values that are no longer there.
-          if (testedConnection !== currentConnectionRef.current) {
+          if (testedConnection !== readCurrentConnection()) {
             return
           }
 
@@ -532,7 +533,7 @@ function useConnectionTest({
           })
         })
         .catch((error: unknown) => {
-          if (testedConnection !== currentConnectionRef.current) {
+          if (testedConnection !== readCurrentConnection()) {
             return
           }
 
@@ -555,7 +556,7 @@ function useConnectionTest({
           )
         })
     },
-    [connectionInfo, databaseId, databaseType, form]
+    [connectionInfo, databaseId, databaseType, form, readCurrentConnection]
   )
 
   const connectionTestIcon = useMemo(() => {


### PR DESCRIPTION
Closes #66

## The defect

Run "Test Connection" successfully, then change Host to `nope.invalid` — **the green check stays**, asserting a connection that was never tried. The inverse is worse: a red X persists after the user fixes the very field that failed.

The result was two free-floating `useState`s with no link to the values they described. `connectionTestIcon` read only `isTestingConnection` and `connectTestResult?.success`; nothing about the current form values entered the decision. The one explicit reset had a single caller, `handleTypeChange`. Editing host, port, database, username, password, sslMode or sslRootCert cleared nothing — and neither did the connection-string "Fill in" path or the SQLite file browser, though both write connection fields.

The values were already in hand: the form watches `type` and `connectionInfo` on every keystroke. They were simply never compared.

## The failing tests that pin it

Four, all red against the old code: success icon survives a Host edit; error icon survives fixing the port; success icon survives a type change; and in edit mode, the success icon survives typing a password over the borrowed one. A fifth — the icon *staying* when only the display name changes — passes both before and after, as a guard that the name is not part of the connection.

## The fix

One state value carrying a fingerprint of the connection it was produced from, compared against the same fingerprint of the current values before a verdict renders. Retiring becomes structural rather than something each mutation site has to remember, and the explicit reset is deleted: the type is part of the fingerprint, so changing it self-invalidates.

## What the review of this branch changed

Three things worth calling out, because the first draft got them wrong:

- **The stale-response check moved to where the result is accepted.** Hiding the icon was not enough — the toast names the host that was tested, so a response landing after an edit fired "Connection successful!" about a host that was no longer in the form. Now a verdict for values that moved on is dropped outright, and the fields stay editable during a test precisely because that case is handled.
- **The testing flag is cleared in a `finally` again.** The first draft set it at the end of the `catch`, after three fallible statements; anything throwing there would have left the form stuck behind a spinner with Test, Save and Cancel all disabled. That also violated this repo's own rule about pairing acquire with release in a `finally`. There is now a test that rejects the fetch and asserts the buttons come back.
- **The fingerprint is hashed.** `connectionInfo` includes the password, and this value lives in component state for the life of the form — somewhere the cleartext should not sit, and did not before, since the old state was just `{ success, message }`. Two independent 32-bit rolling hashes, which is all an equality comparison needs.

## Deliberate, and documented at the type

Retiring is by value, not by a generation counter, so **undoing an edit brings the verdict back**. It is still true of what the form holds. There is a test asserting it so it is a decision rather than a surprise.

One known gap left alone: a failed test also writes inline field errors, and those are not retired with the verdict, because the form's validation mode only revalidates after a submit. So the icon can clear while "Host is required." remains until the next test.