### PR TITLE
fix(worksheets): make WorksheetService the sole owner of sortOrder

### DIFF
--- a/src/server/services/worksheet-service.test.ts
+++ b/src/server/services/worksheet-service.test.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { asc, eq, isNull } from 'drizzle-orm'
 import { Effect, Layer } from 'effect'
 import { describe, expect, it } from 'vitest'
 
@@ -78,6 +78,194 @@ describe('WorksheetService', () => {
     )
 
     expect(names).toEqual(['Third', 'First', 'Second'])
+  })
+
+  // Nothing enforces uniqueness on sortOrder, and `list` absorbs duplicates
+  // silently by falling through to `desc(createdAt)` — so a break shows up as an
+  // order the user never asked for, with no error anywhere.
+  describe('sortOrder integrity', () => {
+    // Ordered by id, because SQLite guarantees nothing without an ORDER BY and
+    // two of these assertions compare the arrays positionally.
+    const liveSortOrders = Effect.gen(function* () {
+      const appDatabase = yield* AppDatabase
+
+      const rows = yield* appDatabase.execute((client) =>
+        client
+          .select({
+            id: worksheetsTable.id,
+            sortOrder: worksheetsTable.sortOrder
+          })
+          .from(worksheetsTable)
+          .where(isNull(worksheetsTable.deletedAt))
+          .orderBy(asc(worksheetsTable.id))
+      )
+
+      return rows.map((row) => row.sortOrder)
+    })
+
+    it('refuses a reorder that leaves out a live worksheet', async () => {
+      const { error, sortOrders } = await run(
+        Effect.gen(function* () {
+          const service = yield* WorksheetService
+
+          const first = yield* service.create({ name: 'First' })
+          yield* service.create({ name: 'Second' })
+
+          const before = yield* liveSortOrders
+          const error = yield* service.reorder([first.id]).pipe(Effect.flip)
+          const after = yield* liveSortOrders
+
+          return { error, sortOrders: { after, before } }
+        })
+      )
+
+      expect(error._tag).toEqual('UnknownWorksheetIdsError')
+      expect(sortOrders.after).toEqual(sortOrders.before)
+    })
+
+    // Create A/B/C, reorder a subset, create D, reorder another subset: `create`
+    // only ever reads `min(sortOrder)`, so the renumbered rows and the new one
+    // collide and `list` returns an order nobody asked for.
+    it('never lets two live worksheets share a position', async () => {
+      const { error, sortOrders } = await run(
+        Effect.gen(function* () {
+          const service = yield* WorksheetService
+
+          const first = yield* service.create({ name: 'A' })
+          const second = yield* service.create({ name: 'B' })
+          const third = yield* service.create({ name: 'C' })
+
+          yield* service.reorder([first.id, second.id, third.id])
+
+          const fourth = yield* service.create({ name: 'D' })
+
+          // The partial list is what used to collide: D took min - 1 and the
+          // renumber then gave D and C the positions A and B already held.
+          const error = yield* service
+            .reorder([fourth.id, third.id])
+            .pipe(Effect.flip)
+
+          return { error, sortOrders: yield* liveSortOrders }
+        })
+      )
+
+      // Asserted together so the uniqueness cannot pass merely because the
+      // reorder was refused for some unrelated reason.
+      expect({
+        _tag: error._tag,
+        distinctPositions: new Set(sortOrders).size,
+        total: sortOrders.length
+      }).toEqual({
+        _tag: 'UnknownWorksheetIdsError',
+        distinctPositions: 4,
+        total: 4
+      })
+    })
+
+    it('does not count a soft-deleted worksheet as missing from the order', async () => {
+      const names = await run(
+        Effect.gen(function* () {
+          const service = yield* WorksheetService
+
+          const first = yield* service.create({ name: 'First' })
+          const second = yield* service.create({ name: 'Second' })
+          const doomed = yield* service.create({ name: 'Doomed' })
+
+          yield* service.remove(doomed.id)
+
+          const ordered = yield* service.reorder([second.id, first.id])
+
+          return ordered.map((worksheet) => worksheet.name)
+        })
+      )
+
+      expect(names).toEqual(['Second', 'First'])
+    })
+
+    it('writes no position at all when an id is unknown', async () => {
+      const { after, before } = await run(
+        Effect.gen(function* () {
+          const service = yield* WorksheetService
+
+          const first = yield* service.create({ name: 'First' })
+          const second = yield* service.create({ name: 'Second' })
+
+          const before = yield* liveSortOrders
+
+          yield* service
+            .reorder([second.id, first.id, 'missing'])
+            .pipe(Effect.flip)
+
+          const after = yield* liveSortOrders
+
+          return { after, before }
+        })
+      )
+
+      expect(after).toEqual(before)
+    })
+
+    // A repeated id passes the "every supplied id is live" check but would give
+    // that worksheet its last position and leave a gap, so the count check has
+    // to reject it too. The request schema also forbids it; this covers direct
+    // service callers.
+    it('refuses a reorder that names one worksheet twice', async () => {
+      const { error, sortOrders } = await run(
+        Effect.gen(function* () {
+          const service = yield* WorksheetService
+
+          const first = yield* service.create({ name: 'First' })
+          const second = yield* service.create({ name: 'Second' })
+          yield* service.create({ name: 'Third' })
+
+          const error = yield* service
+            .reorder([first.id, second.id, first.id])
+            .pipe(Effect.flip)
+
+          return { error, sortOrders: yield* liveSortOrders }
+        })
+      )
+
+      expect({
+        _tag: error._tag,
+        distinctPositions: new Set(sortOrders).size
+      }).toEqual({ _tag: 'UnknownWorksheetIdsError', distinctPositions: 3 })
+    })
+
+    // One statement, so there is no partial-write window to roll back from.
+    it('renumbers every worksheet in a single statement', async () => {
+      const sortOrders = await run(
+        Effect.gen(function* () {
+          const service = yield* WorksheetService
+
+          const first = yield* service.create({ name: 'First' })
+          const second = yield* service.create({ name: 'Second' })
+          const third = yield* service.create({ name: 'Third' })
+
+          yield* service.reorder([third.id, first.id, second.id])
+
+          const appDatabase = yield* AppDatabase
+
+          const rows = yield* appDatabase.execute((client) =>
+            client
+              .select({
+                name: worksheetsTable.name,
+                sortOrder: worksheetsTable.sortOrder
+              })
+              .from(worksheetsTable)
+              .orderBy(asc(worksheetsTable.sortOrder))
+          )
+
+          return rows
+        })
+      )
+
+      expect(sortOrders).toEqual([
+        { name: 'Third', sortOrder: 0 },
+        { name: 'First', sortOrder: 1 },
+        { name: 'Second', sortOrder: 2 }
+      ])
+    })
   })
 
   it('updates only the provided fields', async () => {

--- a/src/server/services/worksheet-service.ts
+++ b/src/server/services/worksheet-service.ts
@@ -1,5 +1,6 @@
-import { and, asc, desc, eq, inArray, isNull, min, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { Effect } from 'effect'
+import invariant from 'tiny-invariant'
 
 import { worksheetsTable } from '@/database/schema'
 import {
@@ -28,19 +29,19 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
         // current minimum gets it there without renumbering every other row,
         // and it also clears the legacy rows that never got a sortOrder, since
         // those sort last.
-        const [lowest] = yield* appDatabase.execute((client) =>
-          client
-            .select({ sortOrder: min(worksheetsTable.sortOrder) })
-            .from(worksheetsTable)
-            .where(isNull(worksheetsTable.deletedAt))
-        )
-
+        //
+        // The minimum is read in the INSERT itself rather than by a separate
+        // SELECT, so two concurrent creates cannot both read the same minimum
+        // and both claim the place below it. One statement is also why this
+        // needs no transaction: `AppDatabase.transaction` issues BEGIN on the
+        // one shared connection, which would make a second concurrent write
+        // either fail its own BEGIN or get rolled back along with this one.
         const [worksheet] = yield* appDatabase.execute((client) =>
           client
             .insert(worksheetsTable)
             .values({
               name: request.name,
-              sortOrder: (lowest?.sortOrder ?? 0) - 1,
+              sortOrder: sql`(select coalesce(min(${worksheetsTable.sortOrder}), 0) - 1 from ${worksheetsTable} where ${worksheetsTable.deletedAt} is null)`,
               ...(request.content === undefined
                 ? {}
                 : { content: request.content }),
@@ -49,6 +50,11 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
                 : { databaseId: request.databaseId })
             })
             .returning()
+        )
+
+        invariant(
+          worksheet,
+          'The app database did not return the created worksheet.'
         )
 
         return toWorksheetDto(worksheet)
@@ -104,35 +110,65 @@ export class WorksheetService extends Effect.Service<WorksheetService>()(
       const reorder = Effect.fn('WorksheetService.reorder')(function* (
         worksheetIds: readonly string[]
       ) {
-        const records = yield* appDatabase.execute((client) =>
-          client
-            .select({ id: worksheetsTable.id })
-            .from(worksheetsTable)
-            .where(
-              and(
-                inArray(worksheetsTable.id, [...worksheetIds]),
-                isNull(worksheetsTable.deletedAt)
-              )
-            )
+        const liveIds = new Set(
+          (yield* appDatabase.execute((client) =>
+            client
+              .select({ id: worksheetsTable.id })
+              .from(worksheetsTable)
+              .where(isNull(worksheetsTable.deletedAt))
+          )).map((record) => record.id)
         )
 
-        if (records.length !== worksheetIds.length) {
-          const knownIds = new Set(records.map((record) => record.id))
+        const unknownIds = worksheetIds.filter((id) => !liveIds.has(id))
 
+        if (unknownIds.length > 0) {
           return yield* new UnknownWorksheetIdsError({
             message: 'One or more worksheet ids are unknown.',
-            unknownIds: worksheetIds.filter((id) => !knownIds.has(id))
+            unknownIds
           })
         }
 
-        for (const [index, id] of worksheetIds.entries()) {
-          yield* appDatabase.execute((client) =>
-            client
-              .update(worksheetsTable)
-              .set({ sortOrder: index })
-              .where(eq(worksheetsTable.id, id))
-          )
+        // A reorder has to name every live worksheet exactly once. Checking only
+        // that the supplied ids exist accepts a partial list, which renumbers
+        // part of the list and leaves the rest colliding with it — and `list`
+        // absorbs the collision silently by falling through to `desc(createdAt)`.
+        //
+        // Both halves are needed: a repeated id can make the count match while
+        // still leaving a worksheet unnamed, and it would take only its last
+        // position, leaving a gap where the skipped one should have been.
+        const suppliedIds = new Set(worksheetIds)
+
+        if (
+          suppliedIds.size !== worksheetIds.length ||
+          suppliedIds.size !== liveIds.size
+        ) {
+          return yield* new UnknownWorksheetIdsError({
+            message:
+              'The worksheet list changed while you were reordering. Try again.',
+            unknownIds: []
+          })
         }
+
+        // Every position in one statement, so there is no window in which some
+        // rows are renumbered and others are not. A transaction would be the
+        // other way to get that, but `AppDatabase.transaction` issues BEGIN on
+        // the single shared connection: a concurrent write would either fail its
+        // own BEGIN and surface as "restart Squeal", or be swept into this
+        // transaction and rolled back with it after its own handler had already
+        // answered.
+        const positions = sql.join(
+          worksheetIds.map((id, index) => sql`when ${id} then ${index}`),
+          sql` `
+        )
+
+        yield* appDatabase.execute((client) =>
+          client
+            .update(worksheetsTable)
+            .set({
+              sortOrder: sql`case ${worksheetsTable.id} ${positions} end`
+            })
+            .where(inArray(worksheetsTable.id, [...worksheetIds]))
+        )
 
         return yield* list()
       })


### PR DESCRIPTION
Closes #53

## The defect

Worksheets could end up sharing a `sortOrder`, after which the sidebar shows an order the user never asked for — with no error anywhere and no way for the system to recover. `list` falls through to `desc(createdAt)`, which absorbs the corruption silently, and `create` only ever reads `min(sortOrder)`, so a later full reorder repaired it only by accident.

`reorder` guarded on `records.length !== worksheetIds.length`, which checks that every **supplied** id exists — not that every **live** worksheet was supplied. A partial list is schema-valid (the request enforces only `minItems(1)` and `uniqueIds`), and renumbering part of the list leaves the rest colliding with it. It then ran N separate updates in a loop, so a failure partway through persisted exactly that. `create` read the minimum and inserted below it as two separate statements, so two concurrent creates could both claim the same place.

The invariant was being held up by a UI convention the service did not know about: `WorksheetExplorer` always sends the full id list, and dragging is disabled while the list is filtered.

## The failing tests that pin it

A partial reorder was accepted (no error raised), and the A/B/C/D interleaving from the issue produced **2 distinct positions across 4 live worksheets**. Both now red-to-green.

## The fix, and why it is not a transaction

Both writes are single statements, which is what makes them atomic: `create` reads the minimum inside its own `INSERT`, and `reorder` sets every position in one `CASE` update. `reorder` also requires the supplied set to equal the set of live ids, exactly once each.

A transaction was the obvious alternative and the first draft used one. Reviewing this branch showed that was a **regression, not a fix**. `AppDatabase.transaction` issues `BEGIN` on the single shared libsql connection, and I reproduced both consequences against this repo's driver:

- Two concurrent transactions: the second fails with `Failed query: BEGIN`, which `toAppDatabaseError` does not classify as a constraint violation, so it surfaces as *"The app database is unavailable. Restart Squeal and try again."* — a 500 for double-clicking New Worksheet.
- A concurrent plain write during an open transaction **joins it**: the probe's fiber B inserted successfully and read its row back (so its handler would have answered 200), then the row vanished when A rolled back. Surviving rows: `[]`. On the autosave path that is silent loss of editor content.

Single statements avoid both while still closing the window the transaction was there for.

## One thing my own test caught

The review suggested comparing `worksheetIds.length !== liveIds.size`. That is insufficient: with three live worksheets, `['A','B','A']` has length 3 and passes, then assigns A its last position and leaves a gap. The check now requires the supplied ids to be distinct **and** complete, with a test for the repeated-id case.

## Deliberately not in scope

- `DatabaseService.reorder` has the identical shape and its own issue. Leaving it unfixed leaves the two divergent; a shared helper is the right eventual home.
- No database-level unique index on `sortOrder`. Now that the renumber is a single statement there are no transient duplicates, so a partial unique index has become feasible — but it is a schema change touching both `schema.ts` and `tables.ts`.
- **A behaviour consequence of rejecting partial lists:** `useCreateWorksheet` is not optimistic, so dragging during the brief window of a create POST sends a list that omits the new worksheet and is now refused. `onError` invalidates and refetches, so the correct order appears, but the actionable message is not surfaced — `mutations.ts` has no toast convention to follow, so I have not invented one here.