### PR TITLE
fix(databases): make remove and reorder land as one write each

### DIFF
--- a/src/server/services/database-service.test.ts
+++ b/src/server/services/database-service.test.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { Effect, Layer, Option } from 'effect'
 import { describe, expect, it } from 'vitest'
 
@@ -41,6 +41,25 @@ function run<A, E>(
   effect: Effect.Effect<A, E, AppDatabase | DatabaseService | WorksheetService>
 ): Promise<A> {
   return Effect.runPromise(Effect.provide(effect, makeLayer()))
+}
+
+// A real write failure rather than a mocked one. SQLite's RAISE(ABORT) backs
+// the offending statement out and leaves the transaction open, which is the
+// state a rollback actually has to clean up — a stubbed client would prove
+// only that the code called `transaction`, not that the rollback works.
+function failUpdatesTo(table: 'databases' | 'worksheets', when = '1 = 1') {
+  return Effect.gen(function* () {
+    const appDatabase = yield* AppDatabase
+
+    yield* appDatabase.execute((client) =>
+      client.run(
+        sql.raw(
+          `CREATE TRIGGER fail_updates_${table} BEFORE UPDATE ON ${table} WHEN ${when} ` +
+            `BEGIN SELECT RAISE(ABORT, 'injected write failure'); END`
+        )
+      )
+    )
+  })
 }
 
 const differentServerError = expect.objectContaining({
@@ -384,6 +403,56 @@ describe('DatabaseService', () => {
     expect(remaining).toEqual([])
   })
 
+  // The purge-and-soft-delete and the unlink were two statements, so a failure
+  // between them left live worksheets holding the id of a soft-deleted
+  // connection: shown as unconnected, never adopted by create's auto-link,
+  // and answering "database not found" for every query run from them.
+  it('leaves the connection intact when unlinking its worksheets fails', async () => {
+    const { databaseRow, error, linked, worksheetRow } = await run(
+      Effect.gen(function* () {
+        const service = yield* DatabaseService
+        const worksheets = yield* WorksheetService
+        const appDatabase = yield* AppDatabase
+
+        yield* worksheets.create({ name: 'My First Worksheet' })
+
+        const created = yield* service.create('Pagila', connection)
+
+        const [linked] = yield* appDatabase.execute((client) =>
+          client.select().from(worksheetsTable)
+        )
+
+        yield* failUpdatesTo('worksheets')
+
+        const error = yield* Effect.flip(service.remove(created.database.id))
+
+        const [databaseRow] = yield* appDatabase.execute((client) =>
+          client.select().from(databasesTable)
+        )
+        const [worksheetRow] = yield* appDatabase.execute((client) =>
+          client.select().from(worksheetsTable)
+        )
+
+        return { databaseRow, error, linked, worksheetRow }
+      })
+    )
+
+    // Without a linked worksheet the unlink matches no rows, the trigger never
+    // fires, and the rest of this would pass for the wrong reason.
+    expect(linked.databaseId).toEqual(databaseRow.id)
+
+    expect(error._tag).toEqual('AppDatabaseError')
+    // The statement the trigger aborted, so an unrelated database error cannot
+    // satisfy the tag alone. cause is drizzle's wrapper message; the libsql
+    // one carrying "injected write failure" is nested below it.
+    expect(error.cause).toContain('update "worksheets"')
+    expect(databaseRow.deletedAt).toBeNull()
+    expect(
+      databaseRow.connectionInfo.slice(testEncryptionPrefix.length)
+    ).not.toEqual('{}')
+    expect(worksheetRow.databaseId).toEqual(databaseRow.id)
+  })
+
   it('fails with DatabaseNotFoundError when removing an unknown id', async () => {
     const error = await run(
       Effect.gen(function* () {
@@ -453,6 +522,56 @@ describe('DatabaseService', () => {
     expect(ordered.map((database) => database.name)).toEqual([
       'Second',
       'First'
+    ])
+  })
+
+  // Reordering wrote N rows in N statements, so a failure at row k persisted a
+  // partial order while the caller was told the whole thing failed — and
+  // list()'s ordering then interleaved renumbered and stale rows.
+  it('leaves every position unchanged when a reorder fails partway', async () => {
+    const { error, rows } = await run(
+      Effect.gen(function* () {
+        const service = yield* DatabaseService
+        const appDatabase = yield* AppDatabase
+
+        const first = yield* service.create('First', connection)
+        const second = yield* service.create('Second', connection)
+        const third = yield* service.create('Third', connection)
+
+        // Aborts on the row the statement renumbers to 2, so two rows have
+        // already been assigned inside the statement when it fires. That is
+        // what makes the assertion below about statement-level rollback rather
+        // than about failing before anything was written.
+        yield* failUpdatesTo('databases', 'NEW.sortOrder = 2')
+
+        const error = yield* Effect.flip(
+          service.reorder([
+            third.database.id,
+            first.database.id,
+            second.database.id
+          ])
+        )
+
+        const rows = yield* appDatabase.execute((client) =>
+          client
+            .select({
+              name: databasesTable.name,
+              sortOrder: databasesTable.sortOrder
+            })
+            .from(databasesTable)
+            .orderBy(databasesTable.name)
+        )
+
+        return { error, rows }
+      })
+    )
+
+    expect(error._tag).toEqual('AppDatabaseError')
+    expect(error.cause).toContain('update "databases" set "sortOrder"')
+    expect(rows).toEqual([
+      { name: 'First', sortOrder: null },
+      { name: 'Second', sortOrder: null },
+      { name: 'Third', sortOrder: null }
     ])
   })
 

--- a/src/server/services/database-service.ts
+++ b/src/server/services/database-service.ts
@@ -296,17 +296,27 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
 
         const purged = yield* secrets.encrypt('{}')
 
-        // The secret purge and the soft delete are one write, so a deleted
-        // row never retains a password.
-        yield* appDatabase.execute((client) =>
-          client
+        // The purge and the soft delete are already one statement; the
+        // transaction is here for the unlink, which has to land with them. Run
+        // separately, a failure between the two left live worksheets holding
+        // the id of a soft-deleted row. Neither surface draws that as
+        // connected — both resolve the name through list(), which excludes
+        // deleted rows — they draw it as unconnected while the row still points
+        // at the dead id, so create's auto-link never adopts it (that matches
+        // only databaseId IS NULL) and a query run from it answers "database
+        // not found".
+        //
+        // Unlinking first would leave a more benign torn state and need no
+        // transaction. All-or-nothing is stronger, and create already takes the
+        // same BEGIN on the shared connection, so remove joins a hazard rather
+        // than inventing one.
+        yield* appDatabase.transaction(async (client) => {
+          await client
             .update(databasesTable)
             .set({ connectionInfo: purged, deletedAt: Date.now() })
             .where(eq(databasesTable.id, id))
-        )
 
-        yield* appDatabase.execute((client) =>
-          client
+          await client
             .update(worksheetsTable)
             .set({ databaseId: null })
             .where(
@@ -315,7 +325,7 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
                 isNull(worksheetsTable.deletedAt)
               )
             )
-        )
+        })
       })
 
       // Only writes sortOrder — reordering must never touch connectionInfo,
@@ -344,14 +354,34 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
           })
         }
 
-        for (const [index, id] of databaseIds.entries()) {
-          yield* appDatabase.execute((client) =>
-            client
-              .update(databasesTable)
-              .set({ sortOrder: index })
-              .where(eq(databasesTable.id, id))
-          )
-        }
+        // An ordering is one fact, not N per-row facts. Written as N
+        // statements, a failure at row k persisted a torn order while the caller
+        // got AppDatabaseError and the renderer reverted — and list()'s
+        // ordering below then interleaved renumbered and stale rows.
+        //
+        // One statement rather than a transaction, matching
+        // WorksheetService.reorder and for the reason written there:
+        // AppDatabase.transaction issues BEGIN on the single shared connection,
+        // so a concurrent write would either fail its own BEGIN and surface as
+        // "restart Squeal", or be swept into this transaction and rolled back
+        // with it after its own handler had already answered. A single UPDATE
+        // needs none of that to be atomic.
+        //
+        // Non-empty by contract: ReorderDatabasesRequest requires minItems(1),
+        // and sql.join([]) would emit `case "id" end`, a syntax error.
+        const positions = sql.join(
+          databaseIds.map((id, index) => sql`when ${id} then ${index}`),
+          sql` `
+        )
+
+        yield* appDatabase.execute((client) =>
+          client
+            .update(databasesTable)
+            .set({
+              sortOrder: sql`case ${databasesTable.id} ${positions} end`
+            })
+            .where(inArray(databasesTable.id, [...databaseIds]))
+        )
 
         return yield* list()
       })


