### PR TITLE
refactor(traces): name a trace from one span, not four lookups

### DIFF
--- a/src/server/services/trace-store.test.ts
+++ b/src/server/services/trace-store.test.ts
@@ -140,4 +140,402 @@ describe('TraceStore', () => {
 
     expect(traces.map((trace) => trace.traceId)).toEqual(['b'.repeat(32)])
   })
+
+  it('names a trace after its earliest span when none is parentless', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        // A renderer trace mid-flight: the root is exported last, so every
+        // span stored so far names a parent that is not here yet.
+        yield* store.ingestSpans([
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'query.execute',
+            parentSpanId: '9'.repeat(16),
+            serviceName: 'main',
+            startedAt: 1_010
+          }),
+          makeSpan({
+            name: 'HTTP POST /queries',
+            parentSpanId: '9'.repeat(16),
+            serviceName: 'renderer',
+            startedAt: 1_000
+          })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 50 })
+      })
+    )
+
+    expect(traces).toEqual([
+      {
+        durationMs: 15,
+        errorMessage: null,
+        hasError: false,
+        name: 'HTTP POST /queries',
+        serviceName: 'renderer',
+        spanCount: 2,
+        startedAt: 1_000,
+        traceId
+      }
+    ])
+  })
+
+  it('prefers a parentless span to a child that started earlier', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        // The root is timed by the renderer's clock and its children by the
+        // main process's, so a few milliseconds of skew is enough to file a
+        // child ahead of the span that owns it.
+        yield* store.ingestSpans([
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'query.execute',
+            parentSpanId: '9'.repeat(16),
+            serviceName: 'main',
+            startedAt: 1_000
+          }),
+          makeSpan({
+            name: 'query.run',
+            serviceName: 'renderer',
+            startedAt: 1_010
+          })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 50 })
+      })
+    )
+
+    expect(traces).toEqual([
+      {
+        durationMs: 15,
+        errorMessage: null,
+        hasError: false,
+        name: 'query.run',
+        serviceName: 'renderer',
+        spanCount: 2,
+        startedAt: 1_000,
+        traceId
+      }
+    ])
+  })
+
+  it('names a trace after the earliest of several parentless spans', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        yield* store.ingestSpans([
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'POST /queries',
+            serviceName: 'main',
+            startedAt: 1_005
+          }),
+          makeSpan({
+            name: 'query.run',
+            serviceName: 'renderer',
+            startedAt: 1_000
+          })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 50 })
+      })
+    )
+
+    // Both fields have to come off the same span: the pairing is what makes a
+    // summary readable, and nothing in `TraceSummaryDto` would show a name and
+    // a service that came from different spans.
+    expect(traces).toEqual([
+      {
+        durationMs: 10,
+        errorMessage: null,
+        hasError: false,
+        name: 'query.run',
+        serviceName: 'renderer',
+        spanCount: 2,
+        startedAt: 1_000,
+        traceId
+      }
+    ])
+  })
+
+  it('reports a failed trace that carries no message', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        yield* store.ingestSpans([
+          makeSpan({ status: 'error', statusMessage: null })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 50 })
+      })
+    )
+
+    expect(traces).toEqual([
+      {
+        durationMs: 5,
+        errorMessage: null,
+        hasError: true,
+        name: 'POST /queries',
+        serviceName: 'main',
+        spanCount: 1,
+        startedAt: 1_000,
+        traceId
+      }
+    ])
+  })
+
+  it('skips a failure that carries no message to reach one that does', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        // A failure propagates up the span tree, so the outer spans are marked
+        // failed too and only the innermost one knows why.
+        yield* store.ingestSpans([
+          makeSpan({ status: 'error' }),
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'query.execute',
+            parentSpanId: '1'.repeat(16),
+            startedAt: 1_005,
+            status: 'error',
+            statusMessage: 'relation "missing" does not exist'
+          })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 50 })
+      })
+    )
+
+    expect(traces.map((trace) => trace.errorMessage)).toEqual([
+      'relation "missing" does not exist'
+    ])
+  })
+
+  it('reports the first failure when several carry a message', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        // The one the user needs is the original failure, not whatever the
+        // layers above rephrased it as on the way out.
+        yield* store.ingestSpans([
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'query.execute',
+            parentSpanId: '1'.repeat(16),
+            startedAt: 1_005,
+            status: 'error',
+            statusMessage: 'The query failed.'
+          }),
+          makeSpan({
+            status: 'error',
+            statusMessage: 'relation "missing" does not exist'
+          })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 50 })
+      })
+    )
+
+    expect(traces.map((trace) => trace.errorMessage)).toEqual([
+      'relation "missing" does not exist'
+    ])
+  })
+
+  it('ignores a message left on a span that did not fail', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        yield* store.ingestSpans([
+          makeSpan({ statusMessage: 'Canceled by the user.' }),
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'query.execute',
+            parentSpanId: '1'.repeat(16),
+            startedAt: 1_005,
+            status: 'error',
+            statusMessage: 'relation "missing" does not exist'
+          })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 50 })
+      })
+    )
+
+    expect(traces.map((trace) => trace.errorMessage)).toEqual([
+      'relation "missing" does not exist'
+    ])
+  })
+
+  it('matches a search term against the name whatever its case', async () => {
+    const searches = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        yield* store.ingestSpans([
+          makeSpan(),
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'GET /databases',
+            startedAt: 2_000,
+            traceId: 'b'.repeat(32)
+          })
+        ])
+
+        // Both sides have to be folded: 'DATABASES' only matches once the term
+        // is lowered, and 'get' only once the name is.
+        return {
+          loweredName: yield* store.listTraces({
+            errorOnly: false,
+            limit: 50,
+            search: 'get'
+          }),
+          loweredTerm: yield* store.listTraces({
+            errorOnly: false,
+            limit: 50,
+            search: 'DATABASES'
+          })
+        }
+      })
+    )
+
+    expect({
+      loweredName: searches.loweredName.map((trace) => trace.traceId),
+      loweredTerm: searches.loweredTerm.map((trace) => trace.traceId)
+    }).toEqual({
+      loweredName: ['b'.repeat(32)],
+      loweredTerm: ['b'.repeat(32)]
+    })
+  })
+
+  it('searches the name the trace is listed under, not every span in it', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        yield* store.ingestSpans([
+          makeSpan({ name: 'query.run' }),
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'db.query',
+            parentSpanId: '1'.repeat(16),
+            startedAt: 1_005
+          })
+        ])
+
+        // Searching a child's name finds nothing: the list shows one name per
+        // trace, and a row that matched on a name it never displays reads as a
+        // bug in the filter.
+        return yield* store.listTraces({
+          errorOnly: false,
+          limit: 50,
+          search: 'db.query'
+        })
+      })
+    )
+
+    expect(traces).toEqual([])
+  })
+
+  it('filters on when the trace started, not when it ended', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        yield* store.ingestSpans([
+          makeSpan(),
+          // A long trace: it starts before the cutoff and is still running
+          // well after it.
+          makeSpan({
+            id: '2'.repeat(16),
+            name: 'query.execute',
+            parentSpanId: '1'.repeat(16),
+            startedAt: 5_000
+          }),
+          makeSpan({
+            id: '3'.repeat(16),
+            name: 'GET /databases',
+            startedAt: 3_000,
+            traceId: 'b'.repeat(32)
+          })
+        ])
+
+        return yield* store.listTraces({
+          before: 2_000,
+          errorOnly: false,
+          limit: 50
+        })
+      })
+    )
+
+    expect(traces.map((trace) => trace.traceId)).toEqual([traceId])
+  })
+
+  it('lists the most recent trace first', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        yield* store.ingestSpans([
+          makeSpan({ startedAt: 2_000 }),
+          makeSpan({
+            id: '2'.repeat(16),
+            startedAt: 1_000,
+            traceId: 'b'.repeat(32)
+          }),
+          makeSpan({
+            id: '3'.repeat(16),
+            startedAt: 3_000,
+            traceId: 'c'.repeat(32)
+          })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 50 })
+      })
+    )
+
+    expect(traces.map((trace) => trace.traceId)).toEqual([
+      'c'.repeat(32),
+      traceId,
+      'b'.repeat(32)
+    ])
+  })
+
+  it('returns no more traces than the limit', async () => {
+    const traces = await run(
+      Effect.gen(function* () {
+        const store = yield* TraceStore
+
+        yield* store.ingestSpans([
+          makeSpan({ startedAt: 2_000 }),
+          makeSpan({
+            id: '2'.repeat(16),
+            startedAt: 1_000,
+            traceId: 'b'.repeat(32)
+          }),
+          makeSpan({
+            id: '3'.repeat(16),
+            startedAt: 3_000,
+            traceId: 'c'.repeat(32)
+          })
+        ])
+
+        return yield* store.listTraces({ errorOnly: false, limit: 2 })
+      })
+    )
+
+    // The limit is applied after the ordering, so it keeps the newest.
+    expect(traces.map((trace) => trace.traceId)).toEqual([
+      'c'.repeat(32),
+      traceId
+    ])
+  })
 })

