### PR TITLE
refactor(database-form): trust the flat shape error.details is declared as

### DIFF
--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -699,6 +699,50 @@ describe('DatabaseForm', () => {
     })
   })
 
+  // The API client flattens issue paths into dotted keys ('connectionInfo.host'),
+  // so this asserts the dotted key reaches the nested field itself rather than
+  // merely rendering the message somewhere on the form.
+  it('attaches a dotted field error to the nested input it names', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse(
+        {
+          _tag: 'HttpApiDecodeError',
+          issues: [
+            {
+              _tag: 'Type',
+              message: 'Name is already taken',
+              path: ['name']
+            },
+            {
+              _tag: 'Type',
+              message: 'Invalid host format',
+              path: ['connectionInfo', 'host']
+            }
+          ],
+          message: 'The request payload is invalid'
+        },
+        { status: 400 }
+      )
+    )
+
+    renderDatabaseForm()
+
+    await fillForm(user)
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Host')).toHaveAccessibleDescription(
+        'Invalid host format'
+      )
+    })
+
+    expect(screen.getByLabelText('Name')).toHaveAccessibleDescription(
+      'Name is already taken'
+    )
+  })
+
   // Testing a connection skips the form's own validation, so the contract
   // rejects the payload client-side. That has to surface as an inline field
   // error rather than the schema tree ParseError.message renders.

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -7,7 +7,12 @@ import {
   XCircleIcon
 } from 'lucide-react'
 import { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react'
-import { useForm, type Resolver, type UseFormReturn } from 'react-hook-form'
+import {
+  useForm,
+  type FieldPath,
+  type Resolver,
+  type UseFormReturn
+} from 'react-hook-form'
 import { toast } from 'sonner'
 import invariant from 'tiny-invariant'
 import { z } from 'zod'
@@ -1136,36 +1141,14 @@ function applyServerFieldErrors(form: DatabaseFormApi, error: unknown): void {
     return
   }
 
-  const fieldErrors = errorDetailsToFormFieldErrors(error.details)
-
-  for (const [field, { message }] of Object.entries(fieldErrors)) {
-    form.setError(field as keyof FormInput, {
+  // details arrives flat and string-valued: toFieldDetails in api-client.ts is
+  // its only producer, and it already joins each issue path into a dotted key
+  // like 'connectionInfo.host'. Nested keys are dotted FieldPaths rather than
+  // keys of FormInput, which is the shape setError takes.
+  for (const [field, message] of Object.entries(error.details)) {
+    form.setError(field as FieldPath<FormInput>, {
       message,
       type: 'server'
     })
   }
-}
-
-type FieldErrors = Record<string, { message: string }>
-
-function errorDetailsToFormFieldErrors(
-  details: Record<string, unknown>,
-  prefix = ''
-): FieldErrors {
-  const errors: FieldErrors = {}
-
-  for (const [key, value] of Object.entries(details)) {
-    const path = prefix ? `${prefix}.${key}` : key
-
-    if (typeof value === 'string') {
-      errors[path] = { message: value }
-    } else if (value && typeof value === 'object') {
-      Object.assign(
-        errors,
-        errorDetailsToFormFieldErrors(value as Record<string, unknown>, path)
-      )
-    }
-  }
-
-  return errors
 }


### PR DESCRIPTION
Closes #93.

## What

`DatabaseForm` flattened `error.details` with a recursive tree walker before handing each entry to `setError`. `ApiError.details` is `Record<string, string>`, and its only producer — `toFieldDetails` in `src/app/api-client.ts` — already joins each issue path into a dotted key like `connectionInfo.host`. The recursive branch was unreachable, and the `{ message }` records it built were unwrapped again one function later.

The walker is gone; `applyServerFieldErrors` now iterates `Object.entries(error.details)` directly.

## Why the cast is still there, and why it now means something

The old code re-typed the parameter to `Record<string, unknown>` — that is what made the dead branch typecheck, and it threw away the producer's `string` guarantee at the module boundary. It then cast each key to `keyof FormInput`, which is wrong in kind: `'connectionInfo.host'` is never `keyof FormInput` (`'connectionInfo' | 'name' | 'type'`). `setError` takes `FieldPath<FormInput>`, which *does* include the dotted form. The cast now narrows an arbitrary string to a known path space rather than papering over a mismatch. It is still required — react-hook-form 7.66.1 types `UseFormSetError` as `FieldPath<TFieldValues> | 'root' | \`root.${string}\``, so a plain `string` is not assignable.

## Test

Behaviour is unchanged, so there is no RED to show. Instead the new test is the one the issue asked for, and it is verified to have teeth by mutation:

- A single 400 carries two issues — `path: ['name']` and `path: ['connectionInfo', 'host']` — and each field is asserted to carry *its own* message via `toHaveAccessibleDescription`, not merely to have the text somewhere on screen. A message landing on the wrong field fails.
- Mutation check: making the loop take only the last path segment (`field.split('.').at(-1)`) turns `connectionInfo.host` into `host`, which matches no `FormField`, and the test fails.

`toHaveAccessibleDescription` is meaningful here rather than incidentally satisfied: the form renders no `FormDescription`, so a field's accessible description is exactly the error message.

## Checks

- `tsc -p tsconfig.renderer.json` — clean
- `eslint`, `prettier` — clean
- `DatabaseForm.test.tsx` — 36/36 pass
- Full suite: one pre-existing failure in `src/databases/sqlite-adapter.test.ts`, confirmed to fail on clean `main` as well (verified by stashing). Unrelated to this change.

Reviewed by a fresh-context agent whose brief was to *disprove* the flatness premise. It independently confirmed all five `new ApiError` sites go through `api-client.ts`, only two pass `details`, and both via `toFieldDetails`; and that raw server JSON cannot reach `details`, because `HttpApiError` schema-decodes the issues first and a decode failure produces a generic `ApiError` with no details at all.