### PR DESCRIPTION
Closes #70.

`DatabaseService.create` is atomic and says why. `remove` and `reorder` were not, and both torn states were reachable.

## remove

The purge-and-soft-delete was one statement; the worksheet unlink was a second, unguarded one. A failure between them left live worksheets holding the id of a soft-deleted row.

The issue described that as "the sidebar still shows it as connected". It doesn't — both surfaces resolve the name through `list()`, which excludes deleted rows. The real symptom is worse: the worksheet renders as *unconnected* while its row still points at the dead id, so `create`'s auto-link never adopts it (that matches only `databaseId IS NULL`) and any query run from it answers "database not found". It can never be repaired automatically.

Both writes now run in one transaction — the same primitive `create` already uses. Unlinking first instead would leave a more benign torn state and need no transaction; all-or-nothing is stronger, and `create` already takes the same `BEGIN` on the shared connection, so `remove` joins a hazard already on the books rather than inventing one.

## reorder

N rows in N statements, so a failure at row k persisted a partial ordering while the caller got `AppDatabaseError` and the renderer reverted — and `list()`'s ordering then interleaved renumbered and stale rows. It is now one `UPDATE` with a `CASE` over the ids.

**Deliberately not a transaction**, contrary to what the issue proposed. `WorksheetService.reorder` already solved this exact problem this exact way, and the reason is written at `worksheet-service.ts:152`: `AppDatabase.transaction` issues `BEGIN` on the single shared connection, so a concurrent write either fails its own `BEGIN` and surfaces as "restart Squeal", or is swept into this transaction and rolled back with it after its own handler already answered. A single `UPDATE` needs none of that to be atomic.

## Tests

Failure is injected with a real SQLite `BEFORE UPDATE` trigger raising `ABORT`, not a stubbed client — so the tests exercise the driver's own rollback rather than proving the code called `transaction`.

The reorder trigger fires on the row being renumbered to **2**, after two rows in the same statement have already been assigned. That matters: firing on the first row would pass even if SQLite had no statement-level atomicity at all.

Both tests fail against the pre-fix implementation (verified by checking out `HEAD~1`'s service): the connection comes back soft-deleted, and one row keeps `sortOrder` 0 while the rest stay null.

## Known gap, not addressed here

`DatabaseService.reorder` accepts a *partial* list of ids; `WorksheetService.reorder` refuses one (`worksheet-service.ts:141-150`) because renumbering a subset leaves the unnamed rows colliding. That is pre-existing, reachable through the API, and out of scope for this fix.

## Checks

`yarn typecheck`, `eslint`, `prettier --check`, and the full backend Vitest project all pass locally.
