### PR TITLE
fix(queries): make cancel answerable for a query's whole life

### DIFF
--- a/src/server/services/query-runner.test.ts
+++ b/src/server/services/query-runner.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from 'effect'
+import { Deferred, Effect, Layer, Schedule } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import { queriesTable } from '@/database/schema'
@@ -10,12 +10,14 @@ import { makeSquealTracer } from '@/server/tracing/effect-tracer'
 import {
   makeTestAdapterFactory,
   makeTestAppDatabase,
+  testEncryptionPrefix,
   TestSecretStorage,
   type TestAdapterConfig
 } from '@/test/effect-test-helper'
 import { AppDatabase } from './app-database'
 import { DatabaseService } from './database-service'
 import { QueryRunner } from './query-runner'
+import { SecretStorage } from './secret-storage'
 
 const connectionInfo: ConnectionInfo = {
   database: 'pagila',
@@ -42,6 +44,56 @@ function makeLayer(config?: TestAdapterConfig) {
   )
 
   return { layer }
+}
+
+/**
+ * A SecretStorage whose decrypt can be held open on demand, so a test can sit
+ * inside the window `loadConnection` spends waiting on the keychain — which is
+ * exactly where a cancel used to land on nothing at all.
+ */
+function makeGatedSecretStorage() {
+  // A Deferred rather than a bare promise, so a failure elsewhere in the test
+  // interrupts the parked fiber instead of hanging until the vitest timeout.
+  let gate: Deferred.Deferred<void> | undefined
+
+  const layer = Layer.succeed(
+    SecretStorage,
+    SecretStorage.make({
+      decrypt: (value: string) =>
+        Effect.gen(function* () {
+          if (gate !== undefined) {
+            yield* Deferred.await(gate)
+          }
+
+          return value.startsWith(testEncryptionPrefix)
+            ? value.slice(testEncryptionPrefix.length)
+            : value
+        }),
+      encrypt: (value: string) =>
+        Effect.succeed(`${testEncryptionPrefix}${value}`),
+      mode: Effect.sync(() => 'keychain' as const),
+      probe: Effect.sync(() => 'available' as const),
+      setMode: () => Effect.void
+    })
+  )
+
+  return {
+    // A fresh Deferred each time, so gating twice in one test really gates
+    // twice rather than sailing through an already-completed one.
+    closeGate: Effect.gen(function* () {
+      gate = yield* Deferred.make<void>()
+    }),
+    layer,
+    openGate: Effect.gen(function* () {
+      const current = gate
+
+      gate = undefined
+
+      if (current !== undefined) {
+        yield* Deferred.succeed(current, undefined)
+      }
+    })
+  }
 }
 
 type TestContext = AppDatabase | DatabaseService | QueryRunner
@@ -170,15 +222,18 @@ describe('QueryRunner', () => {
 
         yield* runner.createAndRun({ ...queryInput, databaseId: database.id })
 
-        // The background fiber registers its adapter asynchronously; retry
-        // the cancel until it lands.
+        // Cancel is total over the fiber's whole life, so this waits for the
+        // query to actually be running rather than retrying the cancel until
+        // the adapter happens to have registered.
         yield* Effect.gen(function* () {
-          yield* runner.cancel(queryInput.id)
-
           if (rejectRunningQuery === undefined) {
             return yield* Effect.fail(new Error('adapter not running yet'))
           }
-        }).pipe(Effect.retry({ times: 100 }), Effect.delay('1 millis'))
+        }).pipe(
+          Effect.retry({ schedule: Schedule.spaced('1 millis'), times: 100 })
+        )
+
+        yield* runner.cancel(queryInput.id)
 
         yield* runner.awaitIdle
 
