### PR TITLE
refactor(results): give the results row height one owner

### DIFF
--- a/src/app/components/QueryResultTable.test.tsx
+++ b/src/app/components/QueryResultTable.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import invariant from 'tiny-invariant'
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 
 import { stubElementSize } from '../test-element-size'
@@ -122,6 +123,65 @@ describe('QueryResultTable', () => {
     expect(screen.getByText('null')).toBeInTheDocument()
   })
 
+  it('reserves scroll space in the same rows it paints', () => {
+    const rowCount = 10000
+    const largeResult = {
+      fields: [{ name: 'id' }],
+      rows: Array.from({ length: rowCount }, (_, index) => ({ id: index })),
+      rowCount,
+      truncated: true
+    }
+
+    const { container } = render(<QueryResultTable result={largeResult} />)
+
+    // Found by the property rather than by position: which element publishes
+    // it is an implementation detail, since custom properties inherit.
+    const publisher = container.querySelector('[style*="--row-h"]')
+
+    invariant(
+      publisher instanceof HTMLElement,
+      'The row height is published as a custom property.'
+    )
+
+    // Rows are painted at `--row-h` but positioned by arithmetic the
+    // virtualizer does on a number of its own, and nothing checks the two
+    // against each other: a density edit to one leaves every row overlapping
+    // or gapped and the scroll height wrong by rows x delta, with no type
+    // error and no failing test. So take the published height and check the
+    // space reserved for the unrendered rows is exactly that many of them.
+    const paintedRowHeight = Number.parseFloat(
+      publisher.style.getPropertyValue('--row-h')
+    )
+
+    expect(paintedRowHeight).toBeGreaterThan(0)
+
+    // jsdom computes no heights, so the class is the only available evidence
+    // that a row reads the published value at all. Without this the whole
+    // check is arithmetic between two numbers neither of which a row uses:
+    // rewriting the cells to `h-[30px]` passes everything else.
+    const [, firstDataRow] = screen.getAllByRole('row')
+
+    for (const cell of within(firstDataRow).getAllByRole('cell')) {
+      expect(cell).toHaveClass('h-[var(--row-h)]')
+    }
+
+    const spacers = container.querySelectorAll<HTMLElement>(
+      'tr[aria-hidden="true"] td'
+    )
+    const reservedHeight = Array.from(spacers).reduce(
+      (total, spacer) => total + Number.parseFloat(spacer.style.height),
+      0
+    )
+
+    // The spacer rows are aria-hidden, so the rows in the accessibility tree
+    // are the header plus the ones actually rendered.
+    const renderedRowCount = screen.getAllByRole('row').length - 1
+
+    expect(reservedHeight + renderedRowCount * paintedRowHeight).toEqual(
+      rowCount * paintedRowHeight
+    )
+  })
+
   it('windows a large result instead of rendering every row', () => {
     const largeResult = {
       fields: [{ name: 'id' }],
@@ -132,7 +192,8 @@ describe('QueryResultTable', () => {
 
     render(<QueryResultTable result={largeResult} />)
 
-    // A 600px viewport of 34px rows plus overscan is nowhere near 10,000 —
+    // A 600px viewport of one-row-height rows plus overscan is nowhere near
+    // 10,000 —
     // that is the whole point of virtualizing the 10,000-row cap.
     const renderedRows = screen.getAllByRole('row')
 

--- a/src/app/components/QueryResultTable.tsx
+++ b/src/app/components/QueryResultTable.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { memo, ReactElement, useMemo, useRef } from 'react'
+import { CSSProperties, memo, ReactElement, useMemo, useRef } from 'react'
 
 import type { QueryResultDto } from '@/glue/api/schemas'
 
@@ -21,12 +21,20 @@ import {
   formatRowAsJson
 } from './query-result-format'
 
-// Mirrors `--row-h`. The virtualizer needs a number, and every row is the same
-// height, so this is an exact size rather than an estimate.
+// The density knob for this grid, and the only definition of `--row-h`:
+// nothing else may declare that property. It is published on the scroll
+// container below and the rows are painted from it; the virtualizer positions
+// them by arithmetic on this number. A second definition makes a density edit
+// a choice of which copy to change, and getting it wrong leaves every row
+// overlapping or gapped and the scroll height wrong by rows x delta, with no
+// type error and nothing at runtime to say so.
+//
+// Every row is the same height, so this is an exact size rather than an
+// estimate and no `measureElement` is wired.
 const rowHeight = 34
 
-// Rows rendered above and below the window, so a fast scroll does not show a
-// gap before the next measure.
+// Rows rendered above and below the window, so a fast scroll reaches painted
+// rows rather than blank space.
 const overscan = 12
 
 export const QueryResultTable = memo(function QueryResultTable({
@@ -79,6 +87,8 @@ export const QueryResultTable = memo(function QueryResultTable({
     <div
       className="h-full overflow-auto"
       ref={scrollRef}
+      // Cast because React's CSSProperties does not admit custom properties.
+      style={{ '--row-h': `${rowHeight}px` } as CSSProperties}
     >
       <table className="min-w-full border-separate border-spacing-0">
         <colgroup>

--- a/src/app/styles/themes/squeal-dark.css
+++ b/src/app/styles/themes/squeal-dark.css
@@ -2,7 +2,8 @@
  *
  * Only the tokens that differ from light live here. The accent and the density
  * metrics are shared and are defined by the `[data-theme='squeal']` rule in
- * `squeal-light.css`.
+ * `squeal-light.css` -- except the results grid row height, which
+ * `QueryResultTable.tsx` owns; see the header there.
  */
 
 [data-theme='squeal'][data-mode='dark'] {

--- a/src/app/styles/themes/squeal-light.css
+++ b/src/app/styles/themes/squeal-light.css
@@ -1,8 +1,15 @@
 /* Squeal - light mode theme.
  *
  * The mode-independent tokens (the accent and the density metrics) live in the
- * `[data-theme='squeal']` rule below so a density change stays a one-block
- * edit; `squeal-dark.css` only overrides what actually differs per mode.
+ * `[data-theme='squeal']` rule below, so a density change is mostly a
+ * one-block edit; `squeal-dark.css` only overrides what actually differs per
+ * mode.
+ *
+ * One density metric is deliberately not here: the results grid row height.
+ * `QueryResultTable.tsx` owns it as a number, because the virtualizer
+ * positions rows by arithmetic on it, and publishes it to CSS as `--row-h` on
+ * its own scroll container. A compact mode has to set that constant too --
+ * an inline custom property wins over any rule for that subtree.
  */
 
 [data-theme='squeal'] {
@@ -14,7 +21,6 @@
   --code-size: 12.5px;
   --item-h: 30px;
   --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
-  --row-h: 34px;
 }
 
 [data-theme='squeal'][data-mode='light'] {


### PR DESCRIPTION
`--row-h` was defined twice for the same rows. CSS painted them from the theme token in `squeal-light.css`; `@tanstack/react-virtual` positioned them by arithmetic on a separate `rowHeight = 34` in `QueryResultTable.tsx`. The two had to agree and nothing made them — edit either alone and every row is overlapping or gapped and the scroll height is wrong by `rows × delta`, with no type error, no failing test, and no visible symptom on a short result.

The number is a virtualizer input first: it is the argument to `estimateSize`, and with every row the same height and no `measureElement` wired it is exact, not an estimate. So the TypeScript constant is the owner and the component publishes it to CSS as an inline `--row-h` on its own scroll container. The theme token is deleted. The `h-[var(--row-h)]` classes are untouched — Tailwind emits the arbitrary-value utility whether or not a stylesheet declares the property.

Both stylesheet headers promised a density change is a one-block edit, so both now name the exception. That matters beyond documentation: the reference design's `body.compact` varies `--row-h` alongside `--item-h` and the code metrics, and an inline custom property beats any rule for that subtree — so a compact mode has to set the constant, and the header says so.

The other metrics stay put. Not because they are all shared (`--code-lh` and `--code-size` have one consumer each) but because nothing computes against them. `--row-h` was the only one with a numeric twin in TypeScript that had to match it.

## Test

Asserts the relationship, not the constant — a test that reads the same number the code does proves nothing. It takes the published `--row-h` off whichever element carries it, checks the rendered cells actually read that variable, and checks the space reserved for the unrendered rows is exactly that many of them.

It fails on the pre-change component (the height is not discoverable at all — `NaN`), on a one-pixel drift in either direction, and on rewriting the cells to a hardcoded height while leaving the arithmetic alone.

Closes #99