### PR TITLE
refactor(traces): collapse the waterfall by depth instead of by parent id

### DIFF
--- a/src/app/components/traces/waterfall-layout.test.ts
+++ b/src/app/components/traces/waterfall-layout.test.ts
@@ -120,4 +120,66 @@ describe('visibleRows', () => {
       'sibling'
     ])
   })
+
+  it('hides collapsed branches independently of each other', () => {
+    const layout = computeWaterfallLayout([
+      buildSpan({ durationMs: 100, id: 'root', startedAt: 1000 }),
+      buildSpan({ id: 'branch-a', parentSpanId: 'root', startedAt: 1010 }),
+      buildSpan({ id: 'a-child', parentSpanId: 'branch-a', startedAt: 1020 }),
+      buildSpan({ id: 'branch-b', parentSpanId: 'root', startedAt: 1030 }),
+      buildSpan({ id: 'b-child', parentSpanId: 'branch-b', startedAt: 1040 }),
+      buildSpan({
+        id: 'b-grandchild',
+        parentSpanId: 'b-child',
+        startedAt: 1050
+      })
+    ])
+
+    const visible = visibleRows(layout.rows, new Set(['branch-a', 'b-child']))
+
+    expect(visible.map((row) => row.span.id)).toEqual([
+      'root',
+      'branch-a',
+      'branch-b',
+      'b-child'
+    ])
+  })
+
+  it('keeps a branch hidden when a collapsed row sits inside it', () => {
+    const layout = computeWaterfallLayout([
+      buildSpan({ durationMs: 100, id: 'root', startedAt: 1000 }),
+      buildSpan({ id: 'child', parentSpanId: 'root', startedAt: 1010 }),
+      buildSpan({
+        id: 'grandchild',
+        parentSpanId: 'child',
+        startedAt: 1020
+      }),
+      buildSpan({ id: 'sibling', parentSpanId: 'root', startedAt: 1030 })
+    ])
+
+    const visible = visibleRows(layout.rows, new Set(['root', 'child']))
+
+    expect(visible.map((row) => row.span.id)).toEqual(['root'])
+  })
+
+  it('hides the children of a collapsed span that was re-parented as a root', () => {
+    const layout = computeWaterfallLayout([
+      buildSpan({
+        durationMs: 50,
+        id: 'orphan',
+        parentSpanId: 'not-ingested',
+        startedAt: 1000
+      }),
+      buildSpan({
+        id: 'orphan-child',
+        parentSpanId: 'orphan',
+        startedAt: 1010
+      }),
+      buildSpan({ id: 'other-root', startedAt: 1100 })
+    ])
+
+    const visible = visibleRows(layout.rows, new Set(['orphan']))
+
+    expect(visible.map((row) => row.span.id)).toEqual(['orphan', 'other-root'])
+  })
 })

--- a/src/app/components/traces/waterfall-layout.ts
+++ b/src/app/components/traces/waterfall-layout.ts
@@ -75,25 +75,30 @@ export function computeWaterfallLayout(spans: SpanDto[]): WaterfallLayout {
   return { rows, totalDurationMs: traceEnd - traceStart }
 }
 
+// Reads ancestry off the tree `computeWaterfallLayout` emitted rather than off
+// `parentSpanId`, so the re-parenting of orphans above stays a local decision.
+// Requires `rows` in DFS pre-order carrying tree depth: a row's descendants are
+// exactly the rows between it and the next row at the same or lower depth.
 export function visibleRows(
   rows: WaterfallRow[],
   collapsed: Set<string>
 ): WaterfallRow[] {
-  const hidden = new Set<string>()
   const visible: WaterfallRow[] = []
 
-  for (const row of rows) {
-    if (row.span.parentSpanId && hidden.has(row.span.parentSpanId)) {
-      hidden.add(row.span.id)
+  let collapsedDepth = Number.POSITIVE_INFINITY
 
+  for (const row of rows) {
+    if (row.depth > collapsedDepth) {
       continue
     }
 
     visible.push(row)
 
-    if (collapsed.has(row.span.id)) {
-      hidden.add(row.span.id)
-    }
+    // Only a visible row moves the watermark, so a collapsed row nested inside
+    // an already collapsed branch cannot raise it back up.
+    collapsedDepth = collapsed.has(row.span.id)
+      ? row.depth
+      : Number.POSITIVE_INFINITY
   }
 
   return visible


### PR DESCRIPTION
Closes #87.

## What

`visibleRows` rebuilt span ancestry from `row.span.parentSpanId` plus a `hidden: Set<string>`, even though `computeWaterfallLayout` had already decided ancestry — including deliberately **re-parenting orphans as roots**. The two encodings agreed only by a non-local coincidence: a re-parented orphan's `parentSpanId` is by construction absent from the span list, so it could never collide with an id in `hidden`.

Rows are already DFS pre-order carrying `depth`, so "hidden" is a single number. This tracks a `collapsedDepth` watermark and skips while the row is deeper, which depends only on the structure the layout emitted.

Only a *visible* row moves the watermark, so a collapsed row nested inside an already collapsed branch cannot raise it back up.

## Behaviour

Unchanged for every input the schema can produce. `spans.id` is a `TEXT PRIMARY KEY`, so the one divergence class that exists at all — duplicate span ids, where the old version leaked hiding across unrelated subtrees through the shared id — is unreachable.

## Tests

Adds the three cases #87 named as untested:

- two collapsed branches at different depths on different subtrees
- a collapsed row nested inside an already collapsed branch (the watermark must not be raised by the inner one)
- a collapsed span that was re-parented as a root — the assumption the old code silently depended on

The first two were mutation-checked: each fails against the specific wrong implementation its name targets (watermark never reset; hidden collapsed rows still moving the watermark). The third is a contract test — it pins the re-parenting assumption for the future rather than catching a live bug, which is expected given #87 states there is no reachable defect.

`TraceWaterfall.tsx` is the only caller and passes `layout.rows` straight through, unfiltered and unsorted, so the new pre-order precondition holds.

## Checks

- `tsc -p tsconfig.renderer.json --noEmit` clean
- `eslint` clean on both files
- traces suite: 30/30 green; full suite 953/955

The 2 unrelated failures are `src/databases/sqlite-adapter.test.ts > connects and executes SELECT 1`, which fails identically on a clean `main` checkout.
