### PR TITLE
refactor(explorer): decide a row's tables in one place

### DIFF
--- a/src/app/components/DatabaseExplorer.test.tsx
+++ b/src/app/components/DatabaseExplorer.test.tsx
@@ -264,6 +264,48 @@ describe('DatabaseExplorer', () => {
     expect(screen.queryByText('users')).not.toBeInTheDocument()
   })
 
+  it('reveals only the tables a search matched', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [testDatabase],
+      schemas: { 'db-123': testSchema }
+    })
+
+    await user.type(screen.getByPlaceholderText('Filter tables'), 'user')
+
+    // The match is what forces the row open, so what it opens onto is the
+    // matching tables — not the whole list with the answer somewhere in it.
+    expect(screen.getByText('users')).toBeInTheDocument()
+    expect(screen.queryByText('posts')).not.toBeInTheDocument()
+  })
+
+  it('shows each database its own tables', async () => {
+    const user = userEvent.setup()
+    const otherSchema: SchemaInfo = {
+      databaseName: 'otherdb',
+      tables: [{ ...testSchema.tables[0], tableName: 'invoices' }]
+    }
+
+    renderWithProviders(<DatabaseExplorer />, {
+      databases: [
+        testDatabase,
+        { ...testDatabase, id: 'db-999', name: 'Other Database' }
+      ],
+      schemas: { 'db-123': testSchema, 'db-999': otherSchema }
+    })
+
+    await user.click(screen.getByText('Other Database'))
+
+    // The rows read their schemas by position in an array built from a second
+    // pass over the same databases. That is correct only while the two passes
+    // stay in step, and nothing about it is checked by types: a filter or sort
+    // added to one of them would quietly file one database's tables under
+    // another's name.
+    expect(screen.getByText('invoices')).toBeInTheDocument()
+    expect(screen.queryByText('users')).not.toBeInTheDocument()
+  })
+
   it('collapses a database the search forced open', async () => {
     const user = userEvent.setup()
 

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -17,11 +17,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { toast } from 'sonner'
 
 import { useCollections } from '../collections-context'
-import {
-  useDatabases,
-  useDatabaseSchema,
-  useDatabaseSchemas
-} from '../hooks/queries'
+import { useDatabases, useDatabaseSchemas } from '../hooks/queries'
 import {
   useCreateWorksheet,
   useDeleteDatabase,
@@ -64,6 +60,7 @@ interface RenderedDatabaseRow {
   database: DatabaseDto
   hasMultipleSchemas: boolean
   searchMatch?: DatabaseMatch
+  tables: TableInfo[]
 }
 
 // Builds the rows to render: while searching, only databases with a match
@@ -71,6 +68,14 @@ interface RenderedDatabaseRow {
 // Each row notes whether its database spans multiple schemas, so duplicate
 // table names (common across schemas) stay distinguishable without adding
 // noise to single-schema databases.
+//
+// This is the only place holding both the schema and the match, so it is the
+// only place that decides what a row shows. That matters because
+// `DatabaseMatch.tables` means two things — the matching subset when the
+// search forces the row open, the whole list when only the name matched — and
+// resolving it here is what lets the list component take a plain array of
+// tables. `DatabaseRow` is still handed the match, but only to decide whether
+// the row is open.
 function computeRenderedRows(
   databases: DatabaseDto[],
   schemas: (SchemaInfo | undefined)[],
@@ -78,14 +83,24 @@ function computeRenderedRows(
 ): RenderedDatabaseRow[] {
   const isSearching = searchQuery.trim().length > 0
 
-  const rows = databases.map((database, index) => ({
-    database,
-    hasMultipleSchemas: spansMultipleSchemas(schemas[index]),
-    searchMatch: isSearching
+  const rows = databases.map((database, index) => {
+    const searchMatch = isSearching
       ? (computeDatabaseMatch(database, schemas[index], searchQuery) ??
         undefined)
       : undefined
-  }))
+
+    return {
+      database,
+      hasMultipleSchemas: spansMultipleSchemas(schemas[index]),
+      searchMatch,
+      // Reading the schema here rather than in the expanded row gives up no
+      // laziness: the caller fetches every schema unconditionally. If a
+      // conditional prefetch is ever reintroduced, the tables have to be
+      // threaded from wherever that fetch lands instead of being read again
+      // further down.
+      tables: searchMatch?.tables ?? schemas[index]?.tables ?? []
+    }
+  })
 
   if (!isSearching) {
     return rows
@@ -276,7 +291,8 @@ export function DatabaseExplorer(): ReactElement {
   const isSearching = normalizedSearchQuery.length > 0
 
   // Prefetch every schema in the background so search and expansion are instant,
-  // and reuse those results as the source for matching tables and columns.
+  // and reuse those results as the source for what each row shows, matched or
+  // not.
   const schemaResults = useDatabaseSchemas(
     databases.data.map((database) => database.id)
   )
@@ -369,6 +385,7 @@ export function DatabaseExplorer(): ReactElement {
                 isSortingDisabled={isSortingDisabled}
                 searchMatch={row.searchMatch}
                 searchQuery={normalizedSearchQuery}
+                tables={row.tables}
                 onDelete={handleDeleteDatabase}
                 onEdit={handleEditDatabase}
                 onRefresh={refresh}
@@ -462,9 +479,11 @@ interface DatabaseRowProps {
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
   onRefresh: (database: DatabaseDto) => void
+  /** Only for deciding whether the row is open — what it shows is `tables`. */
   searchMatch?: DatabaseMatch
   /** Normalized, so trailing whitespace does not count as a new question. */
   searchQuery: string
+  tables: TableInfo[]
 }
 
 // A decision only speaks for the context it was made in:
@@ -519,7 +538,8 @@ function DatabaseRow({
   onEdit,
   onRefresh,
   searchMatch,
-  searchQuery
+  searchQuery,
+  tables
 }: DatabaseRowProps): ReactElement {
   const dispatch = useAppDispatch()
 
@@ -579,7 +599,7 @@ function DatabaseRow({
         <DatabaseTableList
           database={database}
           hasMultipleSchemas={hasMultipleSchemas}
-          searchMatch={searchMatch}
+          tables={tables}
         />
       )}
     </div>
@@ -662,27 +682,20 @@ function DatabaseRowHeader({
 interface DatabaseTableListProps {
   database: DatabaseDto
   hasMultipleSchemas: boolean
-  searchMatch?: DatabaseMatch
+  tables: TableInfo[]
 }
 
 function DatabaseTableList({
   database,
   hasMultipleSchemas,
-  searchMatch
+  tables
 }: DatabaseTableListProps): ReactElement {
   const dispatch = useAppDispatch()
   const expandedTables = useAppSelector(
     (state) => state.databaseExplorer.expandedTables
   )
 
-  // While searching, the tables come from the precomputed match, so the lazy
-  // fetch is skipped; otherwise the list only mounts once the row is
-  // expanded, which is exactly when the schema is needed.
-  const schema = useDatabaseSchema(searchMatch ? undefined : database.id)
-
   const handleQueryTable = useQueryTableWorksheet(database, hasMultipleSchemas)
-
-  const tables = searchMatch?.tables ?? schema.data?.tables ?? []
 
   return (
     <div className="pt-[1px] pb-[3px]">

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -82,7 +82,11 @@ export function useSecretStorage(): SecretStorageResponse {
   return useSuspenseQuery(secretStorageQueryOptions).data
 }
 
-export function useDatabaseSchema(databaseId: string | undefined) {
+// One database's schema. Not exported: the only reader outside this module was
+// the explorer's table list, which now takes its tables from the parent's
+// prefetch, and nothing else should reach past `useDatabaseSchemas` for a
+// single row. `useServerVersion` below is the one caller left.
+function useDatabaseSchema(databaseId: string | undefined) {
   return useQuery<SchemaInfoDto>({
     queryKey: databaseId ? queryKeys.schema(databaseId) : ['schema', 'noop'],
     queryFn: () => {
@@ -98,9 +102,10 @@ export function useDatabaseSchema(databaseId: string | undefined) {
 }
 
 // Warms every database's schema in the background so search and expansion are
-// instant. Reuses the same query keys as useDatabaseSchema, so a later
-// per-database read is a cache hit rather than a second request. Results line
-// up by index with databaseIds.
+// instant, and is the source the explorer reads each row's tables from. Uses
+// the same query keys as useDatabaseSchema, so the version read there is a
+// cache hit rather than a second request. Results line up by index with
+// databaseIds.
 export function useDatabaseSchemas(databaseIds: string[]) {
   return useQueries({
     queries: databaseIds.map((databaseId) => ({


### PR DESCRIPTION
`DatabaseTableList` re-derived the table list its parent already had — a `useDatabaseSchema` call with a conditional-undefined argument, then a three-way fallback `searchMatch?.tables ?? schema.data?.tables ?? []`. Its comment explained this as a lazy fetch, but `DatabaseExplorer` already calls `useDatabaseSchemas` over every database unconditionally with `staleTime: Infinity`, so the lazy mount was deferring a cache read.

The real point is ownership. `DatabaseMatch.tables` means two things — the matching subset when the search forces a row open, the whole list when only the database name matched — and that ambiguity travelled down through `DatabaseRow` into the list component, which resolved it against a second copy of the schema.

`computeRenderedRows` is the only place holding both the schema and the match, so it now fills a `tables` field on each row. `DatabaseTableList` takes a plain array and drops the hook, the conditional argument, and the fallback chain. Searching rows also stop parking on the shared `['schema', 'noop']` sentinel key.

Behaviour is unchanged, including the asymmetric case: a name-only match keeps the full table list so a manual expand during search still shows everything.

## Tests

Two branches nothing covered, both of which this could have broken silently:

- **a table-name search reveals only the matching table** — fails against the old implementation with the match ignored, and against the new one with the precedence dropped.
- **each database shows its own tables** — the list is now resolved by position in an array built from a second pass over the same databases. Correct only while the two passes stay in step, and unchecked by types. The test fails when the index is pinned to `0`; the whole suite passed without it.

Closes #94