### PR TITLE
chore(database): delete the dead chats and messages tables

### DIFF
--- a/doctor.config.json
+++ b/doctor.config.json
@@ -31,9 +31,8 @@
         ],
         "rules": ["react-doctor/prefer-dynamic-import"]
       },
-      // The schema statements are deliberately sequential: messages carries a
-      // foreign key to chats, every index needs its table to exist first, and
-      // they all run on one SQLite connection. The rule's suggested fix
+      // The schema statements are deliberately sequential: every index needs
+      // its table to exist first, and they all run on one SQLite connection. The rule's suggested fix
       // (Promise.all) applies to independent calls, which these are not.
       {
         "files": ["src/database/tables.ts"],

--- a/src/database/reconcile-columns.test.ts
+++ b/src/database/reconcile-columns.test.ts
@@ -166,7 +166,32 @@ describe('reconcileColumns', () => {
 // they disagree, every query on the affected table fails at runtime while every
 // test still passes, because the test helpers build their databases from
 // tables.ts and so never see the drift.
+//
+// The column checks below are driven by `appTables`, which is derived from
+// schema.ts — so a whole table left behind in tables.ts is one they can never
+// look at. That is what the first test covers.
 describe('tables.ts matches schema.ts', () => {
+  it('creates exactly the tables schema.ts declares', async () => {
+    const database = drizzle(':memory:')
+
+    await createTables(database)
+
+    const rows = await database.all<{ name: string }>(
+      // SQLite's own bookkeeping tables — sqlite_sequence, sqlite_stat1 —
+      // appear here the moment anything uses AUTOINCREMENT or ANALYZE, and
+      // they are not drift.
+      sql`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+        ORDER BY name
+      `
+    )
+
+    expect(rows.map((row) => row.name)).toEqual(
+      appTables.map(getTableName).sort()
+    )
+  })
+
   it.each(appTables.map((table) => [getTableName(table), table] as const))(
     'declares every %s column',
     async (tableName, table) => {

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -6,18 +6,6 @@ import {
   text
 } from 'drizzle-orm/sqlite-core'
 
-export const chatsTable = sqliteTable('chats', {
-  id: text()
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  createdAt: integer()
-    .notNull()
-    .$defaultFn(() => Date.now()),
-  updatedAt: integer()
-    .notNull()
-    .$defaultFn(() => Date.now())
-})
-
 export const databasesTable = sqliteTable('databases', {
   id: text()
     .primaryKey()
@@ -31,18 +19,6 @@ export const databasesTable = sqliteTable('databases', {
   name: text().notNull(),
   sortOrder: integer(),
   type: text().notNull()
-})
-
-export const messagesTable = sqliteTable('messages', {
-  id: text()
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  chatId: text()
-    .notNull()
-    .references(() => chatsTable.id),
-  content: text().notNull(),
-  role: text().notNull(),
-  toolInvocations: text()
 })
 
 export const queriesTable = sqliteTable(

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -1,28 +1,8 @@
 import { sql, type SQL } from 'drizzle-orm'
 import type { LibSQLDatabase } from 'drizzle-orm/libsql'
 
-// Order matters: a table carrying a foreign key has to come after the table it
-// references.
+// Order matters: an index has to come after the table it is defined on.
 const statements: SQL[] = [
-  sql`
-    CREATE TABLE IF NOT EXISTS chats (
-      id TEXT PRIMARY KEY NOT NULL,
-      createdAt INTEGER NOT NULL,
-      updatedAt INTEGER NOT NULL
-    )
-  `,
-
-  sql`
-    CREATE TABLE IF NOT EXISTS messages (
-      id TEXT PRIMARY KEY NOT NULL,
-      chatId TEXT NOT NULL,
-      role TEXT NOT NULL,
-      content TEXT NOT NULL,
-      toolInvocations TEXT,
-      FOREIGN KEY (chatId) REFERENCES chats(id) ON DELETE CASCADE
-    )
-  `,
-
   sql`
     CREATE TABLE IF NOT EXISTS databases (
       id TEXT PRIMARY KEY NOT NULL,


### PR DESCRIPTION
Closes #77.

The AI-chat feature and `src/main/chat` were removed; its two tables were not. Nothing reads them, yet they were created in every user's database on every boot and walked by `reconcileColumns` on every boot, and between them they held the schema's only foreign key.

## No DROP TABLE

`createTables` is `CREATE TABLE IF NOT EXISTS` and nothing queries these, so in an already-installed database the two tables are simply orphaned. Nothing in the app walks `sqlite_master` over the app database — `reconcileColumns` iterates `appTables`, retention sweeps two named tables, and there is no VACUUM or backup path — so nothing will ever see them again. Dropping them would be a destructive migration bought for nothing.

## Driving it test-first

The existing guard could not have caught a half-done version of this change: it iterates `appTables`, which is derived from `schema.ts`, so a table left behind in `tables.ts` is a table it never looks at. It now also asserts that `createTables` creates exactly the tables `schema.ts` declares — and that assertion does fail against a `schema.ts`-only deletion, which is how this change was driven (delete from `schema.ts`, watch it go red with `+chats`/`+messages`, then delete the DDL).

The query excludes `sqlite_%`, matching `sqlite-adapter.ts`, so a future `AUTOINCREMENT` or `ANALYZE` cannot make it fail claiming drift that does not exist.

## Comments that outlived their reason

Two comments justified themselves with the foreign key that is now gone: the ordering note in `tables.ts` and the react-doctor `async-await-in-loop` override in `doctor.config.json`. Both now give the ordering constraint that still holds — an index has to come after the table it is defined on, which SQLite does enforce (`IF NOT EXISTS` does not rescue it).

## Left alone deliberately

- `drizzle/` still declares both tables. Nothing reads it; #104 covers deleting the folder.
- The guard compares tables and columns, not indexes. An index in `schema.ts` but missing from `tables.ts` still ships silently — worth a follow-up, but not this change.