### PR TITLE
fix(tracing): bound the map of running query traces

### DIFF
--- a/src/app/components/traces/SpanDetailPanel.test.tsx
+++ b/src/app/components/traces/SpanDetailPanel.test.tsx
@@ -50,6 +50,14 @@ describe('SpanDetailPanel', () => {
     expect(screen.getByText(/at x/)).toBeInTheDocument()
   })
 
+  it('does not paint an unset status as a success', () => {
+    render(<SpanDetailPanel span={{ ...span, status: 'unset' }} />)
+
+    const badge = screen.getByText('unset')
+
+    expect(badge.className).not.toContain('text-ok')
+  })
+
   it('has no close button of its own', () => {
     render(<SpanDetailPanel span={span} />)
 

--- a/src/app/components/traces/SpanDetailPanel.tsx
+++ b/src/app/components/traces/SpanDetailPanel.tsx
@@ -39,7 +39,11 @@ export function SpanDetailPanel({ span }: SpanDetailPanelProps): ReactElement {
         <span
           className={cn(
             'rounded-full px-2 py-0.5',
-            span.status === 'error' ? 'bg-err/20 text-err' : 'bg-ok/20 text-ok'
+            span.status === 'error' && 'bg-err/20 text-err',
+            span.status === 'ok' && 'bg-ok/20 text-ok',
+            // A span that ended without a verdict — an abandoned query trace —
+            // is neither, and painting it as a success would be a lie.
+            span.status === 'unset' && 'bg-hover text-text2'
           )}
         >
           {span.status}

--- a/src/app/tracing/query-traces.test.ts
+++ b/src/app/tracing/query-traces.test.ts
@@ -19,6 +19,10 @@ const query = {
   worksheetId: 'worksheet-1'
 }
 
+// Mirrors maxActiveQueryTraces in query-traces.ts. Lowering the cap there
+// without touching these tests should break them.
+const activeQueryTraceCap = 50
+
 async function flushedSpans() {
   const send = vi.fn().mockResolvedValue({ insertedCount: 0 })
 
@@ -36,6 +40,12 @@ async function flushedSpans() {
         statusMessage: string | null
       }[]
   )
+}
+
+function startQueryTraces(count: number): void {
+  for (let index = 0; index < count; index++) {
+    queryTraces.startQueryTrace({ ...query, id: `query-${index}` })
+  }
 }
 
 describe('query traces', () => {
@@ -131,5 +141,58 @@ describe('query traces', () => {
     expect(() =>
       queryTraces.finishQueryTrace({ error: null, id: 'unknown' })
     ).not.toThrow()
+  })
+
+  it('abandons the oldest trace once the cap is reached', async () => {
+    startQueryTraces(activeQueryTraceCap + 1)
+
+    const spans = await flushedSpans()
+
+    expect(spans.length).toEqual(1)
+    expect(spans[0]?.attributes['query.id']).toEqual('query-0')
+    expect(spans[0]?.status).toEqual('unset')
+    expect(spans[0]?.events.map((event) => event.name)).toEqual([
+      'query.abandoned'
+    ])
+  })
+
+  it('abandons nothing while the map is merely full', async () => {
+    startQueryTraces(activeQueryTraceCap)
+
+    expect(await flushedSpans()).toEqual([])
+  })
+
+  it('keeps abandoning as further traces start', async () => {
+    startQueryTraces(activeQueryTraceCap + 10)
+
+    const spans = await flushedSpans()
+
+    expect(spans.map((span) => span.attributes['query.id'])).toEqual(
+      Array.from({ length: 10 }, (_, index) => `query-${index}`)
+    )
+  })
+
+  it('keeps every trace but the abandoned one', () => {
+    startQueryTraces(activeQueryTraceCap + 1)
+
+    const parents = Array.from(
+      { length: activeQueryTraceCap + 1 },
+      (_, index) => queryTraces.getQueryTraceParent(`query-${index}`)
+    )
+
+    expect(parents.filter((parent) => parent === undefined).length).toEqual(1)
+    expect(parents[0]).toEqual(undefined)
+  })
+
+  it('ignores a finish for a trace that was abandoned', async () => {
+    startQueryTraces(activeQueryTraceCap + 1)
+    queryTraces.finishQueryTrace({ error: null, id: 'query-0' })
+
+    const spans = await flushedSpans()
+
+    expect(spans.length).toEqual(1)
+    expect(spans[0]?.events.map((event) => event.name)).toEqual([
+      'query.abandoned'
+    ])
   })
 })

--- a/src/app/tracing/query-traces.ts
+++ b/src/app/tracing/query-traces.ts
@@ -20,6 +20,24 @@ interface QueryTraceResult {
 // the correlation key at every hop.
 const activeQuerySpans = new Map<string, Span>()
 
+// Only `finishQueryTrace` removes an entry, and its callers are the result
+// poller and the failed optimistic insert. The poller follows one query per
+// worksheet — the latest — so switching worksheets mid-run disables it, and so
+// does starting a second run in the same worksheet. Either way the span would
+// otherwise sit here for the lifetime of the window, holding up to 2000
+// characters of SQL and never exporting at all.
+//
+// The cap does not make tracing complete: whatever is still open when the
+// window closes is lost, exactly as before. What it does is bound the map and
+// give an evicted trace a terminal outcome that reaches the exporter, so the
+// oldest leak becomes visible instead of silently retained.
+//
+// The cap is deliberately generous, because reaching it ends the root span of
+// a query that may still be running. The sibling bridge on the same key,
+// `errorNoticeQueryIds`, uses 20: a stale toast intent is cheap to drop, while
+// this drops a trace of work the user actually did.
+const maxActiveQueryTraces = 50
+
 export function finishQueryTrace(query: QueryTraceResult): void {
   const span = activeQuerySpans.get(query.id)
 
@@ -53,6 +71,10 @@ export function startQueryTrace(query: QueryTraceInput): void {
     return
   }
 
+  if (activeQuerySpans.size >= maxActiveQueryTraces) {
+    abandonOldestQueryTrace()
+  }
+
   const attributes: SpanAttributes = {
     'db.statement': query.content,
     'query.id': query.id
@@ -67,4 +89,25 @@ export function startQueryTrace(query: QueryTraceInput): void {
   }
 
   activeQuerySpans.set(query.id, startSpan('query.run', { attributes }))
+}
+
+function abandonOldestQueryTrace(): void {
+  // A Map iterates in insertion order, so the first entry is the oldest. The
+  // only caller checks the size first, but destructuring an empty map throws a
+  // TypeError that TypeScript cannot see, and this runs on the path that
+  // starts the user's query.
+  const oldest = activeQuerySpans.entries().next().value
+
+  if (!oldest) {
+    return
+  }
+
+  const [queryId, span] = oldest
+
+  activeQuerySpans.delete(queryId)
+
+  // The status stays unset: the query was not observed to succeed or fail, and
+  // saying either would be a guess.
+  span.addEvent('query.abandoned')
+  span.end()
 }


### PR DESCRIPTION
Closes #56.

`activeQuerySpans` was an unbounded module-level `Map` — no TTL, no cap, no sweep — in direct violation of the memory rule in CLAUDE.md. The only thing that removed an entry was `finishQueryTrace`, whose callers are the result poller and the rejected optimistic insert. The poller follows one query per worksheet (the latest), so switching worksheets mid-run disables it, and so does starting a second run in the same worksheet. Either way the root span stayed in the map for the lifetime of the window, holding up to 2000 characters of SQL and never exporting at all — a trace that is silently absent is the worst way for tracing to fail.

## What changed

`startQueryTrace` abandons the oldest entry when the map is full: the span gets a `query.abandoned` event and ends, so it reaches the exporter. Its status stays `unset`, because nothing observed the query succeed or fail.

This does not make tracing complete — whatever is still open when the window closes is lost exactly as before. What the cap buys is a bounded map and a terminal, exported outcome for the oldest leak instead of silent retention.

The cap is 50. Reaching it ends the root span of a query that may still be running, so it is deliberately generous. The sibling bridge on the same correlation key, `errorNoticeQueryIds`, has been capped this way all along — at 20, because dropping a stale toast intent costs less than dropping the trace of work the user actually did.

Abandonment makes `status: 'unset'` reachable in a stored span for the first time, and the span detail badge painted everything that was not an error as a success, so an abandoned trace read as a green "unset". The badge now branches on all three statuses.

## Tests

Driven test-first, and each new test was mutation-checked (`>=` → `>`, drop the delete, drop the event, drop the `end()` — all four killed):

- the oldest trace is exported with the abandoned event and an unset status
- nothing is abandoned while the map is merely full, pinning the boundary
- eviction repeats rather than firing once, in start order
- the abandoned id is forgotten and the rest survive
- a late finish for an abandoned id neither throws nor double-exports
- an unset status is not painted as a success