### PR TITLE
refactor(editor): make an editor screen with nothing to edit unrepresentable

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -267,14 +267,7 @@ export function App(): ReactElement {
           <>
             <Workspace />
 
-            {editorScreen && (
-              <EditorScreen
-                databaseId={editorScreen.databaseId}
-                mode={
-                  editorScreen.type === 'create-database' ? 'create' : 'edit'
-                }
-              />
-            )}
+            {editorScreen && <EditorScreen {...editorScreen} />}
           </>
         )}
       </div>

--- a/src/app/components/EditorScreen.test.tsx
+++ b/src/app/components/EditorScreen.test.tsx
@@ -40,7 +40,7 @@ describe('EditorScreen', () => {
       renderWithProviders(
         <EditorScreen
           databaseId="db-123"
-          mode="edit"
+          type="edit-database"
         />,
         { databases: [testDatabase] }
       )
@@ -52,7 +52,7 @@ describe('EditorScreen', () => {
       renderWithProviders(
         <EditorScreen
           databaseId="db-123"
-          mode="edit"
+          type="edit-database"
         />,
         { databases: [testDatabase] }
       )
@@ -76,12 +76,48 @@ describe('EditorScreen', () => {
       renderWithProviders(
         <EditorScreen
           databaseId="nonexistent"
-          mode="edit"
+          type="edit-database"
         />,
         { databases: [] }
       )
 
-      expect(screen.getByText('Database not found.')).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'This database has been deleted. Close this screen and pick another one.'
+        )
+      ).toBeInTheDocument()
+
+      // The message replaces the form rather than joining it. A form left
+      // mounted here is in edit mode against a row that is gone, so Save
+      // would PATCH a deleted id.
+      expect(screen.queryByLabelText('Name')).not.toBeInTheDocument()
+
+      // The panel keeps its header, which is what carries the close button.
+      expect(screen.getByText('Edit database')).toBeInTheDocument()
+    })
+
+    it('can be closed when the database is not found', async () => {
+      const user = userEvent.setup()
+      const { store } = renderWithProviders(
+        <EditorScreen
+          databaseId="nonexistent"
+          type="edit-database"
+        />,
+        {
+          databases: [],
+          ui: {
+            editorScreen: { databaseId: 'nonexistent', type: 'edit-database' }
+          }
+        }
+      )
+
+      // The screen is a full-screen overlay over everything else, so a panel
+      // with no way out is not a message -- it is a stuck window.
+      await user.click(screen.getByRole('button', { name: 'Close' }))
+
+      await waitFor(() => {
+        expect(store.getState().ui.editorScreen).toBeUndefined()
+      })
     })
 
     it('closes the editor screen when the close button is clicked', async () => {
@@ -89,7 +125,7 @@ describe('EditorScreen', () => {
       const { store } = renderWithProviders(
         <EditorScreen
           databaseId="db-123"
-          mode="edit"
+          type="edit-database"
         />,
         {
           databases: [testDatabase],
@@ -97,7 +133,7 @@ describe('EditorScreen', () => {
         }
       )
 
-      await user.click(screen.getByRole('button', { name: '' }))
+      await user.click(screen.getByRole('button', { name: 'Close' }))
 
       await waitFor(() => {
         expect(store.getState().ui.editorScreen).toBeUndefined()
@@ -109,7 +145,7 @@ describe('EditorScreen', () => {
       const { store } = renderWithProviders(
         <EditorScreen
           databaseId="db-123"
-          mode="edit"
+          type="edit-database"
         />,
         {
           databases: [testDatabase],
@@ -127,13 +163,17 @@ describe('EditorScreen', () => {
 
   describe('create mode', () => {
     it('renders the add database header', () => {
-      renderWithProviders(<EditorScreen mode="create" />, { databases: [] })
+      renderWithProviders(<EditorScreen type="create-database" />, {
+        databases: []
+      })
 
       expect(screen.getByText('Add database')).toBeInTheDocument()
     })
 
     it('starts with an empty form', () => {
-      renderWithProviders(<EditorScreen mode="create" />, { databases: [] })
+      renderWithProviders(<EditorScreen type="create-database" />, {
+        databases: []
+      })
 
       expect(screen.getByLabelText('Name')).toHaveValue('')
       expect(screen.getByLabelText('Host')).toHaveValue('')

--- a/src/app/components/EditorScreen.tsx
+++ b/src/app/components/EditorScreen.tsx
@@ -31,17 +31,19 @@ function toFormConnectionInfo(
   }
 }
 
-export interface EditorScreenProps {
-  databaseId?: string
-  mode: 'create' | 'edit'
-}
+// The two shapes the screen has: an add, which has no database, and an edit,
+// which always names one. Structurally the store's `EditorScreen`, so App can
+// spread the state straight in.
+export type EditorScreenProps =
+  | { type: 'create-database' }
+  | { databaseId: string; type: 'edit-database' }
 
-export function EditorScreen({
-  databaseId,
-  mode
-}: EditorScreenProps): ReactElement {
+export function EditorScreen(props: EditorScreenProps): ReactElement {
   const dispatch = useAppDispatch()
   const databases = useDatabases()
+
+  const databaseId =
+    props.type === 'edit-database' ? props.databaseId : undefined
 
   const database = useMemo(
     () =>
@@ -53,18 +55,10 @@ export function EditorScreen({
     dispatch(uiActions.closeEditorScreen())
   }, [dispatch])
 
-  if (mode === 'edit' && !database) {
-    return (
-      <div className="absolute inset-0 z-100 bg-bg/70 flex justify-center items-center">
-        <div className="rounded-md border border-border bg-panel px-6 py-5 text-text2 shadow-[0_8px_24px_rgba(0,0,0,0.14)]">
-          Database not found.
-        </div>
-      </div>
-    )
-  }
-
-  const isCreateMode = mode === 'create'
+  const isCreateMode = props.type === 'create-database'
   const title = isCreateMode ? 'Add database' : 'Edit database'
+
+  const isNotFound = props.type === 'edit-database' && database === undefined
 
   const defaultValues = database
     ? {
@@ -94,6 +88,7 @@ export function EditorScreen({
           <h1 className="text-2xl font-semibold">{title}</h1>
 
           <Button
+            aria-label="Close"
             size="icon-sm"
             variant="ghost"
             onClick={handleClose}
@@ -102,12 +97,27 @@ export function EditorScreen({
           </Button>
         </div>
 
-        <DatabaseForm
-          databaseId={databaseId}
-          defaultValues={defaultValues}
-          onCancel={handleClose}
-          onSuccess={handleClose}
-        />
+        {isNotFound ? (
+          // Deletion is the only writer that removes a row, and it is not
+          // optimistic -- `useDeleteDatabase` writes in `onSuccess` -- so
+          // there is no rollback window to miss an id in. `useDatabases`
+          // suspends and App reads it before this can mount, so the list is
+          // loaded and this is not a load race either. Rendered inside the
+          // panel rather than as a bare message, because the screen covers
+          // everything below it and nothing here answers Escape -- a message
+          // with no close button is not an error state, it is a stuck window.
+          <p className="text-text2">
+            This database has been deleted. Close this screen and pick another
+            one.
+          </p>
+        ) : (
+          <DatabaseForm
+            databaseId={databaseId}
+            defaultValues={defaultValues}
+            onCancel={handleClose}
+            onSuccess={handleClose}
+          />
+        )}
       </div>
     </div>
   )

--- a/src/app/store/ui-slice.test.ts
+++ b/src/app/store/ui-slice.test.ts
@@ -21,12 +21,6 @@ describe('uiSlice', () => {
         type: 'create-database'
       })
     })
-
-    it('should not include databaseId when creating', () => {
-      const state = reducer(initialState, uiActions.openCreateDatabase())
-
-      expect(state.editorScreen?.databaseId).toBeUndefined()
-    })
   })
 
   describe('openEditDatabase', () => {

--- a/src/app/store/ui-slice.ts
+++ b/src/app/store/ui-slice.ts
@@ -1,9 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-export interface EditorScreen {
-  databaseId?: string
-  type: 'edit-database' | 'create-database'
-}
+// A discriminated union rather than an optional id beside a free type: the
+// reducers below only ever produce these two pairings, and saying so is what
+// lets the screen be handed the state as its props with no translation and no
+// branch for a combination that cannot occur.
+export type EditorScreen =
+  | { type: 'create-database' }
+  | { databaseId: string; type: 'edit-database' }
 
 export interface UiState {
   editorScreen?: EditorScreen


### PR DESCRIPTION
`EditorScreen` took `mode: 'create' | 'edit'` and `databaseId?: string` as independent props, so four combinations typechecked and two meant nothing — an edit with no id, and a create with one. The component carried a branch for the first:

```ts
if (mode === 'edit' && !database) {
  return <a bare centered message>
}
```

That branch conflated "edit mode with no id at all" (a call that should never have been written) with "an id that no longer resolves" (a database deleted from under an open screen). Only the second can happen, but the branch could not tell them apart, so it answered both with a panel that has no header and no close button. The screen is `absolute inset-0 z-100` over the whole workspace and nothing here answers Escape — `ConnectionPicker`, `SecretStorageConsentScreen`, `TraceDashboard` and the worksheet rename hook are the only Escape handlers in the app. So that panel is not a message. It is a window with no way out.

Both props collapse into one discriminated union, in the slice and in the component:

```ts
| { type: 'create-database' }
| { databaseId: string; type: 'edit-database' }
```

The reducers already produced exactly these two pairings, so no call site moves and no behaviour changes. `editorScreen` is never persisted — the store writes only `ui.gettingStartedDismissed` — so there is no rehydration or migration question. `App` stops translating `type` into `mode` and spreads the state straight in.

With "edit with nothing to edit" unrepresentable, the remaining case can only be a stale id, so it folds back into the normal panel with its header and close button and says what happened: **"This database has been deleted. Close this screen and pick another one."** Not a guess — deletion is the only writer that removes a row and it is not optimistic, so there is no rollback window; and `useDatabases` suspends and `App` reads it before this can mount, so the list is loaded.

The close button had no accessible name at all (the old test found it as `getByRole('button', { name: '' })`). It is icon-only, so it gets `aria-label="Close"`.

## Tests

Three guards, each failing against the mutation it exists for:

- **the not-found panel can be closed** — fails with no button to click, and against a version that keeps the early return while using the union
- **the form is not also rendered there** — a form in that state is in edit mode against a row that is gone, so Save would PATCH a deleted id
- **the header is still present** — it is what carries the close button

Dropped `should not include databaseId when creating` from the slice tests: that assertion is now a type error, and the whole-object `toEqual` above it already covered the behaviour.

Closes #92