### PR TITLE
refactor(errors): delete the internal error that is never raised

### DIFF
--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -11,15 +11,6 @@ export class AppDatabaseError extends Schema.TaggedError<AppDatabaseError>()(
   }
 ) {}
 
-export class ConnectionFailedError extends Schema.TaggedError<ConnectionFailedError>()(
-  'ConnectionFailedError',
-  {
-    // Driver messages only — the full error object embeds the connection
-    // config (host, user), which must never be logged or serialized.
-    message: Schema.String
-  }
-) {}
-
 export class QueryExecutionError extends Schema.TaggedError<QueryExecutionError>()(
   'QueryExecutionError',
   {

--- a/src/server/http/internal-errors.test.ts
+++ b/src/server/http/internal-errors.test.ts
@@ -1,0 +1,142 @@
+import { Cause, Effect, Exit, Option } from 'effect'
+import invariant from 'tiny-invariant'
+import { describe, expect, it } from 'vitest'
+
+import {
+  DatabaseNotFoundError,
+  DifferentServerError,
+  NoDatabaseAvailableError,
+  QueryNotFoundError,
+  SchemaLoadFailedError,
+  UnauthorizedError,
+  UnknownDatabaseIdsError,
+  UnknownWorksheetIdsError,
+  UpdateNotReadyError,
+  WorksheetNotFoundError
+} from '@/glue/api/errors'
+import {
+  AppDatabaseError,
+  QueryExecutionError,
+  SecretDecryptError
+} from '../errors'
+import { orDieInternal } from './internal-errors'
+
+describe('orDieInternal', () => {
+  // The taxonomy is a list of classes and an `instanceof` chain that has to
+  // name every one of them. Nothing links the two, so a class added to
+  // `errors.ts` and forgotten here reaches the renderer as a typed failure the
+  // contract never declared.
+  it.each([
+    [
+      'an app database error',
+      new AppDatabaseError({ message: 'no such table' })
+    ],
+    [
+      'a query execution error',
+      new QueryExecutionError({ message: 'syntax error at or near "SELCT"' })
+    ],
+    [
+      'a secret decrypt error',
+      new SecretDecryptError({
+        message: 'The stored password could not be read.'
+      })
+    ]
+  ])('turns %s into a defect', async (_description, error) => {
+    const exit = await Effect.runPromiseExit(orDieInternal(Effect.fail(error)))
+
+    invariant(Exit.isFailure(exit), 'The effect fails.')
+
+    expect(Cause.dieOption(exit.cause)).toEqual(Option.some(error))
+    expect(Cause.failureOption(exit.cause)).toEqual(Option.none())
+  })
+
+  // The mirror image, and the half that costs a user something: the chain
+  // widening by one class turns a declared failure into a 500. Every error in
+  // the contract is listed, because a handler pipes its whole error channel
+  // through here and the chain names classes, not routes.
+  it.each([
+    [
+      'a database not found error',
+      new DatabaseNotFoundError({
+        databaseId: 'db-123',
+        message: 'Database not found.'
+      })
+    ],
+    [
+      'a different server error',
+      new DifferentServerError({ message: 'Enter the password again.' })
+    ],
+    [
+      'a no database available error',
+      new NoDatabaseAvailableError({ message: 'Add a connection first.' })
+    ],
+    [
+      'a query not found error',
+      new QueryNotFoundError({
+        message: 'Query not found.',
+        queryId: 'query-123'
+      })
+    ],
+    [
+      'a schema load failed error',
+      new SchemaLoadFailedError({
+        databaseName: 'pagila',
+        message: 'The schema could not be read.'
+      })
+    ],
+    [
+      'an unauthorized error',
+      new UnauthorizedError({ message: 'Missing session token.' })
+    ],
+    [
+      'an unknown database ids error',
+      new UnknownDatabaseIdsError({
+        message: 'Unknown databases.',
+        unknownIds: ['db-123']
+      })
+    ],
+    [
+      'an unknown worksheet ids error',
+      new UnknownWorksheetIdsError({
+        message: 'Unknown worksheets.',
+        unknownIds: ['ws-123']
+      })
+    ],
+    [
+      'an update not ready error',
+      new UpdateNotReadyError({ message: 'No update is ready to install.' })
+    ],
+    [
+      'a worksheet not found error',
+      new WorksheetNotFoundError({
+        message: 'Worksheet not found.',
+        worksheetId: 'ws-123'
+      })
+    ]
+  ])('leaves %s in the typed channel', async (_description, error) => {
+    const exit = await Effect.runPromiseExit(orDieInternal(Effect.fail(error)))
+
+    invariant(Exit.isFailure(exit), 'The effect fails.')
+
+    expect(Cause.failureOption(exit.cause)).toEqual(Option.some(error))
+    expect(Cause.dieOption(exit.cause)).toEqual(Option.none())
+  })
+
+  it('runs the effect once and passes its value through', async () => {
+    let runs = 0
+
+    const value = await Effect.runPromise(
+      orDieInternal(
+        Effect.sync(() => {
+          runs += 1
+
+          return { databases: [] }
+        })
+      )
+    )
+
+    // Every handler is piped through this, so a wrapper that evaluated its
+    // effect twice would run the user's query twice.
+    expect({ runs, value }).toEqual({ runs: 1, value: { databases: [] } })
+  })
+})

--- a/src/server/http/internal-errors.ts
+++ b/src/server/http/internal-errors.ts
@@ -2,21 +2,15 @@ import { Effect } from 'effect'
 
 import {
   AppDatabaseError,
-  ConnectionFailedError,
   QueryExecutionError,
   SecretDecryptError
 } from '../errors'
 
-type InternalError =
-  | AppDatabaseError
-  | ConnectionFailedError
-  | QueryExecutionError
-  | SecretDecryptError
+type InternalError = AppDatabaseError | QueryExecutionError | SecretDecryptError
 
 function isInternalError(error: unknown): error is InternalError {
   return (
     error instanceof AppDatabaseError ||
-    error instanceof ConnectionFailedError ||
     error instanceof QueryExecutionError ||
     error instanceof SecretDecryptError
   )

--- a/src/server/services/query-runner.ts
+++ b/src/server/services/query-runner.ts
@@ -419,6 +419,17 @@ function isCancellationError(error: unknown): boolean {
     .includes('canceling statement due to user request')
 }
 
+// The message, never the object. A driver error carries the connection it was
+// thrown for -- pg hangs `address` and `port` off it, and the config is one
+// property away on several drivers -- and what this returns becomes a
+// QueryExecutionError's message, lands in the `queries.error` column, and is
+// read back by the renderer as `QueryDto.error`. Serializing the error itself
+// would put the connection in all three.
+//
+// The message alone still names the host and the user, because that is what
+// makes "password authentication failed for user ..." actionable. The same
+// extraction, with the same reason, is done at `connection-tests.ts` and
+// `databases.ts`.
 function extractErrorMessage(error: unknown): string {
   if (error instanceof AggregateError) {
     const messages = error.errors.map((entry) =>


### PR DESCRIPTION
Closes #80.

## What

`ConnectionFailedError` was declared in `src/server/errors.ts`, imported into `internal-errors.ts`, added to the `InternalError` union, and given a branch in `isInternalError` — and never constructed. `git log -S "new ConnectionFailedError" --all` is empty: it was dead from birth. It is not in `src/glue/api/errors.ts`, so it was never on the wire, never in an `.addError(...)`, and never decoded by tag. Removing it leaves `orDieInternal` behaving identically, and `tsc` proves the reference list was complete.

## Why it was worth deleting

Not an invalid state — a misleading one. Its comment read as a live security invariant ("the full error object embeds the connection config (host, user), which must never be logged or serialized") guarding a path that does not exist, so a reader looking for where connection failures are modelled was sent to the wrong file. They actually surface as a 200 from `POST /connection-tests` with `success: false` (the renderer's "Connection failed" toast), or as a `QueryExecutionError` message / `SchemaLoadFailedError` when a query or schema read tripped over one.

The invariant is real, so it moves to a place that enforces it: `extractErrorMessage` in `query-runner.ts`, which takes `.message` off driver errors and never the object. The note is narrowed to what is true — the object is never serialized; the message still names the host and the user, which is what makes it actionable — and points at the two sibling extractions with the same reason.

## Tests

`orDieInternal` had no test of its own, so the deletion had no guard beyond `tsc`. `src/server/http/internal-errors.test.ts` is new and was written first:

- each of the three remaining internal errors becomes a defect and leaves the typed channel empty
- every error in the wire contract stays in the typed channel
- the wrapped effect runs exactly once and yields its value

Five mutations are killed: dropping a branch of the `instanceof` chain, widening it to everything, widening it by one wire error (which would turn a 404 from the result poller into a 500), evaluating the effect twice (which would run the user's query twice), and failing instead of dying.

`yarn typecheck`, `yarn lint`, prettier, and the full backend suite (19 files / 192 tests) pass.