### PR TITLE
refactor(sql-parser): drive statement splitting and typing from one table

### DIFF
--- a/src/app/sql-parser/parser.test.ts
+++ b/src/app/sql-parser/parser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { createAstFromSql } from './parser'
+import { createAstFromSql, statementTypes } from './parser'
+import { tokenize } from './tokenizer'
 
 describe('createAstFromSql', () => {
   describe('single statements', () => {
@@ -314,5 +315,52 @@ SELECT * FROM users`
         sql.slice(result.statements[1].start, result.statements[1].end)
       ).toEqual('SELECT 2')
     })
+  })
+
+  // statementTypes drives both splitting and typing, so each entry is asserted
+  // to do both -- that pairing is what a drifted table breaks.
+  describe('statement keywords', () => {
+    // The table only decides anything for words the tokenizer calls keywords,
+    // so an entry the tokenizer does not know is silently inert.
+    it.each([...statementTypes.keys()])(
+      'tokenizes %s as a single keyword token',
+      (keyword) => {
+        expect(tokenize(keyword)).toEqual([
+          expect.objectContaining({ type: 'keyword', value: keyword })
+        ])
+      }
+    )
+
+    it.each([
+      { keyword: 'DELETE', statement: 'DELETE FROM users', type: 'delete' },
+      {
+        keyword: 'INSERT',
+        statement: 'INSERT INTO users VALUES (1)',
+        type: 'insert'
+      },
+      { keyword: 'SELECT', statement: 'SELECT 2', type: 'select' },
+      {
+        keyword: 'UPDATE',
+        statement: 'UPDATE users SET name = 1',
+        type: 'update'
+      }
+    ])(
+      'starts a statement on $keyword and types it $type',
+      ({ statement, type }) => {
+        const sql = ['SELECT 1', statement].join('\n')
+
+        const result = createAstFromSql(sql)
+
+        expect(result.statements).toEqual([
+          { end: 8, start: 0, text: 'SELECT 1', type: 'select' },
+          {
+            end: sql.length,
+            start: 9,
+            text: statement,
+            type
+          }
+        ])
+      }
+    )
   })
 })

--- a/src/app/sql-parser/parser.ts
+++ b/src/app/sql-parser/parser.ts
@@ -18,11 +18,20 @@ export interface Script {
   statements: Statement[]
 }
 
-const statementKeywords = new Set(['DELETE', 'INSERT', 'SELECT', 'UPDATE'])
+// One table drives both decisions below: whether a keyword starts a new
+// statement, and what type that statement is. Keeping them in one place is
+// what stops them drifting apart -- a keyword that splits but has no type
+// would parse into a statement classified 'unknown'.
+export const statementTypes = new Map<string, StatementType>([
+  ['DELETE', 'delete'],
+  ['INSERT', 'insert'],
+  ['SELECT', 'select'],
+  ['UPDATE', 'update']
+])
 
 function isStatementKeyword(token: Token): boolean {
   return (
-    token.type === 'keyword' && statementKeywords.has(token.value.toUpperCase())
+    token.type === 'keyword' && statementTypes.has(token.value.toUpperCase())
   )
 }
 
@@ -31,20 +40,14 @@ function getStatementType(tokens: Token[]): StatementType {
     (t) => t.type !== 'whitespace' && t.type !== 'comment'
   )
 
-  if (!firstSignificant) {
+  // Only a bare word is ever tokenized as a keyword -- a quoted SELECT keeps
+  // its quotes in token.value and so misses the table anyway -- which makes
+  // this guard defence-in-depth against a future tokenizer change.
+  if (!firstSignificant || firstSignificant.type !== 'keyword') {
     return 'unknown'
   }
 
-  if (firstSignificant.type === 'keyword') {
-    const keyword = firstSignificant.value.toUpperCase()
-
-    if (keyword === 'SELECT') return 'select'
-    if (keyword === 'INSERT') return 'insert'
-    if (keyword === 'UPDATE') return 'update'
-    if (keyword === 'DELETE') return 'delete'
-  }
-
-  return 'unknown'
+  return statementTypes.get(firstSignificant.value.toUpperCase()) ?? 'unknown'
 }
 
 function trimTokens(tokens: Token[]): Token[] {
@@ -109,8 +112,8 @@ function finishStatement(state: ParserState, sql: string): void {
   state.currentTokens = []
 }
 
-// Statements are split on semicolons and on top-level statement keywords
-// (SELECT/INSERT/UPDATE/DELETE outside parentheses).
+// Statements are split on semicolons and on the top-level keywords in
+// statementTypes (outside parentheses).
 function consumeToken(state: ParserState, token: Token, sql: string): void {
   if (isPunctuation(token, '(')) {
     state.parenDepth++


### PR DESCRIPTION
Closes #97.

## What

The same four keywords were written down twice in one 163-line file, driving two decisions that had to agree and were not tied together:

- a `statementKeywords` Set decided **where a statement starts**
- a parallel if-chain decided **what type it is**

They could drift silently and asymmetrically — adding a word to the Set alone makes the parser split there and classify the result `'unknown'`; adding it to the if-chain alone makes that type unreachable.

Both are now one `Map<string, StatementType>`. `isStatementKeyword` asks whether the table has the keyword; `getStatementType` reads the value out of it.

## The third copy

The issue also names an implicit third copy: `isStatementKeyword` requires `token.type === 'keyword'`, which holds only because all four words are in the tokenizer's keyword set. An entry the tokenizer doesn't know would be silently inert — `['MERGE', 'merge']` would do nothing at all, because `readWord` types `MERGE` as an `identifier`.

So the table is exported and a guard test asserts every key tokenizes to a single `keyword` token, in the same shape as the existing `reconcile-columns.test.ts` guard. That copy is now tied too. Verified: adding an entry the tokenizer doesn't know fails the guard.

## Behaviour

Unchanged. The restructured guard in `getStatementType` is exactly equivalent — the old if-chain's fall-through and the old non-keyword fall-through both landed on the same trailing `return 'unknown'`.

Note the `token.type === 'keyword'` guard is kept as defence-in-depth rather than because it excludes quoted identifiers: `readQuotedIdentifier` keeps the quote characters in `token.value`, so a quoted `SELECT` misses the table anyway. The comment says so.

## Tests

Adds a case per keyword asserting the same entry both splits a statement *and* types it, mutation-checked in both drift directions:

- dropping `DELETE` from the split side → one statement typed `select` → fails
- dropping `DELETE` from the type side → right split, `type: 'unknown'` → fails

Honest scope note: the pre-existing suite already caught both of those mutants. The genuinely new coverage is INSERT splitting *without* a semicolon, the pairing asserted in a single `toEqual`, and the tokenizer guard.

## Checks

- `prettier --check` clean on both files
- `tsc -p tsconfig.renderer.json --noEmit` clean
- `eslint src/app/sql-parser/` clean
- sql-parser suite 89/89; full suite 959/960

The 1 unrelated failure is `src/databases/sqlite-adapter.test.ts > connects and executes SELECT 1`, which fails identically on a clean `main` checkout.
