### PR TITLE
test(results): pin column header alignment as one class, not the other

### DIFF
--- a/src/app/components/QueryResultTable.test.tsx
+++ b/src/app/components/QueryResultTable.test.tsx
@@ -181,20 +181,29 @@ describe('QueryResultTable', () => {
       truncated: false
     }
 
+    // Asserted as "has one and not the other", because an element carrying both
+    // `text-left` and `text-right` would satisfy a presence-only check while
+    // rendering whichever the stylesheet happened to order last.
     it('right-aligns a numeric column header over its values', () => {
       render(<QueryResultTable result={numericResult} />)
 
-      expect(screen.getByRole('columnheader', { name: 'total' })).toHaveClass(
-        'text-right'
-      )
+      const header = screen.getByRole('columnheader', { name: 'total' })
+
+      expect({
+        left: header.classList.contains('text-left'),
+        right: header.classList.contains('text-right')
+      }).toEqual({ left: false, right: true })
     })
 
     it('leaves a text column header left-aligned', () => {
       render(<QueryResultTable result={numericResult} />)
 
-      expect(screen.getByRole('columnheader', { name: 'name' })).toHaveClass(
-        'text-left'
-      )
+      const header = screen.getByRole('columnheader', { name: 'name' })
+
+      expect({
+        left: header.classList.contains('text-left'),
+        right: header.classList.contains('text-right')
+      }).toEqual({ left: true, right: false })
     })
 
     // A null used to be aligned on its own type, so it hung off the left edge


### PR DESCRIPTION
Follow-up to #48 (merged in #118). This check was written just after that PR merged, so it missed the train.

## Why

The alignment tests from #48 asserted only that the header *has* `text-right`:

```ts
expect(screen.getByRole('columnheader', { name: 'total' })).toHaveClass('text-right')
```

An element carrying **both** `text-left` and `text-right` satisfies that, while the browser renders whichever the stylesheet orders last. So the test could pass with the header visibly misaligned — exactly the bug #48 set out to fix.

That gap is why I had wanted an end-to-end pass on the real app for #48. A dev server was already running on port 5173 from another session, so rather than compete for it I closed the gap in the test instead, which pins it permanently rather than once.

## The change

Assert one class present and the other absent, for both the numeric and the text column. Test-only — no production code touched.