### PR TITLE
fix(auth): ask one question about the bearer header, in one place

### DIFF
--- a/src/server/http/api.test.ts
+++ b/src/server/http/api.test.ts
@@ -126,8 +126,9 @@ describe('authentication', () => {
     )
   })
 
-  // The scheme token is case-insensitive per RFC 7235, and the platform's own
-  // bearer decoder ignores its case, so the trace-read middleware must too.
+  // The scheme token is case-insensitive per RFC 7235. Both routes now answer
+  // through presentsToken, so this pair is a regression guard on the shared
+  // predicate rather than on two independent ones.
   it('accepts a lowercase bearer scheme on a normal route', async () => {
     const response = await rawRequest(
       HttpClientRequest.get('/databases').pipe(
@@ -147,6 +148,38 @@ describe('authentication', () => {
 
     expect(response).toEqual({ body: { traces: [] }, status: 200 })
   })
+
+  // The two middlewares extracted the credential two different ways: the
+  // platform's decoder is `.slice('Bearer '.length)` and never looks at the
+  // scheme, while the trace-read path parsed it with a regex. They disagreed on
+  // real headers in both directions -- a doubled space was 401 on /databases
+  // and 200 on /traces, and any seven-character scheme was the reverse. Firing
+  // the same header at both routes is what stops the next divergence shipping.
+  it.each([
+    ['a doubled space after the scheme', `Bearer  ${testApiToken}`, 200],
+    ['a tab after the scheme', `bearer\t${testApiToken}`, 200],
+    ['a seven-character non-bearer scheme', `Digest ${testApiToken}`, 401],
+    ['no scheme at all', testApiToken, 401]
+  ])(
+    'answers %s alike on both authorized routes',
+    async (_description, authorization, status) => {
+      const databases = await rawRequest(
+        HttpClientRequest.get('/databases').pipe(
+          HttpClientRequest.setHeader('authorization', authorization)
+        )
+      )
+      const traces = await rawRequest(
+        HttpClientRequest.get('/traces').pipe(
+          HttpClientRequest.setHeader('authorization', authorization)
+        )
+      )
+
+      expect({ databases: databases.status, traces: traces.status }).toEqual({
+        databases: status,
+        traces: status
+      })
+    }
+  )
 
   // A browser always sends Origin cross-origin, so the development carve-out
   // must not apply to it — otherwise any visited page could read the span

--- a/src/server/http/authorization-live.ts
+++ b/src/server/http/authorization-live.ts
@@ -4,7 +4,7 @@ import { Config, Effect, Layer, Redacted } from 'effect'
 import { UnauthorizedError } from '@/glue/api/errors'
 import { Authorization, TraceReadAuthorization } from '@/glue/api/security'
 import { ApiToken } from './api-token'
-import { bearerCredential, isAuthorized } from './authorization'
+import { presentsToken } from './authorization'
 
 const unauthorized = new UnauthorizedError({ message: 'Unauthorized' })
 
@@ -14,10 +14,21 @@ export const AuthorizationLive = Layer.effect(
     const token = yield* ApiToken
 
     return {
-      bearer: (credential) =>
-        isAuthorized(Redacted.value(credential), Redacted.value(token))
-          ? Effect.void
-          : Effect.fail(unauthorized)
+      // The decoded credential the platform passes in is ignored: it is a
+      // blind seven-character slice of the header, so it accepts any scheme
+      // and mangles any extra space. Read the header and ask the same question
+      // the trace-read middleware asks. Reading HttpServerRequest here is
+      // legal because this handler's R is HttpRouter.Provided.
+      bearer: () =>
+        Effect.gen(function* () {
+          const request = yield* HttpServerRequest.HttpServerRequest
+
+          if (
+            !presentsToken(request.headers.authorization, Redacted.value(token))
+          ) {
+            return yield* Effect.fail(unauthorized)
+          }
+        })
     }
   })
 )
@@ -49,10 +60,7 @@ export const TraceReadAuthorizationLive = Layer.effect(
       }
 
       if (
-        !isAuthorized(
-          bearerCredential(request.headers.authorization),
-          Redacted.value(token)
-        )
+        !presentsToken(request.headers.authorization, Redacted.value(token))
       ) {
         return yield* Effect.fail(unauthorized)
       }

--- a/src/server/http/authorization.test.ts
+++ b/src/server/http/authorization.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { presentsToken } from './authorization'
+
+const token = 'test-api-token'
+
+describe('presentsToken', () => {
+  it.each([
+    ['the canonical scheme', `Bearer ${token}`],
+    ['a lowercase scheme', `bearer ${token}`],
+    ['an uppercase scheme', `BEARER ${token}`],
+    // RFC 7235 §2.1 separates the scheme from the credential with 1*SP, so more
+    // than one space is well-formed. The platform's blind seven-character slice
+    // read the second space as part of the credential and rejected it.
+    ['a doubled space', `Bearer  ${token}`],
+    ['a tab separator', `bearer\t${token}`]
+  ])('accepts the session token behind %s', (_description, header) => {
+    expect(presentsToken(header, token)).toEqual(true)
+  })
+
+  it.each([
+    ['no header at all', undefined],
+    ['an empty header', ''],
+    // Seven characters, so the platform's slice dropped exactly the scheme and
+    // authenticated this on every route except the trace reads.
+    ['a Digest scheme', `Digest ${token}`],
+    ['a Basic scheme', `Basic ${token}`],
+    ['the bare token with no scheme', token],
+    ['the scheme with no separator', `Bearer${token}`],
+    ['the right scheme and the wrong token', 'Bearer wrong-token'],
+    ['the scheme alone', 'Bearer ']
+  ])('rejects %s', (_description, header) => {
+    expect(presentsToken(header, token)).toEqual(false)
+  })
+
+  // The session token is 32 random bytes hex-encoded and can never be empty, so
+  // this is defence in depth rather than a reachable bypass. It is pinned
+  // because the predicate used to answer '' for an absent header and for a
+  // malformed one alike, which made both compare equal to an empty token -- and
+  // because a well-formed header with nothing behind the scheme yields a real
+  // '' that no amount of care about the undefined cases would have caught.
+  it.each([
+    ['no header', undefined],
+    ['a malformed scheme', 'Digest '],
+    ['the scheme with an empty credential', 'Bearer ']
+  ])(
+    'rejects %s even when the token itself is empty',
+    (_description, header) => {
+      expect(presentsToken(header, '')).toEqual(false)
+    }
+  )
+})

--- a/src/server/http/authorization.ts
+++ b/src/server/http/authorization.ts
@@ -1,19 +1,51 @@
 import { createHash, timingSafeEqual } from 'node:crypto'
 
+// RFC 7235 §2.1: the scheme token is case-insensitive, and 1*SP separates it
+// from the credential — so more than one space is well-formed. HTAB is not in
+// 1*SP; it is accepted anyway because `Bearer\t<token>` already authenticated
+// on every route (the scheme plus a tab is exactly the seven characters the
+// platform's decoder slices off), and narrowing that now would be a
+// regression rather than a fix.
 const bearerScheme = /^bearer[ \t]+/i
 
-// RFC 7235 §2.1 makes the scheme token case-insensitive, and the platform's own
-// bearer decoder ignores its case too. Being stricter here is what made
-// lowercase `bearer` work on every route except the trace reads.
-export function bearerCredential(header: string | undefined): string {
+// The single definition of "does this request present the session token", used
+// by both authorization middlewares.
+//
+// It exists because they used to answer it two different ways and disagreed on
+// real headers in both directions. The platform's own bearer decoder is
+// `(headers.authorization ?? '').slice('Bearer '.length)` — it never inspects
+// the scheme — so `Digest <token>` authenticated while `Bearer  <token>` did
+// not, and the trace-read path, which parsed the header, did the reverse. That
+// seam had already shipped one divergence: the lowercase `bearer` that worked
+// everywhere except trace reads.
+export function presentsToken(
+  header: string | undefined,
+  token: string
+): boolean {
+  const credential = bearerCredential(header)
+
+  // An empty credential is rejected outright rather than compared. Absent and
+  // malformed headers answer undefined, but `Bearer ` on its own is
+  // well-formed and yields '', which would authenticate against an empty
+  // token. The session token is 32 random bytes hex-encoded and can never be
+  // empty, so this is defence in depth rather than a live bypass — but it only
+  // is defence in depth if it covers the well-formed case too.
+  if (credential === undefined || credential === '') {
+    return false
+  }
+
+  return isAuthorized(credential, token)
+}
+
+function bearerCredential(header: string | undefined): string | undefined {
   if (header === undefined) {
-    return ''
+    return undefined
   }
 
   const match = bearerScheme.exec(header)
 
   if (match === null) {
-    return ''
+    return undefined
   }
 
   return header.slice(match[0].length)
@@ -21,7 +53,7 @@ export function bearerCredential(header: string | undefined): string {
 
 // Hashing both sides first makes timingSafeEqual usable for tokens of
 // unequal length without leaking the length through an early return.
-export function isAuthorized(presented: string, token: string): boolean {
+function isAuthorized(presented: string, token: string): boolean {
   const presentedDigest = createHash('sha256').update(presented).digest()
   const tokenDigest = createHash('sha256').update(token).digest()
 


### PR DESCRIPTION
Closes #71.

The two authorization middlewares extracted the credential two different ways, and disagreed on real headers **in both directions**.

`AuthorizationLive` trusted the credential the platform decoded. That decoder is not a bearer parser — `HttpApiBuilder.js:508` is `(request.headers.authorization ?? '').slice('Bearer '.length)`, seven characters off the front with no look at the scheme. `TraceReadAuthorization` parsed the header itself with a regex.

| Header | `/databases` before | `/traces` before | after |
|---|---|---|---|
| `Digest <token>` | **200** | 401 | 401 |
| `Bearer  <token>` (doubled space) | 401 | **200** | 200 |

Neither is a bypass — both paths still require byte equality with the session token, and the divergence only decides which *malformed* headers carrying a valid token get through. But this seam had already shipped one divergence (the lowercase `bearer` that worked everywhere except trace reads), which is the argument for collapsing it rather than patching it a third time.

## The change

`presentsToken(header, token)` is the single definition; both middlewares call it. `AuthorizationLive` reads `HttpServerRequest` inside its bearer handler and ignores the decoded argument — legal because the handler's `R` is `HttpRouter.Provided`, exactly how the trace-read middleware already got the request.

`HttpApiSecurity.bearer` stays declared to avoid reshaping the middleware tag from a security-shaped one into a bare one. Nothing reads its decode, and there is no OpenAPI endpoint that would. Collapsing the two tags into one shape is the real end state and is left for a follow-up.

An empty credential is refused outright: absent and malformed headers answer `undefined` rather than `''`, and `Bearer ` on its own — well-formed, yielding a genuine `''` — is rejected before the comparison. The token is `randomBytes(32).toString('hex')` and can never be empty, so this is defence in depth rather than a live fix; the second half is what makes it complete, since the `undefined` cases alone left the well-formed empty credential authenticating against an empty token.

HTAB after the scheme is accepted even though RFC 7235's `1*SP` does not include it: `bearer\t<token>` already authenticated on every route (scheme + tab is exactly seven characters), so narrowing it now would be a regression, not a fix. The comment at the regex says so.

## Tests

- **First unit tests for `authorization.ts`** — 16 cases across accept, reject, and reject-with-an-empty-token. Both old behaviours were replayed as mutations to confirm the new cases catch them.
- **A parity test in `api.test.ts`** fires the same header at `/databases` and `/traces` and asserts one `{ databases, traces }` object, so the next divergence fails a test instead of shipping. Two of its four rows fail before this change, once in each direction; the other two were already in agreement and are there to pin that.

## Checks

`yarn typecheck`, `eslint`, `prettier --check`, and the full backend Vitest project all pass locally.
