### PR TITLE
fix(worksheets): rename from one session, not one per surface

### DIFF
--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -161,7 +161,7 @@ export function WorksheetExplorer(): ReactElement {
     inputRef,
     setEditingName,
     startEditing
-  } = useWorksheetRename(worksheets.data)
+  } = useWorksheetRename(worksheets.data, 'explorer')
 
   const { handleNewWorksheet, handleSelectWorksheet } = useWorksheetActions(
     worksheets.data,

--- a/src/app/components/WorksheetTabs.tsx
+++ b/src/app/components/WorksheetTabs.tsx
@@ -135,8 +135,12 @@ function useNewWorksheet(
 
 interface TabHotkeysOptions {
   activeWorksheetId: string | undefined
-  /** Set while a tab is being renamed, which owns the keyboard. */
-  editingWorksheetId: string | null
+  /**
+   * True while a worksheet is being renamed anywhere, which owns the keyboard.
+   * Anywhere and not just here: the sidebar list renames the same worksheets
+   * from the same session, and both hotkeys below run on form tags.
+   */
+  isRenaming: boolean
   openTabs: WorksheetDto[]
   onActivate: (worksheetId: string) => void
   onClose: (worksheetId: string) => void
@@ -149,19 +153,24 @@ interface TabHotkeysOptions {
  * dead exactly where they are most useful.
  */
 function useTabHotkeys(options: TabHotkeysOptions): void {
-  const {
-    activeWorksheetId,
-    editingWorksheetId,
-    openTabs,
-    onActivate,
-    onClose
-  } = options
+  const { activeWorksheetId, isRenaming, openTabs, onActivate, onClose } =
+    options
 
   useHotkeys(
     'mod+w',
     (event) => {
-      // Closing the tab out from under a rename would throw the edit away.
-      if (!activeWorksheetId || editingWorksheetId) {
+      // Closing a tab is not what this key means while a name is being
+      // edited — for a rename in this strip it takes the input with it, and
+      // from the sidebar it acts on a surface the user is not looking at. The
+      // key still has to be swallowed, though: Electron's default menu binds
+      // mod+w to `close`, so letting it through takes the whole window.
+      if (isRenaming) {
+        event.preventDefault()
+
+        return
+      }
+
+      if (!activeWorksheetId) {
         return
       }
 
@@ -170,13 +179,13 @@ function useTabHotkeys(options: TabHotkeysOptions): void {
       onClose(activeWorksheetId)
     },
     { enableOnContentEditable: true, enableOnFormTags: true },
-    [activeWorksheetId, editingWorksheetId, onClose]
+    [activeWorksheetId, isRenaming, onClose]
   )
 
   useHotkeys(
     tabHotkeys,
     (event, hotkey) => {
-      const worksheet = editingWorksheetId
+      const worksheet = isRenaming
         ? undefined
         : tabAtHotkeyPosition(openTabs, Number(hotkey.keys?.[0]))
 
@@ -188,7 +197,7 @@ function useTabHotkeys(options: TabHotkeysOptions): void {
       onActivate(worksheet.id)
     },
     { enableOnContentEditable: true, enableOnFormTags: true },
-    [editingWorksheetId, onActivate, openTabs]
+    [isRenaming, onActivate, openTabs]
   )
 }
 
@@ -218,7 +227,7 @@ export function WorksheetTabs(): ReactElement {
   const activeWorksheetId = useAppSelector(selectActiveWorksheetId)
   const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
 
-  const rename = useWorksheetRename(worksheets.data)
+  const rename = useWorksheetRename(worksheets.data, 'tabs')
 
   const openTabs = useOpenTabs(openWorksheetIds, worksheets.data)
   const openTabIds = openTabs.map((worksheet) => worksheet.id)
@@ -264,7 +273,7 @@ export function WorksheetTabs(): ReactElement {
 
   useTabHotkeys({
     activeWorksheetId,
-    editingWorksheetId: rename.editingWorksheetId,
+    isRenaming: rename.isRenaming,
     onActivate: handleActivate,
     onClose: handleClose,
     openTabs

--- a/src/app/components/worksheet-rename-session.test.tsx
+++ b/src/app/components/worksheet-rename-session.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import invariant from 'tiny-invariant'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { WorksheetDto } from '@/glue/worksheets'
+
+import { renderWithProviders } from '../test-utils'
+import { WorksheetExplorer } from './WorksheetExplorer'
+import { WorksheetTabs } from './WorksheetTabs'
+
+vi.mock('../api-client', () => ({
+  apiClient: {
+    createWorksheet: vi.fn(),
+    deleteWorksheet: vi.fn(),
+    getDatabases: vi.fn(async () => []),
+    updateWorksheet: vi.fn()
+  }
+}))
+
+import { apiClient } from '../api-client'
+
+function worksheet(id: string, name: string): WorksheetDto {
+  return {
+    content: '',
+    createdAt: 1704067200000,
+    databaseId: null,
+    id,
+    lastOpenedAt: null,
+    name,
+    sortOrder: null
+  }
+}
+
+const revenue = worksheet('ws-1', 'Revenue')
+const signups = worksheet('ws-2', 'Signups')
+
+const allWorksheets = [revenue, signups]
+
+const openTabs = {
+  activeWorksheetId: 'ws-1',
+  openWorksheetIds: ['ws-1', 'ws-2']
+}
+
+function renderBothSurfaces() {
+  return renderWithProviders(
+    <>
+      <WorksheetExplorer />
+      <WorksheetTabs />
+    </>,
+    { databases: [], tabs: openTabs, worksheets: allWorksheets }
+  )
+}
+
+// The sidebar list and the tab strip are mounted at the same time, and the tab
+// hotkeys are registered with enableOnFormTags, so they fire while a rename
+// input has the keyboard. The tab strip knew only about renames it had started
+// itself, which left every hotkey live during a sidebar rename.
+describe('renaming a worksheet from the sidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(apiClient.updateWorksheet).mockResolvedValue(revenue)
+  })
+
+  it('opens only one input, whichever surface asked last', async () => {
+    const user = userEvent.setup()
+
+    renderBothSurfaces()
+
+    await user.dblClick(screen.getByRole('button', { name: 'Revenue' }))
+    await user.dblClick(screen.getByRole('tab', { name: 'Signups' }))
+
+    expect(screen.getAllByRole('textbox', { name: /^Rename/ })).toHaveLength(1)
+  })
+
+  it('swallows the close shortcut instead of leaving it to the window', async () => {
+    const user = userEvent.setup()
+
+    renderBothSurfaces()
+
+    await user.dblClick(screen.getByRole('button', { name: 'Revenue' }))
+
+    // fireEvent answers false when the handler called preventDefault. Letting
+    // the event through is not inert: mod+w is Electron's own `close`
+    // accelerator, so the whole window would go.
+    const wasNotPrevented = fireEvent.keyDown(document, {
+      code: 'KeyW',
+      key: 'w',
+      metaKey: true
+    })
+
+    expect(wasNotPrevented).toEqual(false)
+  })
+
+  it('keeps a name typed in the other surface when a new worksheet takes the session', async () => {
+    const user = userEvent.setup()
+
+    let publishWorksheet: ((worksheet: WorksheetDto) => void) | undefined
+
+    vi.mocked(apiClient.createWorksheet).mockReturnValue(
+      new Promise<WorksheetDto>((resolve) => {
+        publishWorksheet = resolve
+      })
+    )
+
+    renderBothSurfaces()
+
+    // The tab strip has a New worksheet button of its own, but only the
+    // sidebar's opens the new name for editing.
+    const explorerHeader = screen.getByRole('heading', {
+      name: 'Worksheets'
+    }).parentElement
+
+    invariant(
+      explorerHeader,
+      'The Worksheets heading sits in the explorer header.'
+    )
+
+    // The create is in flight, so its rename starts with no click and no focus
+    // change — nothing blurs the input the user is typing in.
+    await user.click(
+      within(explorerHeader).getByRole('button', { name: 'New worksheet' })
+    )
+
+    await user.dblClick(screen.getByRole('tab', { name: 'Revenue' }))
+
+    const input = screen.getByDisplayValue('Revenue')
+
+    await user.clear(input)
+    await user.type(input, 'Q3 Revenue')
+
+    invariant(publishWorksheet, 'The create should have been started.')
+
+    publishWorksheet(worksheet('ws-3', 'Untitled Worksheet'))
+
+    await waitFor(() => {
+      expect(apiClient.updateWorksheet).toHaveBeenCalledWith('ws-1', {
+        name: 'Q3 Revenue'
+      })
+    })
+  })
+
+  it('leaves the close shortcut inert while the name is being edited', async () => {
+    const user = userEvent.setup()
+
+    const { store } = renderBothSurfaces()
+
+    await user.dblClick(screen.getByRole('button', { name: 'Revenue' }))
+
+    expect(
+      screen.getByRole('textbox', { name: 'Rename Revenue' })
+    ).toBeInTheDocument()
+
+    await user.keyboard('{Meta>}w{/Meta}')
+
+    expect(store.getState().tabs).toEqual({
+      ...openTabs,
+      status: 'reconciled'
+    })
+  })
+
+  it('leaves the tab position shortcuts inert while the name is being edited', async () => {
+    const user = userEvent.setup()
+
+    const { store } = renderBothSurfaces()
+
+    await user.dblClick(screen.getByRole('button', { name: 'Revenue' }))
+
+    expect(
+      screen.getByRole('textbox', { name: 'Rename Revenue' })
+    ).toBeInTheDocument()
+
+    await user.keyboard('{Meta>}2{/Meta}')
+
+    expect(store.getState().tabs).toEqual({
+      ...openTabs,
+      status: 'reconciled'
+    })
+  })
+
+  it('releases the hotkeys when the renamed worksheet is gone', async () => {
+    const user = userEvent.setup()
+
+    // Deleting a worksheet mid-rename unmounts its input without ending the
+    // session, and nothing else ever will — there is no input left to blur or
+    // press Escape in. Held on to, it dead-keys mod+w and mod+1…9 for the rest
+    // of the session.
+    const { store } = renderWithProviders(<WorksheetTabs />, {
+      editor: {
+        worksheetRename: {
+          draftName: 'Deleted',
+          scope: 'explorer',
+          worksheetId: 'ws-gone'
+        }
+      },
+      tabs: openTabs,
+      worksheets: allWorksheets
+    })
+
+    await user.keyboard('{Meta>}2{/Meta}')
+
+    expect(store.getState().tabs).toEqual({
+      ...openTabs,
+      activeWorksheetId: 'ws-2',
+      status: 'reconciled'
+    })
+  })
+})

--- a/src/app/hooks/use-worksheet-rename.ts
+++ b/src/app/hooks/use-worksheet-rename.ts
@@ -1,7 +1,14 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 
 import { useCollections } from '../collections-context'
+import { useAppDispatch, useAppSelector, useAppStore } from '../store'
+import {
+  worksheetRenameDraftUpdated,
+  worksheetRenameEnded,
+  worksheetRenameStarted,
+  type WorksheetRenameScope
+} from '../store/editor-slice'
 import { WorksheetDto } from '@/glue/worksheets'
 
 export type WorksheetRenameControls = ReturnType<typeof useWorksheetRename>
@@ -11,14 +18,41 @@ export type WorksheetRenameControls = ReturnType<typeof useWorksheetRename>
  * worksheet is being edited, the draft name, and the commit that writes it
  * through the collection. The update is optimistic, so a rejected save rolls
  * back on its own and only needs a toast.
+ *
+ * There is one session for the whole app rather than one per surface, because
+ * both surfaces are mounted at once and the tab hotkeys are registered with
+ * `enableOnFormTags`. Held per surface, the tab strip could only see renames it
+ * had started itself, so while the sidebar had a name half-typed `mod+w` closed
+ * the active tab and `mod+1…9` switched to another — acting on a surface the
+ * user was not looking at, under keys they had aimed at the input. `scope` is
+ * what keeps the input itself in one place: `editingWorksheetId` answers "am I
+ * the surface editing it", `isRenaming` answers "is anyone".
  */
-export function useWorksheetRename(worksheets: WorksheetDto[]) {
+export function useWorksheetRename(
+  worksheets: WorksheetDto[],
+  scope: WorksheetRenameScope
+) {
+  const dispatch = useAppDispatch()
+  const store = useAppStore()
   const { worksheets: worksheetsCollection } = useCollections()
 
-  const [editingWorksheetId, setEditingWorksheetId] = useState<string | null>(
-    null
+  // Three narrow reads rather than one of the session object: the surface that
+  // is not editing would otherwise re-render on every keystroke in the other
+  // one, and both are mounted the whole time.
+  const editingWorksheetId = useAppSelector((state) =>
+    state.editor.worksheetRename?.scope === scope
+      ? state.editor.worksheetRename.worksheetId
+      : null
   )
-  const [editingName, setEditingName] = useState('')
+  const editingName = useAppSelector((state) =>
+    state.editor.worksheetRename?.scope === scope
+      ? state.editor.worksheetRename.draftName
+      : ''
+  )
+  const renamedWorksheetId = useAppSelector(
+    (state) => state.editor.worksheetRename?.worksheetId ?? null
+  )
+
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -28,35 +62,24 @@ export function useWorksheetRename(worksheets: WorksheetDto[]) {
     }
   }, [editingWorksheetId])
 
-  const startEditing = useCallback((worksheet: WorksheetDto) => {
-    setEditingWorksheetId(worksheet.id)
-    setEditingName(worksheet.name)
-  }, [])
+  const setEditingName = useCallback(
+    (name: string) => {
+      dispatch(worksheetRenameDraftUpdated(name))
+    },
+    [dispatch]
+  )
 
-  const handleRenameCancel = useCallback(() => {
-    setEditingWorksheetId(null)
-    setEditingName('')
-  }, [])
-
-  const handleRenameSubmit = useCallback(
-    (worksheetId: string) => {
-      const trimmedName = editingName.trim()
-
-      if (!trimmedName) {
-        handleRenameCancel()
-
-        return
-      }
-
+  const commitRename = useCallback(
+    (worksheetId: string, name: string) => {
+      const trimmedName = name.trim()
       const worksheet = worksheets.find((w) => w.id === worksheetId)
 
-      if (!worksheet || worksheet.name === trimmedName) {
-        handleRenameCancel()
-
+      // An empty name, a worksheet that has since gone, or no change at all:
+      // there is nothing to write, and blanking the name would be worse than
+      // keeping it.
+      if (!trimmedName || !worksheet || worksheet.name === trimmedName) {
         return
       }
-
-      setEditingWorksheetId(null)
 
       const transaction = worksheetsCollection.update(worksheetId, (draft) => {
         draft.name = trimmedName
@@ -67,10 +90,46 @@ export function useWorksheetRename(worksheets: WorksheetDto[]) {
 
         toast.error('Failed to rename worksheet', { description: message })
       })
-
-      setEditingName('')
     },
-    [editingName, handleRenameCancel, worksheetsCollection, worksheets]
+    [worksheetsCollection, worksheets]
+  )
+
+  const startEditing = useCallback(
+    (worksheet: WorksheetDto) => {
+      // Starting a session takes it from whoever had it, and React fires no
+      // blur when that input unmounts with the focus staying put. Creating a
+      // worksheet does exactly that: its rename opens from a resolved promise,
+      // no click involved. Read the session now rather than from a selector so
+      // this sees what is open at the moment of the take-over.
+      const previous = store.getState().editor.worksheetRename
+
+      if (previous && previous.worksheetId !== worksheet.id) {
+        commitRename(previous.worksheetId, previous.draftName)
+      }
+
+      dispatch(
+        worksheetRenameStarted({
+          draftName: worksheet.name,
+          scope,
+          worksheetId: worksheet.id
+        })
+      )
+    },
+    [commitRename, dispatch, scope, store]
+  )
+
+  const handleRenameCancel = useCallback(() => {
+    dispatch(worksheetRenameEnded())
+  }, [dispatch])
+
+  const handleRenameSubmit = useCallback(
+    (worksheetId: string) => {
+      // Closing the session first means the input is gone whether or not the
+      // name changed, and the optimistic update rolls itself back on failure.
+      handleRenameCancel()
+      commitRename(worksheetId, editingName)
+    },
+    [commitRename, editingName, handleRenameCancel]
   )
 
   const handleKeyDown = useCallback(
@@ -92,6 +151,13 @@ export function useWorksheetRename(worksheets: WorksheetDto[]) {
     handleKeyDown,
     handleRenameSubmit,
     inputRef,
+    // A session whose worksheet has been deleted still holds the keyboard, and
+    // nothing would ever end it — no input is mounted to blur or press Escape
+    // in. Asking whether the worksheet is still here answers that without an
+    // unmount effect, which StrictMode would fire spuriously.
+    isRenaming:
+      renamedWorksheetId !== null &&
+      worksheets.some((worksheet) => worksheet.id === renamedWorksheetId),
     setEditingName,
     startEditing
   }

--- a/src/app/store/editor-slice.test.ts
+++ b/src/app/store/editor-slice.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import reducer, {
+  databaseSearchQueryUpdated,
+  EditorState,
+  worksheetRenameDraftUpdated,
+  worksheetRenameEnded,
+  worksheetRenameStarted,
+  worksheetSearchQueryUpdated
+} from './editor-slice'
+
+const initialState: EditorState = {
+  databaseSearchQuery: '',
+  worksheetRename: null,
+  worksheetSearchQuery: ''
+}
+
+const renaming: EditorState = {
+  ...initialState,
+  worksheetRename: {
+    draftName: 'Revenue',
+    scope: 'explorer',
+    worksheetId: 'ws-1'
+  }
+}
+
+describe('editorSlice', () => {
+  describe('initial state', () => {
+    it('starts with no rename and no searches', () => {
+      const state = reducer(undefined, { type: 'unknown' })
+
+      expect(state).toEqual(initialState)
+    })
+  })
+
+  describe('databaseSearchQueryUpdated', () => {
+    it('stores the query', () => {
+      const state = reducer(initialState, databaseSearchQueryUpdated('pagila'))
+
+      expect(state).toEqual({ ...initialState, databaseSearchQuery: 'pagila' })
+    })
+  })
+
+  describe('worksheetSearchQueryUpdated', () => {
+    it('stores the query', () => {
+      const state = reducer(initialState, worksheetSearchQueryUpdated('rev'))
+
+      expect(state).toEqual({ ...initialState, worksheetSearchQuery: 'rev' })
+    })
+  })
+
+  describe('worksheetRenameStarted', () => {
+    it('opens the session on the given surface', () => {
+      const state = reducer(
+        initialState,
+        worksheetRenameStarted({
+          draftName: 'Revenue',
+          scope: 'explorer',
+          worksheetId: 'ws-1'
+        })
+      )
+
+      expect(state).toEqual(renaming)
+    })
+
+    // There is one session for the whole app, so the surface that had it loses
+    // its input rather than leaving two open at once.
+    it('replaces a session the other surface had open', () => {
+      const state = reducer(
+        renaming,
+        worksheetRenameStarted({
+          draftName: 'Signups',
+          scope: 'tabs',
+          worksheetId: 'ws-2'
+        })
+      )
+
+      expect(state).toEqual({
+        ...initialState,
+        worksheetRename: {
+          draftName: 'Signups',
+          scope: 'tabs',
+          worksheetId: 'ws-2'
+        }
+      })
+    })
+  })
+
+  describe('worksheetRenameDraftUpdated', () => {
+    it('keeps the scope and the worksheet while the name changes', () => {
+      const state = reducer(renaming, worksheetRenameDraftUpdated('Q3 Revenue'))
+
+      expect(state).toEqual({
+        ...initialState,
+        worksheetRename: {
+          draftName: 'Q3 Revenue',
+          scope: 'explorer',
+          worksheetId: 'ws-1'
+        }
+      })
+    })
+
+    it('invents no session when none is open', () => {
+      const state = reducer(initialState, worksheetRenameDraftUpdated('Q3'))
+
+      expect(state).toEqual(initialState)
+    })
+  })
+
+  describe('worksheetRenameEnded', () => {
+    it('closes the session', () => {
+      const state = reducer(renaming, worksheetRenameEnded())
+
+      expect(state).toEqual(initialState)
+    })
+
+    it('leaves the searches alone', () => {
+      const state = reducer(
+        {
+          databaseSearchQuery: 'pagila',
+          worksheetRename: renaming.worksheetRename,
+          worksheetSearchQuery: 'rev'
+        },
+        worksheetRenameEnded()
+      )
+
+      expect(state).toEqual({
+        databaseSearchQuery: 'pagila',
+        worksheetRename: null,
+        worksheetSearchQuery: 'rev'
+      })
+    })
+  })
+})

--- a/src/app/store/editor-slice.ts
+++ b/src/app/store/editor-slice.ts
@@ -1,14 +1,28 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
+// Which surface opened the rename input. The session is shared, so this is how
+// the sidebar list and the tab strip each tell "I am the one being edited"
+// apart from "someone else is being edited" — the second of which still has to
+// hold the tab hotkeys off.
+export type WorksheetRenameScope = 'explorer' | 'tabs'
+
+export interface WorksheetRenameSession {
+  draftName: string
+  scope: WorksheetRenameScope
+  worksheetId: string
+}
+
 // Which worksheet is open now lives in the tabs slice — `tabOpened` both opens
 // and activates, so there is no separate "selected" concept any more.
 export interface EditorState {
   databaseSearchQuery: string
+  worksheetRename: WorksheetRenameSession | null
   worksheetSearchQuery: string
 }
 
 const initialState: EditorState = {
   databaseSearchQuery: '',
+  worksheetRename: null,
   worksheetSearchQuery: ''
 }
 
@@ -19,13 +33,40 @@ const editorSlice = createSlice({
     databaseSearchQueryUpdated: (state, action: PayloadAction<string>) => {
       state.databaseSearchQuery = action.payload
     },
+    worksheetRenameDraftUpdated: (state, action: PayloadAction<string>) => {
+      // A keystroke can only come from an input that is already open, so this
+      // is the narrowing TypeScript needs rather than a case that happens.
+      // Dropping the draft is still the right answer if it ever does: a
+      // session invented here would have no scope to belong to.
+      if (state.worksheetRename === null) {
+        return
+      }
+
+      state.worksheetRename.draftName = action.payload
+    },
+    worksheetRenameEnded: (state) => {
+      state.worksheetRename = null
+    },
+    // Starting a rename anywhere replaces the session, so the surface that had
+    // it loses its input rather than leaving two open at once.
+    worksheetRenameStarted: (
+      state,
+      action: PayloadAction<WorksheetRenameSession>
+    ) => {
+      state.worksheetRename = action.payload
+    },
     worksheetSearchQueryUpdated: (state, action: PayloadAction<string>) => {
       state.worksheetSearchQuery = action.payload
     }
   }
 })
 
-export const { databaseSearchQueryUpdated, worksheetSearchQueryUpdated } =
-  editorSlice.actions
+export const {
+  databaseSearchQueryUpdated,
+  worksheetRenameDraftUpdated,
+  worksheetRenameEnded,
+  worksheetRenameStarted,
+  worksheetSearchQueryUpdated
+} = editorSlice.actions
 
 export default editorSlice.reducer

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch, useSelector, useStore } from 'react-redux'
 
 import databaseExplorerReducer, {
   DatabaseExplorerState
@@ -60,7 +60,13 @@ export function createStore() {
   return store
 }
 
-type AppDispatch = ReturnType<typeof createStore>['dispatch']
+type AppStore = ReturnType<typeof createStore>
+type AppDispatch = AppStore['dispatch']
 
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>()
 export const useAppSelector = useSelector.withTypes<RootState>()
+
+// For the rare read that must not subscribe the component: a callback that
+// needs the state as it is at the moment it runs, not as it was when the
+// callback was created.
+export const useAppStore = useStore.withTypes<AppStore>()

--- a/src/app/test-utils.tsx
+++ b/src/app/test-utils.tsx
@@ -117,6 +117,7 @@ function createDatabaseExplorerState(
 function createEditorState(options: RenderOptions): EditorState {
   return {
     databaseSearchQuery: options.editor?.databaseSearchQuery ?? '',
+    worksheetRename: options.editor?.worksheetRename ?? null,
     worksheetSearchQuery: options.editor?.worksheetSearchQuery ?? ''
   }
 }


### PR DESCRIPTION
Closes #95

`useWorksheetRename` was called twice — once in the tab strip, once in the sidebar list — and each call held its own `editingWorksheetId`. Both components are mounted at the same time, so the app had two independent rename sessions over the same worksheets.

`WorksheetTabs` passed only its own `rename.editingWorksheetId` into `useTabHotkeys`, and both hotkeys there are registered with `enableOnFormTags`, so they fire while an input has the keyboard. While a name was being edited in the sidebar, the tab strip knew nothing about it: `mod+w` closed the active tab and `mod+1…9` switched to another — acting on a surface the user was not looking at, under keys they had aimed at the input. The sidebar's input and its half-typed name survived that; a tab the user did not ask to close did not. Renaming in the tab strip was guarded, renaming in the sidebar was not, and both surfaces offer Rename from their context menu.

## The change

The session lives in the editor slice as `{ draftName, scope, worksheetId } | null`. `scope` keeps the input in one place: `editingWorksheetId` answers "am I the surface editing it" and drives rendering exactly as before, while the new `isRenaming` answers "is anyone" and is what the hotkeys guard on. Starting a rename anywhere replaces the session, so two inputs cannot be open at once by construction.

Three details the shared session forces:

- **`mod+w` now calls `preventDefault` before bowing out.** Returning early left the key to Electron's default menu, which binds it to `close` — so guarding the rename would have closed the *window* instead of the tab.
- **`startEditing` commits whatever session it takes over.** React fires no blur when an input unmounts with the focus staying put, and creating a worksheet opens its rename from a resolved promise with no click involved, so a name being typed in the other surface would have gone silently.
- **`isRenaming` asks whether the renamed worksheet still exists.** A session left behind by a deleted worksheet has no input to blur or press Escape in, so nothing would ever end it and the hotkeys would stay dead for the rest of the session.

The slice was the home rather than a new provider because both surfaces are already store-connected, the editor slice already holds worksheet UI state (`worksheetSearchQuery`), and nothing in it is persisted — so a session cannot survive a restart and reopen an input over a worksheet that is gone. The hook reads it through three narrow selectors rather than one on the session object, or the idle surface would re-render on every keystroke in the other.

## Testing

`worksheet-rename-session.test.tsx` renders both surfaces together, which is the only way to reach this — the existing `WorksheetTabs` rename tests pass with either implementation, because a tab-strip rename was always guarded. Each test fails before the change it covers: the tab closed, the tab switched, the window taken, the typed name dropped, the hotkeys dead. `editor-slice.test.ts` covers the reducers directly, matching its sibling slices.

Full suite: 966 passed, 1 failed — `sqlite-adapter.test.ts` "connects and executes SELECT 1", a pre-existing Windows-only `file:///C:/…` URL difference that passes on CI.