### PR TITLE
refactor(api-client): tell the two ParseErrors apart by status alone

### DIFF
--- a/src/app/api-client.test.ts
+++ b/src/app/api-client.test.ts
@@ -429,10 +429,19 @@ describe('apiClient', () => {
         expect.fail('Expected the request to reject')
       } catch (error) {
         expect(error).toBeInstanceOf(ApiError)
-        expect((error as ApiError).message).toEqual(
-          'Squeal could not read the response from its backend. Please report this.'
+
+        // The status is the response's own. That is the only assertion
+        // separating this branch from the encode-failure one above, which
+        // answers 400 for a request that never went out — so a status
+        // synthesised here would report a failure that did not happen.
+        expect(error).toEqual(
+          expect.objectContaining({
+            details: undefined,
+            message:
+              'Squeal could not read the response from its backend. Please report this.',
+            statusCode: 200
+          })
         )
-        expect((error as ApiError).details).toBeUndefined()
       }
     })
   })
@@ -448,6 +457,47 @@ describe('apiClient', () => {
 
       expect(request?.attributes['http.status_code']).toEqual(200)
       expect(request?.status).toEqual('ok')
+    })
+
+    it('records the status of a tagged error on the span', async () => {
+      mockFetch.mockResolvedValueOnce(
+        respondWith(
+          {
+            _tag: 'DatabaseNotFoundError',
+            databaseId: 'missing',
+            message: 'Database not found'
+          },
+          { status: 404 }
+        )
+      )
+
+      await expect(apiClient.getDatabaseSchema('missing')).rejects.toBeDefined()
+
+      const spans = enqueueSpan.mock.calls.map(([record]) => record)
+      const request = spans.find(
+        (span) => span.name === 'HTTP GET /databases/:id/schema'
+      )
+
+      // A tagged error is rethrown as itself, so it is not an ApiError and the
+      // fallback beside the phase read cannot answer for it. The recorded
+      // status comes from the phase or from nowhere.
+      expect(request?.attributes['http.status_code']).toEqual(404)
+      expect(request?.status).toEqual('error')
+    })
+
+    it('records the substituted status when no response arrived', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Failed to fetch'))
+
+      await expect(apiClient.getDatabases()).rejects.toBeInstanceOf(ApiError)
+
+      const spans = enqueueSpan.mock.calls.map(([record]) => record)
+      const request = spans.find((span) => span.name === 'HTTP GET /databases')
+
+      // Nothing came back, so the phase has no status and the span takes the
+      // one the ApiError was given. Without that fallback the span for every
+      // unreachable backend carries no status at all.
+      expect(request?.attributes['http.status_code']).toEqual(503)
+      expect(request?.status).toEqual('error')
     })
 
     it('marks the span as errored when the request fails', async () => {

--- a/src/app/api-client.ts
+++ b/src/app/api-client.ts
@@ -59,13 +59,15 @@ const getApiToken = memoizePromise(() => window.electron.getApiToken())
 // request transform reads.
 const currentTraceparent = FiberRef.unsafeMake<string | undefined>(undefined)
 
-// Payload encoding happens strictly before the request is executed, so a
-// ParseError raised while `sent` is still false means the payload was invalid
-// and nothing left the machine, while one raised afterwards means the response
-// did not match the contract. `run` gives every call its own marker, so
-// concurrent requests never read each other's state.
+// How far a call got, in one field. Undefined means no response ever reached
+// us; a number means one did, and is its status.
+//
+// That is enough to tell the two ParseErrors apart, which is the only reason
+// this exists — see `toThrowable` for why one field is enough.
+//
+// `run` gives every call its own marker, so concurrent requests never read
+// each other's state.
 interface RequestPhase {
-  sent: boolean
   status?: number
 }
 
@@ -88,11 +90,6 @@ const getClient = memoizePromise(() =>
             Effect.gen(function* () {
               const token = yield* Effect.promise(getApiToken)
               const traceparent = yield* FiberRef.get(currentTraceparent)
-              const phase = yield* FiberRef.get(currentRequestPhase)
-
-              if (phase !== undefined) {
-                phase.sent = true
-              }
 
               const authorized = HttpClientRequest.setHeader(
                 request,
@@ -189,9 +186,14 @@ function toThrowable(
   }
 
   if (ParseResult.isParseError(error)) {
-    // Nothing was sent: the payload failed to encode against the contract, so
-    // this is invalid user input and the issues map onto form fields.
-    if (!phase.sent) {
+    // A ParseError can only be raised in two places: before the request is
+    // executed, where every encoder runs — path, body, headers, url params —
+    // or after a response arrived and failed to decode. In between there is
+    // nothing to parse; a request that left and then failed on the wire
+    // raises a RequestError. So no status means no request, and this is the
+    // request failing to encode against the contract, which makes it invalid
+    // input whose issues map onto form fields.
+    if (phase.status === undefined) {
       return new ApiError(
         400,
         validationMessage,
@@ -201,8 +203,10 @@ function toThrowable(
 
     console.error('The API response did not match the contract:', error.message)
 
+    // The status is a number here by the branch above, and it is the real one:
+    // the response arrived and only its body was wrong.
     return new ApiError(
-      phase.status ?? 500,
+      phase.status,
       'Squeal could not read the response from its backend. Please report this.'
     )
   }
@@ -231,7 +235,7 @@ function toThrowable(
 
 function run<A, E>(
   effect: Effect.Effect<A, E, HttpClient.HttpClient>,
-  phase: RequestPhase = { sent: false }
+  phase: RequestPhase = {}
 ): Promise<A> {
   return runtime
     .runPromiseExit(Effect.locally(effect, currentRequestPhase, phase))
@@ -269,7 +273,7 @@ function traced<A, E>(
     kind: 'client',
     ...(parent === undefined ? {} : { parent })
   })
-  const phase: RequestPhase = { sent: false }
+  const phase: RequestPhase = {}
 
   return run(
     Effect.locally(effect, currentTraceparent, formatTraceparent(span.context)),


### PR DESCRIPTION
Closes #89.

`RequestPhase` carried `sent: boolean` beside `status?: number`. The boolean had one writer and one reader, and the pair admitted states that cannot occur — `{ sent: false, status: 200 }` typechecked. The fact was already in `status`: undefined means no response ever reached us, a number means one did.

A ParseError can only be raised before the request is executed, where every encoder runs (path, body, headers, url params), or after a response arrived and failed to decode. In between there is nothing to parse, and a request that left and then failed on the wire raises a `RequestError`. So "no status" is exactly "the request never went out", which is what the one branch reading `sent` needed to know.

`phase.status ?? 500` was already unreachable by that same argument; the change makes it unreachable by type, so it is removed rather than left as a default that cannot fire.

## Tests

- The existing contract-mismatch test now asserts the `ApiError` carries the response's real status. It fails if a status is synthesised there, and both it and the encode-failure test fail if the branch is inverted — so the pair pins the boundary from each side.
- Two span tests cover the status read one call further on, which takes the phase's status or, failing that, the `ApiError`'s own. Neither operand was covered before, so either could be deleted without a test noticing: a tagged 404 exercises the first (a tagged error is rethrown as itself, so the fallback cannot answer for it), an unreachable backend the second.

Every mutation tried against these — inverting the branch, deleting the phase write, synthesising a 500, dropping either operand of the span read — is now caught.