### PR TITLE
refactor(results): derive "is this query running" where the query already is

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -29,6 +29,7 @@ import { useCancelQuery } from './hooks/mutations'
 import { useStartQuery } from './hooks/use-start-query'
 import { useWorksheetAutosave } from './hooks/useWorksheetAutosave'
 import { isConnectionUnreadable, type DatabaseDto } from '@/glue/databases'
+import { isQueryInFlight } from '@/glue/queries'
 import { secretStorageMessages } from '@/glue/secret-storage'
 import { useAppDispatch, useAppSelector } from './store'
 import { selectActiveWorksheetId } from './store/tabs-slice'
@@ -230,7 +231,7 @@ export function useWorksheetSession(openWorksheetId: string | undefined) {
     handleRunQuery,
     handleUpdateContent,
     isCanceling,
-    isQueryRunning: Boolean(query && !query.finishedAt),
+    isQueryRunning: isQueryInFlight(query),
     query,
     saveState,
     setCursorOffset,
@@ -364,7 +365,6 @@ function Workspace(): ReactElement {
 
         <ResultsPane
           databaseName={currentDatabase?.name}
-          isQueryRunning={isQueryRunning}
           query={query}
           worksheetId={openWorksheetId}
         />

--- a/src/app/components/QueryResultContent.test.tsx
+++ b/src/app/components/QueryResultContent.test.tsx
@@ -30,7 +30,6 @@ describe('QueryResultContent', () => {
     render(
       <QueryResultContent
         databaseName="Pagila"
-        isQueryRunning={false}
         query={undefined}
       />
     )
@@ -42,7 +41,6 @@ describe('QueryResultContent', () => {
     render(
       <QueryResultContent
         databaseName="Pagila"
-        isQueryRunning
         query={{ ...baseQuery, finishedAt: null }}
       />
     )
@@ -54,7 +52,6 @@ describe('QueryResultContent', () => {
     render(
       <QueryResultContent
         databaseName={undefined}
-        isQueryRunning
         query={{ ...baseQuery, finishedAt: null }}
       />
     )
@@ -66,7 +63,6 @@ describe('QueryResultContent', () => {
     render(
       <QueryResultContent
         databaseName="Pagila"
-        isQueryRunning={false}
         query={{
           ...baseQuery,
           result: {
@@ -89,7 +85,6 @@ describe('QueryResultContent', () => {
     render(
       <QueryResultContent
         databaseName="Pagila"
-        isQueryRunning={false}
         query={{
           ...baseQuery,
           error:
@@ -111,7 +106,6 @@ describe('QueryResultContent', () => {
     render(
       <QueryResultContent
         databaseName="Pagila"
-        isQueryRunning={false}
         query={{ ...baseQuery, error: 'syntax error at or near "FORM"' }}
       />
     )
@@ -125,7 +119,6 @@ describe('QueryResultContent', () => {
     render(
       <QueryResultContent
         databaseName="Pagila"
-        isQueryRunning={false}
         query={{ ...baseQuery, error: canceledQueryMessage }}
       />
     )

--- a/src/app/components/QueryResultContent.tsx
+++ b/src/app/components/QueryResultContent.tsx
@@ -1,7 +1,7 @@
 import { BanIcon } from 'lucide-react'
 import { ReactElement, useEffect, useState } from 'react'
 
-import { canceledQueryMessage } from '@/glue/queries'
+import { canceledQueryMessage, isQueryInFlight } from '@/glue/queries'
 import type { QueryDto } from '@/glue/api/schemas'
 
 import { QueryResultEmpty } from './QueryResultEmpty'
@@ -10,20 +10,18 @@ import { toQueryErrorParts } from './query-error-parts'
 
 interface QueryResultContentProps {
   databaseName: string | undefined
-  isQueryRunning: boolean
   query: QueryDto | undefined
 }
 
 export function QueryResultContent({
   databaseName,
-  isQueryRunning,
   query
 }: QueryResultContentProps): ReactElement {
-  if (isQueryRunning) {
+  if (isQueryInFlight(query)) {
     return (
       <RunningQuery
         databaseName={databaseName}
-        since={query?.queriedAt}
+        since={query.queriedAt}
       />
     )
   }
@@ -90,7 +88,7 @@ function RunningQuery({
   since
 }: {
   databaseName: string | undefined
-  since: number | undefined
+  since: number
 }): ReactElement {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3">
@@ -102,11 +100,9 @@ function RunningQuery({
 
       {/* The design shows static text, but a long query with no sign of
           progress reads as a hang. */}
-      {since !== undefined && (
-        <p className="text-[11.5px] text-text3">
-          <ElapsedTime since={since} />
-        </p>
-      )}
+      <p className="text-[11.5px] text-text3">
+        <ElapsedTime since={since} />
+      </p>
     </div>
   )
 }

--- a/src/app/components/ResultsPane.test.tsx
+++ b/src/app/components/ResultsPane.test.tsx
@@ -50,7 +50,6 @@ function SwitchablePane(): ReactElement {
 
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={undefined}
         worksheetId={worksheetId}
       />
@@ -85,7 +84,6 @@ describe('ResultsPane', () => {
     renderWithProviders(
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={undefined}
         worksheetId="ws-1"
       />,
@@ -100,7 +98,6 @@ describe('ResultsPane', () => {
     renderWithProviders(
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={undefined}
         worksheetId="ws-1"
       />,
@@ -110,11 +107,30 @@ describe('ResultsPane', () => {
     expect(screen.queryByText(/rows ·/)).not.toBeInTheDocument()
   })
 
+  // The meta line and the body have to answer "is this still running" from the
+  // same place. While that answer arrived as a prop, a caller could make them
+  // disagree -- a spinner under a header reading "100 rows", or the reverse.
+  it('shows the running body and no meta line for a query still in flight', () => {
+    const runningQuery = query({ ...successfulQuery, finishedAt: null })
+
+    renderWithProviders(
+      <ResultsPane
+        databaseName="Pagila"
+        query={runningQuery}
+        worksheetId="ws-1"
+      />,
+      { openWorksheetId: 'ws-1', queries: [runningQuery] }
+    )
+
+    expect(screen.getByText('Running on Pagila…')).toBeInTheDocument()
+    expect(screen.queryByText(/rows ·/)).not.toBeInTheDocument()
+    expect(screen.queryByText('No results yet')).not.toBeInTheDocument()
+  })
+
   it('summarises a successful run', () => {
     renderWithProviders(
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={successfulQuery}
         worksheetId="ws-1"
       />,
@@ -131,7 +147,6 @@ describe('ResultsPane', () => {
     renderWithProviders(
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={failed}
         worksheetId="ws-1"
       />,
@@ -147,7 +162,6 @@ describe('ResultsPane', () => {
     renderWithProviders(
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={successfulQuery}
         worksheetId="ws-1"
       />,
@@ -166,7 +180,6 @@ describe('ResultsPane', () => {
     renderWithProviders(
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={undefined}
         worksheetId="ws-1"
       />,
@@ -184,7 +197,6 @@ describe('ResultsPane', () => {
     renderWithProviders(
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={undefined}
         worksheetId="ws-1"
       />,
@@ -244,7 +256,6 @@ describe('ResultsPane', () => {
     renderWithProviders(
       <ResultsPane
         databaseName="Pagila"
-        isQueryRunning={false}
         query={undefined}
         worksheetId="ws-1"
       />,

--- a/src/app/components/ResultsPane.tsx
+++ b/src/app/components/ResultsPane.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, useEffect, useState } from 'react'
 
 import type { QueryDto } from '@/glue/api/schemas'
+import { isQueryFinished } from '@/glue/queries'
 
 import { usePersistedSizes } from '../hooks/use-persisted-sizes'
 import { useWorksheetMessages } from '../hooks/use-worksheet-messages'
@@ -24,7 +25,6 @@ const maximumRememberedHeights = 50
 
 interface ResultsPaneProps {
   databaseName: string | undefined
-  isQueryRunning: boolean
   query: QueryDto | undefined
   worksheetId: string | undefined
 }
@@ -42,7 +42,6 @@ function formatRowCount(result: {
 
 export function ResultsPane({
   databaseName,
-  isQueryRunning,
   query,
   worksheetId
 }: ResultsPaneProps): ReactElement {
@@ -144,7 +143,6 @@ export function ResultsPane({
           ) : (
             <QueryResultContent
               databaseName={databaseName}
-              isQueryRunning={isQueryRunning}
               query={query}
             />
           )}
@@ -155,7 +153,7 @@ export function ResultsPane({
 }
 
 function ResultsMeta({ query }: { query: QueryDto | undefined }): ReactElement {
-  if (!query || query.finishedAt === null) {
+  if (!isQueryFinished(query)) {
     return <></>
   }
 

--- a/src/app/components/StatusBar.tsx
+++ b/src/app/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { ActivityIcon } from 'lucide-react'
 import { ReactElement } from 'react'
 
+import { isQueryFinished } from '@/glue/queries'
 import type { QueryDto } from '@/glue/api/schemas'
 import type { DatabaseDto } from '@/glue/databases'
 
@@ -37,7 +38,7 @@ const healthTitles: Record<ConnectionHealth, string> = {
 }
 
 function getConnectionHealth(query: QueryDto | undefined): ConnectionHealth {
-  if (!query || query.finishedAt === null) {
+  if (!isQueryFinished(query)) {
     return 'unknown'
   }
 
@@ -45,7 +46,7 @@ function getConnectionHealth(query: QueryDto | undefined): ConnectionHealth {
 }
 
 function formatRunSummary(query: QueryDto | undefined): string | undefined {
-  if (!query || query.finishedAt === null) {
+  if (!isQueryFinished(query)) {
     return undefined
   }
 

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -11,6 +11,7 @@ import {
   type QueryDto,
   UpdateDatabaseRequest
 } from '@/glue/api/schemas'
+import { isQueryFinished, isQueryInFlight } from '@/glue/queries'
 
 export interface CancelQuery {
   cancel: () => void
@@ -46,7 +47,7 @@ export function useCancelQuery(query: QueryDto | undefined): CancelQuery {
     setCancelingQueryId(queryId)
   }, [])
 
-  const runningQueryId = query?.finishedAt === null ? query.id : undefined
+  const runningQueryId = isQueryInFlight(query) ? query.id : undefined
   const isCanceling =
     runningQueryId !== undefined && cancelingQueryId === runningQueryId
 
@@ -60,7 +61,7 @@ export function useCancelQuery(query: QueryDto | undefined): CancelQuery {
     if (
       cancelingQueryId !== undefined &&
       query?.id === cancelingQueryId &&
-      query.finishedAt !== null
+      isQueryFinished(query)
     ) {
       setCanceling(undefined)
     }

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -15,7 +15,11 @@ import type {
   UpdateStatusResponse
 } from '@/glue/api/schemas'
 import { isConnectionUnreadable, type DatabaseDto } from '@/glue/databases'
-import { canceledQueryMessage } from '@/glue/queries'
+import {
+  canceledQueryMessage,
+  isQueryFinished,
+  isQueryInFlight
+} from '@/glue/queries'
 
 const queryPollInterval = 250
 
@@ -183,7 +187,7 @@ export function useQueryResultSync(query: QueryDto | undefined): void {
   const { queries } = useCollections()
 
   const queryId = query?.id
-  const isRunning = Boolean(query && !query.finishedAt)
+  const isRunning = isQueryInFlight(query)
 
   const polled = useQuery<QueryDto>({
     queryKey: queryId ? queryKeys.query(queryId) : ['query', 'noop'],
@@ -202,11 +206,11 @@ export function useQueryResultSync(query: QueryDto | undefined): void {
         return queryPollInterval
       }
 
-      return data.finishedAt ? false : queryPollInterval
+      return isQueryFinished(data) ? false : queryPollInterval
     }
   })
 
-  const finished = polled.data?.finishedAt ? polled.data : undefined
+  const finished = isQueryFinished(polled.data) ? polled.data : undefined
 
   useEffect(() => {
     // Also re-runs when the collection row regresses to running (for example

--- a/src/glue/queries.test.ts
+++ b/src/glue/queries.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { isQueryFinished, isQueryInFlight } from './queries'
+
+describe('isQueryInFlight', () => {
+  it('is false without a query', () => {
+    expect(isQueryInFlight(undefined)).toEqual(false)
+  })
+
+  it('is true while finishedAt is null', () => {
+    expect(isQueryInFlight({ finishedAt: null })).toEqual(true)
+  })
+
+  it('is false once finishedAt is set', () => {
+    expect(isQueryInFlight({ finishedAt: 3373 })).toEqual(false)
+  })
+
+  // The callers this replaced tested finishedAt for falsiness, which read a
+  // query finished at epoch 0 as still running. No producer emits 0 today.
+  it('treats a query finished at 0 as finished', () => {
+    expect(isQueryInFlight({ finishedAt: 0 })).toEqual(false)
+  })
+})
+
+describe('isQueryFinished', () => {
+  it('is false without a query', () => {
+    expect(isQueryFinished(undefined)).toEqual(false)
+  })
+
+  it('is false while finishedAt is null', () => {
+    expect(isQueryFinished({ finishedAt: null })).toEqual(false)
+  })
+
+  it('is true once finishedAt is set', () => {
+    expect(isQueryFinished({ finishedAt: 3373 })).toEqual(true)
+  })
+
+  it('is true for a query finished at 0', () => {
+    expect(isQueryFinished({ finishedAt: 0 })).toEqual(true)
+  })
+})

--- a/src/glue/queries.ts
+++ b/src/glue/queries.ts
@@ -1,3 +1,26 @@
 // Shared between the main process and the renderer. Keep this module free of
 // main-process imports — the renderer bundles it.
 export const canceledQueryMessage = 'Query canceled.'
+
+// One answer to "has this query finished", so the places that ask -- the
+// results body, its meta line, the status bar, the poller -- cannot disagree.
+// finishedAt is compared to null rather than tested for falsiness, because 0
+// is a legitimate timestamp, and the callers converted here were split across
+// both conventions. Narrowing finishedAt is what lets a caller compute a
+// duration, or read the row it just proved is finished, without asking the
+// question a second time.
+export function isQueryFinished<T extends QueryLifecycle>(
+  query: T | undefined
+): query is T & { finishedAt: number } {
+  return query !== undefined && query.finishedAt !== null
+}
+
+export function isQueryInFlight<T extends QueryLifecycle>(
+  query: T | undefined
+): query is T & { finishedAt: null } {
+  return query !== undefined && !isQueryFinished(query)
+}
+
+interface QueryLifecycle {
+  finishedAt: number | null
+}


### PR DESCRIPTION
Closes #96.

## What

`isQueryRunning` was derived state passed as a prop beside the very value it derives from. `App` computed `Boolean(query && !query.finishedAt)` and handed *both* it and `query` to `ResultsPane`, which never read the boolean — it only forwarded it to `QueryResultContent`.

Meanwhile `ResultsMeta`, in the same file, answered the same question from a different source (`query.finishedAt === null`). The pane's header and its body decided "is the run finished" independently, and the prop pair admitted both contradictions — a spinner under a header reading `100 rows · 2,373 ms`, or `No results yet` for a query still in flight. Both were constructible with no type error.

One predicate now lives in `src/glue/queries.ts`:

- `isQueryFinished` narrows `finishedAt` to `number`, so `ResultsMeta` computes a duration without asking the question twice.
- `isQueryInFlight` narrows it to `null`, which retires a `since !== undefined` guard in `RunningQuery` that could never be false.
- `WorksheetToolbar` keeps its boolean prop — it does not receive `query`, so it still legitimately needs one.

## Scope note

Five further sites asked the same question inline, split across *both* conventions: the result poller and its enable flag (`hooks/queries.ts`), the cancel wait (`hooks/mutations.ts`), and both `StatusBar` helpers. They are converted too. A shared predicate that only two of eight callers use does not actually stop the callers disagreeing — and the `finishedAt === 0` divergence the issue names was live between `hooks/queries.ts` (running) and `StatusBar.tsx` (finished), not just in `App`. No producer emits `0` (every writer is `Date.now()`; `use-start-query` writes `null`), so this is latent only.

## Test

The one genuine RED: the new `ResultsPane` case fails before the change, because with the prop absent the body falls through to `QueryResultEmpty` instead of the spinner.

The fixture is deliberately a query **carrying rows that has not finished** — a state no producer emits, and that is the point. With only `ResultsMeta`'s guard mutated (`!isQueryFinished(query)` → `query === undefined`), the body still spins while the header renders `100 rows · …`, and the case fails on exactly that assertion (line 85). A `result: null` fixture would have made the "no meta line" half vacuous, since the meta line returns empty for a resultless query either way.

`src/glue/queries.test.ts` adds 8 unit cases across both predicates, including `finishedAt: 0`.

## Checks

- `tsc` both projects — clean
- `eslint`, `prettier --check` — clean
- Full suite: **960 passed / 961**. The one failure is `src/databases/sqlite-adapter.test.ts`, confirmed to fail on clean `main` (verified by stashing). Unrelated.

Reviewed by a fresh-context agent. It verified behavioural equivalence at all three original call sites, confirmed nothing produces `finishedAt: 0`, and confirmed the type guard is sound. Its three findings — the vacuous assertion, the over-claimed comment, and the non-narrowing `isQueryInFlight` — are all addressed above.