@@ -190,6 +245,176 @@ describe('QueryRunner', () => {
     expect(cancelCalls).toBeGreaterThanOrEqual(1)
     expect(finished.error).toEqual(canceledQueryMessage)
     expect(finished.result).toBeNull()
+  })
+
+  // The persisted row, the fiber and the adapter all start at different
+  // instants. Loading the connection decrypts the stored password through the OS
+  // keychain, so there is a real window in which the query is running and no
+  // adapter exists yet — cancel has to be answerable there too.
+  it('cancels a query that has not finished loading its connection', async () => {
+    const secretStorage = makeGatedSecretStorage()
+    let runQueryCalls = 0
+
+    const adapterFactory = makeTestAdapterFactory({
+      runQuery: () => {
+        runQueryCalls = runQueryCalls + 1
+
+        return Promise.resolve({
+          fields: [{ name: 'value' }],
+          rowCount: 1,
+          rows: [{ value: 1 }],
+          truncated: false
+        })
+      }
+    })
+
+    const layer = QueryRunner.DefaultWithoutDependencies.pipe(
+      Layer.provideMerge(DatabaseService.DefaultWithoutDependencies),
+      Layer.provideMerge(adapterFactory.layer),
+      Layer.provideMerge(makeTestAppDatabase()),
+      Layer.provideMerge(secretStorage.layer)
+    )
+
+    const finished = await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const runner = yield* QueryRunner
+          const database = yield* createDatabase
+
+          // Everything from here on decrypts through a keychain that will not
+          // answer until the cancel has landed.
+          yield* secretStorage.closeGate
+
+          yield* runner.createAndRun({
+            ...queryInput,
+            databaseId: database.id
+          })
+
+          // No retry: the cancel has to be recorded on its own.
+          yield* runner.cancel(queryInput.id)
+
+          yield* secretStorage.openGate
+
+          yield* runner.awaitIdle
+
+          return yield* runner.get(queryInput.id)
+        }),
+        layer
+      )
+    )
+
+    expect({
+      error: finished.error,
+      finishedAt: finished.finishedAt,
+      result: finished.result,
+      runQueryCalls
+    }).toEqual({
+      error: canceledQueryMessage,
+      finishedAt: expect.any(Number),
+      result: null,
+      runQueryCalls: 0
+    })
+  })
+
+  // `cancel` is optional on the adapter interface and only Postgres implements
+  // it, so for MySQL and SQLite there is nothing to interrupt a running
+  // statement. The recorded intent is what makes cancel mean something there:
+  // the statement finishes, and its result is discarded rather than reported
+  // after the user was told the query was canceled.
+  it('honors a cancel an adapter cannot carry out', async () => {
+    let hasStartedQuery = false
+    let releaseQuery = (): void => undefined
+
+    const running = new Promise<void>((resolve) => {
+      releaseQuery = resolve
+    })
+
+    const finished = await run(
+      Effect.gen(function* () {
+        const runner = yield* QueryRunner
+        const database = yield* createDatabase
+
+        yield* runner.createAndRun({ ...queryInput, databaseId: database.id })
+
+        yield* Effect.gen(function* () {
+          if (!hasStartedQuery) {
+            return yield* Effect.fail(new Error('query not running yet'))
+          }
+        }).pipe(
+          Effect.retry({ schedule: Schedule.spaced('1 millis'), times: 100 })
+        )
+
+        yield* runner.cancel(queryInput.id)
+
+        // Only now does the statement complete, successfully.
+        releaseQuery()
+
+        yield* runner.awaitIdle
+
+        return yield* runner.get(queryInput.id)
+      }),
+      {
+        // No `cancel` at all — the shape MySQL and SQLite present.
+        runQuery: async () => {
+          hasStartedQuery = true
+
+          await running
+
+          return {
+            fields: [{ name: 'value' }],
+            rowCount: 1,
+            rows: [{ value: 1 }],
+            truncated: false
+          }
+        }
+      }
+    )
+
+    expect({
+      error: finished.error,
+      finishedAt: finished.finishedAt,
+      result: finished.result
+    }).toEqual({
+      error: canceledQueryMessage,
+      finishedAt: expect.any(Number),
+      result: null
+    })
+  })
+
+  // The entry's lifetime is exactly the fiber's, so once the query is done there
+  // is nothing left to cancel and the adapter is never asked — a result the user
+  // already has is never rewritten. The adapter is also unpublished the moment
+  // the statement settles, so a cancel arriving while the result is being saved
+  // finds nothing to signal without relying on any adapter's internals.
+  it('leaves a finished result intact when the cancel arrives too late', async () => {
+    let cancelCalls = 0
+
+    const finished = await run(
+      Effect.gen(function* () {
+        const runner = yield* QueryRunner
+        const database = yield* createDatabase
+
+        yield* runner.createAndRun({ ...queryInput, databaseId: database.id })
+        yield* runner.awaitIdle
+
+        yield* runner.cancel(queryInput.id)
+
+        return yield* runner.get(queryInput.id)
+      }),
+      {
+        cancel: () => {
+          cancelCalls = cancelCalls + 1
+
+          return Promise.resolve()
+        }
+      }
+    )
+
+    expect({
+      cancelCalls,
+      error: finished.error,
+      hasResult: finished.result !== null
+    }).toEqual({ cancelCalls: 0, error: null, hasResult: true })
   })
 
   it('fails with QueryNotFoundError for an unknown query id', async () => {

--- a/src/server/services/query-runner.ts
+++ b/src/server/services/query-runner.ts
@@ -1,5 +1,6 @@
 import { desc, eq, isNull } from 'drizzle-orm'
 import { Cause, Clock, Effect, FiberMap, Option } from 'effect'
+import invariant from 'tiny-invariant'
 
 import { databasesTable, queriesTable } from '@/database/schema'
 import {
@@ -34,6 +35,15 @@ type AdapterOutcome =
   | { readonly _tag: 'canceled' }
   | { readonly _tag: 'completed'; readonly result: QueryResult }
 
+// One entry per forked query, created before the fork so cancel is answerable
+// for the fiber's whole life. `adapter` attaches once the connection is loaded;
+// `isCanceled` is sticky, the same way the adapters themselves record a cancel
+// that arrives before there is a socket to end.
+interface InFlightQuery {
+  adapter: DatabaseAdapter | undefined
+  isCanceled: boolean
+}
+
 export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
   accessors: true,
   dependencies: [
@@ -53,7 +63,15 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
     // The link between the cancel route and in-flight work: user cancel goes
     // through adapter.cancel() (for Postgres, pg_cancel_backend), never fiber
     // interruption, so results that just completed are not lost.
-    const adapters = new Map<string, DatabaseAdapter>()
+    //
+    // The entry carries the intent as well as the adapter, because the two do
+    // not begin at the same instant: loading the connection decrypts the stored
+    // password through the OS keychain, so a query can be running with no
+    // adapter yet. A map of adapters alone could only say "an adapter exists",
+    // leaving "the user wants this canceled" nowhere to live until one did —
+    // and a cancel landing in that window did nothing at all while the query ran
+    // on to a successful result.
+    const inFlight = new Map<string, InFlightQuery>()
 
     const loadConnection = (query: QueryRow) =>
       Effect.gen(function* () {
@@ -168,19 +186,58 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
 
     const execute = (query: QueryRow) =>
       Effect.gen(function* () {
+        const entry = inFlight.get(query.id)
+
+        // Registered synchronously before the fork, so it is always here.
+        invariant(entry !== undefined, `Query ${query.id} is not registered.`)
+
         const { adapter, databaseType } = yield* loadConnection(query)
 
-        adapters.set(query.id, adapter)
+        // A cancel that arrived while the connection was loading had nothing to
+        // act on, so it is answered here instead — and the terminal row still
+        // has to be written, or the query stays "running" until the boot
+        // reconciler notices.
+        if (entry.isCanceled) {
+          yield* recordCanceledEvent
+          yield* writeFailure(query.id, canceledQueryMessage)
+
+          return
+        }
+
+        // Published only now: an adapter that is never going to run a statement
+        // should not be reachable by a second cancel.
+        entry.adapter = adapter
 
         const outcome = yield* runAdapterQuery(
           adapter,
           databaseType,
           query
-        ).pipe(Effect.ensuring(Effect.sync(() => adapters.delete(query.id))))
+        ).pipe(
+          // Unpublished the moment the statement settles, so a cancel landing
+          // during the write below cannot reach a finished adapter. The entry
+          // itself still lives as long as the fiber.
+          Effect.ensuring(
+            Effect.sync(() => {
+              entry.adapter = undefined
+            })
+          )
+        )
 
         if (outcome._tag === 'canceled') {
           // The event is recorded on the db.query span inside runAdapterQuery,
           // which is the span that represents the canceled statement.
+          yield* writeFailure(query.id, canceledQueryMessage)
+
+          return
+        }
+
+        // The statement finished, but the user asked for it to stop and this
+        // adapter could not carry that out — `cancel` is optional, and only the
+        // Postgres adapter implements it. Honoring the intent here is what stops
+        // MySQL and SQLite from reporting a cancel and then producing the result
+        // anyway.
+        if (entry.isCanceled) {
+          yield* recordCanceledEvent
           yield* writeFailure(query.id, canceledQueryMessage)
 
           return
@@ -198,19 +255,38 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
           Cause.isInterruptedOnly(cause)
             ? Effect.void
             : writeFailure(query.id, messageFromCause(cause))
-        )
+        ),
+        // Released here rather than around the adapter call, so the entry's
+        // lifetime is the fiber's lifetime and no path — including a failure to
+        // load the connection — can leak one.
+        Effect.ensuring(Effect.sync(() => inFlight.delete(query.id)))
       )
 
     const cancel = Effect.fn('QueryRunner.cancel')(function* (id: string) {
-      const adapter = adapters.get(id)
+      const entry = inFlight.get(id)
 
       // Canceling an unknown or already finished query is a deliberate
       // no-op.
+      if (entry === undefined) {
+        return
+      }
+
+      // Recorded first, so it counts even when there is no adapter to act on —
+      // either because the connection is still loading, or because this adapter
+      // has no cancel at all. `execute` honors it either way.
+      entry.isCanceled = true
+
+      const adapter = entry.adapter
+
       if (adapter === undefined) {
         return
       }
 
       yield* Effect.promise(() => adapter.cancel?.() ?? Promise.resolve()).pipe(
+        // Bounded for the same reason the shutdown path bounds it: cancel opens
+        // a fresh connection to the user's database, which can hang on an
+        // unreachable host, and this one is awaited by an HTTP handler.
+        Effect.timeout(cancelTimeout),
         Effect.catchAllCause((cause) =>
           Effect.logError(`Could not cancel query ${id}`, cause)
         )
@@ -254,12 +330,32 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
           .returning()
       )
 
+      // Registered synchronously, before the fork, so the query is cancelable
+      // from the same instant it starts running. Registering it from inside the
+      // fiber would reopen the window this closes.
+      //
+      // Uninterruptible as a pair: the release lives in `runInBackground`, so an
+      // interrupt landing between the two would retain the entry forever.
+      //
       // Fork-and-return: the response carries the unfinished row and the
       // renderer polls for the result. The forked fiber inherits this span
       // as its parent, which is what used to require capturing the
       // AsyncLocalStorage context by hand. A duplicate key cannot reach the
       // fork — the primary-key insert above fails first.
-      yield* FiberMap.run(running, insertedRow.id, runInBackground(insertedRow))
+      yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          inFlight.set(insertedRow.id, {
+            adapter: undefined,
+            isCanceled: false
+          })
+
+          yield* FiberMap.run(
+            running,
+            insertedRow.id,
+            runInBackground(insertedRow)
+          )
+        })
+      )
 
       return transformQueryRow(insertedRow)
     })


### PR DESCRIPTION
Closes #50

## The defect

Cancel a query in the first moments after clicking Run and the UI says "Query canceled." while the query runs to completion and saves a **successful** result. The cancel button is already gone, so there is no second chance.

Three notions of "running" started at three different instants — the persisted row at insert, the fiber at fork, and the `adapters` map entry only after `loadConnection` resolved. Loading the connection decrypts the stored password through the OS keychain, so that gap is real. `cancel` read the map, found nothing, and returned: "a deliberate no-op" for an unknown or finished query silently covered a query that was running but not yet connected.

A `Map<string, DatabaseAdapter>` can only say "an adapter exists", so "the user wants this canceled" had nowhere to live until one did.

## The failing test that pins it

A `SecretStorage` whose `decrypt` is held open on a `Deferred`, so the test sits inside the keychain window: create, cancel **with no retry**, release, await idle. Against the old code it reported `error: null` — the cancel vanished and the query saved a successful result.

Also: the existing cancel test retried the cancel up to 100 times at 1ms because *"the background fiber registers its adapter asynchronously"*. It documented this gap rather than covering it. It now waits for the query to be running and cancels once — the retry loop collapsing is itself the assertion that the race is gone.

## What the review of this branch found, and it was the bigger half

`cancel` is **optional** on the `DatabaseAdapter` interface, and only `PostgresAdapter` implements it — `mysql-adapter.ts` and `sqlite-adapter.ts` define no `cancel` at all. So on MySQL and SQLite a cancel could never stop anything: the route answered `{success: true}`, the renderer showed "Query canceled.", and then the statement finished and its result appeared anyway. Same user-visible defect as this issue, for two of three database types, unconditionally.

The recorded intent is exactly what was needed, and the first draft left it unused after a successful outcome. `execute` now consults it at both points where it can still be honored, and discards a result the user asked to cancel. There is a test with a `cancel`-less adapter — the shape MySQL and SQLite present — verified red without the check.

## Lifetime details, all previously implicit

- The entry is released in `runInBackground`, so its lifetime is the fiber's and a failure to load the connection cannot leak one. Creating it and forking are **uninterruptible as a pair**, so an interrupt between them cannot retain one either.
- The adapter is published only *after* the cancel check and unpublished as soon as the statement settles, so a cancel can never reach an adapter that is not about to run or has already finished. Previously that rested on `PostgresAdapter` clearing `activeClient` in a `finally` — true, but an assumption about another module's internals rather than a guarantee here.
- The cancel call is bounded by the same `cancelTimeout` the shutdown path already used. It opens a fresh connection that can hang on an unreachable host, and an HTTP handler awaits it.

Both new terminal paths record the `query.canceled` span event, so the trace no longer shows a query that finished "ok" whose row says "Query canceled." with no cause.

## Deliberately unchanged

Cancel after completion still leaves a successful result intact, with a test. `#54` (the adapter-level window between connect and execute) is a separate issue and is untouched — this fixes the runner's side.