--- a/src/server/services/trace-store.ts
+++ b/src/server/services/trace-store.ts
@@ -58,6 +58,12 @@ export class TraceStore extends Effect.Service<TraceStore>()('TraceStore', {
     const listTraces = Effect.fn(function* (params: ListTracesUrlParams) {
       const { before, errorOnly, limit, search } = params
 
+      // Every filter names a column the aggregate below publishes as an
+      // alias, and is applied outside it -- so `search` matches the name the
+      // trace is listed under rather than any span's name, and `before`
+      // compares against the trace's own start rather than any span's.
+      // Only the aliases are in scope out here; a raw span column would be
+      // rejected by SQLite rather than quietly filter something else.
       const filters = [sql`1 = 1`]
 
       if (errorOnly) {
@@ -75,51 +81,61 @@ export class TraceStore extends Effect.Service<TraceStore>()('TraceStore', {
       // Traces are aggregated rather than read off root spans: the renderer
       // exports its root span last, so grouping keeps in-flight and
       // interrupted traces visible.
+      //
+      // Which span speaks for a trace is stated once, as `representativeId`.
+      // `parentSpanId IS NOT NULL` sorts parentless spans ahead of the rest,
+      // so the ordering reads as "the earliest parentless span, or the
+      // earliest span when none is parentless yet" -- the fallback the
+      // paragraph above needs. The name and the service then come off that
+      // one row by construction. Resolved as two independent lookups apiece,
+      // which is what this replaced, a later edit to one predicate --
+      // preferring `kind = 'server'` roots, say -- would pair one span's name
+      // with another span's service, and nothing in `TraceSummaryDto` would
+      // say so.
+      //
+      // The row is fetched by joining on `spans.id` rather than by ranking
+      // every span with a window function: `ROW_NUMBER() OVER (PARTITION BY
+      // traceId ...)` cannot use `spans_trace_id_index`, and measured against
+      // a full retention budget it made this query about twice as slow as the
+      // two-lookup shape below. This is polled every 2000ms.
       const rows = yield* appDatabase.execute((client) =>
         client.all<TraceSummaryRow>(sql`
           SELECT *
           FROM (
             SELECT
-              traceId,
-              COUNT(*) AS spanCount,
-              MIN(startedAt) AS startedAt,
-              MAX(startedAt + durationMs) - MIN(startedAt) AS durationMs,
-              MAX(status = 'error') AS hasError,
-              (
-                SELECT failed.statusMessage FROM spans AS failed
-                WHERE failed.traceId = spans.traceId
-                  AND failed.status = 'error'
-                  AND failed.statusMessage IS NOT NULL
-                ORDER BY failed.startedAt LIMIT 1
-              ) AS errorMessage,
-              COALESCE(
+              summary.traceId AS traceId,
+              summary.spanCount AS spanCount,
+              summary.startedAt AS startedAt,
+              summary.durationMs AS durationMs,
+              summary.hasError AS hasError,
+              summary.errorMessage AS errorMessage,
+              representative.name AS name,
+              representative.serviceName AS serviceName
+            FROM (
+              SELECT
+                traceId,
+                COUNT(*) AS spanCount,
+                MIN(startedAt) AS startedAt,
+                MAX(startedAt + durationMs) - MIN(startedAt) AS durationMs,
+                MAX(status = 'error') AS hasError,
                 (
-                  SELECT root.name FROM spans AS root
-                  WHERE root.traceId = spans.traceId
-                    AND root.parentSpanId IS NULL
-                  ORDER BY root.startedAt LIMIT 1
-                ),
+                  SELECT failed.statusMessage FROM spans AS failed
+                  WHERE failed.traceId = spans.traceId
+                    AND failed.status = 'error'
+                    AND failed.statusMessage IS NOT NULL
+                  ORDER BY failed.startedAt LIMIT 1
+                ) AS errorMessage,
                 (
-                  SELECT earliest.name FROM spans AS earliest
-                  WHERE earliest.traceId = spans.traceId
-                  ORDER BY earliest.startedAt LIMIT 1
-                )
-              ) AS name,
-              COALESCE(
-                (
-                  SELECT root.serviceName FROM spans AS root
-                  WHERE root.traceId = spans.traceId
-                    AND root.parentSpanId IS NULL
-                  ORDER BY root.startedAt LIMIT 1
-                ),
-                (
-                  SELECT earliest.serviceName FROM spans AS earliest
-                  WHERE earliest.traceId = spans.traceId
-                  ORDER BY earliest.startedAt LIMIT 1
-                )
-              ) AS serviceName
-            FROM spans
-            GROUP BY traceId
+                  SELECT chosen.id FROM spans AS chosen
+                  WHERE chosen.traceId = spans.traceId
+                  ORDER BY chosen.parentSpanId IS NOT NULL, chosen.startedAt
+                  LIMIT 1
+                ) AS representativeId
+              FROM spans
+              GROUP BY traceId
+            ) AS summary
+            JOIN spans AS representative
+              ON representative.id = summary.representativeId
           )
           WHERE ${sql.join(filters, sql` AND `)}
           ORDER BY startedAt DESC


### PR DESCRIPTION
Closes #84.

## What

`listTraces` built each summary's `name` and `serviceName` from a `COALESCE` of two correlated subqueries — the earliest parentless span, falling back to the earliest span — written out twice, byte for byte, differing only in the column projected. Four lookups saying one thing, independently: an edit to one predicate would pair one span's name with another span's service, and nothing in `TraceSummaryDto` marks the two as co-sourced.

Now one correlated subquery picks the representative span's id per trace and a join reads both fields off that row. `ORDER BY parentSpanId IS NOT NULL, startedAt` is exactly "the earliest parentless span, else the earliest span", so the fallback survives. Five per-trace lookups become two.

## The shape that was rejected

The obvious spelling is a `ROW_NUMBER() OVER (PARTITION BY traceId ORDER BY parentSpanId IS NOT NULL, startedAt)` CTE. It was written, benchmarked, and thrown away: the window cannot use `spans_trace_id_index`, so SQLite scans the whole table and builds an automatic index over the materialized CTE.

| corpus | old | window CTE | join (this PR) |
|---|---|---|---|
| 5000 traces x 10 spans | 69ms | 164ms | 72ms |
| 5000 x 10, `search` | 98ms | 190ms | 75ms |
| 500 x 100 | 43ms | 130ms | 48ms |
| 500 x 100, `search` | 54ms | 162ms | 49ms |
| 10000 x 5 | 100ms | 205ms | 107ms |
| 10000 x 5, `search` | 152ms | 244ms | 108ms |

The trace list polls this every 2000ms against a 50,000-span retention budget, so doubling its cost would have inverted the point of the change. The join shape matches the original unfiltered and beats it on `search`. Its rows were also checked against the original query's over a randomized corpus including traces with no parentless span, several parentless spans, and colliding timestamps.

## Tests

Written first and green against every shape — this is a refactor, so they characterize behaviour rather than drive it. Beyond the fallback cases the rewrite could quietly lose (no parentless span — the mid-flight renderer case; several parentless spans; a failure whose message is on an inner span), they pin what a query rewrite can move without breaking a type:

- which failure's message is reported, and that a message left on a span that did not fail is ignored
- `search` folds case on both sides, and matches the name the trace is listed under rather than any span in it
- `before` compares the trace's start, not its end
- newest first, and the limit limits

Thirteen mutations of the query — reversed subquery orderings, a dropped `status = 'error'`, `MAX` for `MIN`, a search widened to every span's name, a `before` reading the trace's end — are all killed.

`yarn typecheck`, `yarn lint`, prettier, and the full backend suite (18 files / 190 tests) pass.