### PR TITLE
refactor(retention): one maintenance fiber over a list of named sweeps

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -220,7 +220,7 @@ app.on('second-instance', () => {
 })
 
 // The first real shutdown path this app has had: disposing the runtime
-// closes the HTTP server, interrupts the retention fibers and any running
+// closes the HTTP server, interrupts the retention fiber and any running
 // queries (best-effort canceling their server-side statements), and releases
 // the app database.
 app.on('before-quit', (event) => {

--- a/src/server/retention.test.ts
+++ b/src/server/retention.test.ts
@@ -1,0 +1,267 @@
+import {
+  Cause,
+  Duration,
+  Effect,
+  Exit,
+  Layer,
+  Logger,
+  Scope,
+  TestClock
+} from 'effect'
+import { TestContext } from 'effect/TestContext'
+import invariant from 'tiny-invariant'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { makeTestAppDatabase } from '@/test/effect-test-helper'
+import { RetentionLive } from './retention'
+
+// The sweeps reach SQLite through the `@/database` singleton rather than
+// through AppDatabase, so there is no layer to substitute for them yet — see
+// issue #85. Mocking the two modules is what lets the shipped RetentionLive run
+// exactly as `runtime.ts` builds it.
+const { deleteExpiredQueries, deleteExpiredSpans } = vi.hoisted(() => ({
+  deleteExpiredQueries: vi.fn<() => Promise<number>>(),
+  deleteExpiredSpans: vi.fn<() => Promise<number>>()
+}))
+
+vi.mock('@/main/queries/query-retention', () => ({ deleteExpiredQueries }))
+
+vi.mock('@/main/tracing/trace-retention', () => ({ deleteExpiredSpans }))
+
+const logMessages: string[] = []
+
+const captureLogs = Logger.replace(
+  Logger.defaultLogger,
+  Logger.make(({ message }) => {
+    const parts = Array.isArray(message) ? message : [message]
+
+    logMessages.push(String(parts[0]))
+  })
+)
+
+// Hands control back to the runtime so the sweeps can make progress, without
+// moving the clock. Written as a zero adjustment rather than a fixed number of
+// yields because how many yields a pass needs grows with the list of sweeps —
+// a count that is right today turns into false failures the day someone adds
+// a line to it.
+const settle = TestClock.adjust(Duration.zero)
+
+function counts(): { queries: number; spans: number } {
+  return {
+    queries: deleteExpiredQueries.mock.calls.length,
+    spans: deleteExpiredSpans.mock.calls.length
+  }
+}
+
+function withRetention<A>(body: Effect.Effect<A, never, never>): Promise<A> {
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* Layer.build(
+          RetentionLive.pipe(Layer.provide(makeTestAppDatabase()))
+        )
+
+        yield* settle
+
+        return yield* body
+      })
+    ).pipe(Effect.provide(captureLogs), Effect.provide(TestContext))
+  )
+}
+
+describe('RetentionLive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    logMessages.length = 0
+
+    deleteExpiredQueries.mockResolvedValue(0)
+    deleteExpiredSpans.mockResolvedValue(0)
+  })
+
+  it('sweeps everything once when the layer is built', async () => {
+    const swept = await withRetention(Effect.sync(counts))
+
+    expect(swept).toEqual({ queries: 1, spans: 1 })
+  })
+
+  it('refuses to build without the app database', async () => {
+    // Nothing in the fiber reads the client, so dropping the dependency would
+    // still compile and still pass every other test here -- and retention
+    // would be free to sweep a schema that has not been created yet. The cast
+    // is the only way to ask for a build the type system is meant to refuse.
+    const withoutTheDatabase = RetentionLive as unknown as Layer.Layer<never>
+
+    const exit = await Effect.runPromiseExit(
+      Effect.scoped(Layer.build(withoutTheDatabase)).pipe(
+        Effect.provide(TestContext)
+      )
+    )
+
+    invariant(Exit.isFailure(exit), 'The layer does not build.')
+
+    expect(String(Cause.squash(exit.cause))).toContain('AppDatabase')
+  })
+
+  it('starts a sweep only once the one before it has finished', async () => {
+    let releaseQueries: () => void = () => undefined
+
+    deleteExpiredQueries.mockReturnValue(
+      new Promise<number>((resolve) => {
+        releaseQueries = () => resolve(0)
+      })
+    )
+
+    const swept = await withRetention(
+      Effect.gen(function* () {
+        // A pass is one point in time, not two: the sweeps share the app
+        // database and the schedule they run on, so they run in the order the
+        // list gives them.
+        const whileBlocked = counts()
+
+        yield* Effect.sync(releaseQueries)
+        yield* settle
+
+        return { onceReleased: counts(), whileBlocked }
+      })
+    )
+
+    expect(swept).toEqual({
+      onceReleased: { queries: 1, spans: 1 },
+      whileBlocked: { queries: 1, spans: 0 }
+    })
+  })
+
+  it('runs the remaining sweeps after one of them fails', async () => {
+    deleteExpiredQueries.mockRejectedValue(new Error('database is locked'))
+
+    const swept = await withRetention(Effect.sync(counts))
+
+    expect(swept).toEqual({ queries: 1, spans: 1 })
+  })
+
+  it('names the sweep that failed in the log', async () => {
+    deleteExpiredSpans.mockRejectedValue(new Error('database is locked'))
+
+    const swept = await withRetention(Effect.sync(counts))
+
+    // The fiber has no other output. A failure nobody can attribute to a sweep
+    // is the same as a failure nobody reported.
+    expect({ logMessages: [...logMessages], swept }).toEqual({
+      logMessages: ['Trace span cleanup failed'],
+      swept: { queries: 1, spans: 1 }
+    })
+  })
+
+  it('sweeps again a day later', async () => {
+    const swept = await withRetention(
+      Effect.gen(function* () {
+        yield* TestClock.adjust(Duration.days(1))
+        yield* settle
+
+        return counts()
+      })
+    )
+
+    expect(swept).toEqual({ queries: 2, spans: 2 })
+  })
+
+  it('does not sweep again before the day is up', async () => {
+    const swept = await withRetention(
+      Effect.gen(function* () {
+        yield* TestClock.adjust(Duration.hours(23))
+        yield* settle
+
+        return counts()
+      })
+    )
+
+    expect(swept).toEqual({ queries: 1, spans: 1 })
+  })
+
+  it('does not let a slow pass push the following days back', async () => {
+    let releaseQueries: () => void = () => undefined
+
+    deleteExpiredQueries.mockResolvedValueOnce(0)
+    deleteExpiredQueries.mockReturnValueOnce(
+      new Promise<number>((resolve) => {
+        releaseQueries = () => resolve(0)
+      })
+    )
+
+    const swept = await withRetention(
+      Effect.gen(function* () {
+        yield* TestClock.adjust(Duration.hours(24))
+        yield* settle
+
+        const whenTheSecondPassStalls = counts()
+
+        yield* TestClock.adjust(Duration.hours(1))
+        yield* Effect.sync(releaseQueries)
+        yield* settle
+
+        const afterTheSecondPass = counts()
+
+        // Two days in, with one pass having taken an hour. A cadence measured
+        // from the end of each pass would be an hour late here, and an hour
+        // later again after every slow pass -- so a machine that is busy every
+        // day walks its maintenance around the clock.
+        yield* TestClock.adjust(Duration.hours(23))
+        yield* settle
+
+        return {
+          afterTheSecondPass,
+          atTheSecondDayMark: counts(),
+          whenTheSecondPassStalls
+        }
+      })
+    )
+
+    expect(swept).toEqual({
+      afterTheSecondPass: { queries: 2, spans: 2 },
+      atTheSecondDayMark: { queries: 3, spans: 3 },
+      whenTheSecondPassStalls: { queries: 2, spans: 1 }
+    })
+  })
+
+  it('keeps to the schedule after a sweep fails', async () => {
+    deleteExpiredQueries.mockRejectedValue(new Error('database is locked'))
+
+    const swept = await withRetention(
+      Effect.gen(function* () {
+        yield* TestClock.adjust(Duration.days(1))
+        yield* settle
+
+        return counts()
+      })
+    )
+
+    expect(swept).toEqual({ queries: 2, spans: 2 })
+  })
+
+  it('stops sweeping when the scope closes', async () => {
+    const swept = await Effect.runPromise(
+      Effect.gen(function* () {
+        const scope = yield* Scope.make()
+
+        yield* Layer.buildWithScope(
+          RetentionLive.pipe(Layer.provide(makeTestAppDatabase())),
+          scope
+        )
+
+        yield* settle
+
+        // The runtime scope closes on before-quit, and a sweep left running
+        // would hold the app database open past disposal.
+        yield* Scope.close(scope, Exit.void)
+
+        yield* TestClock.adjust(Duration.days(2))
+        yield* settle
+
+        return counts()
+      }).pipe(Effect.provide(captureLogs), Effect.provide(TestContext))
+    )
+
+    expect(swept).toEqual({ queries: 1, spans: 1 })
+  })
+})

--- a/src/server/retention.ts
+++ b/src/server/retention.ts
@@ -1,4 +1,4 @@
-// Retention sweeps as scoped fibers owned by the runtime scope: an immediate
+// Retention as one scoped fiber owned by the runtime scope: an immediate
 // sweep at boot, then one per day, and clean interruption at shutdown —
 // replacing the previous fire-and-forget setInterval calls whose handles
 // were never retained.
@@ -8,32 +8,58 @@ import { deleteExpiredQueries } from '@/main/queries/query-retention'
 import { deleteExpiredSpans } from '@/main/tracing/trace-retention'
 import { AppDatabase } from './services/app-database'
 
-function dailySweep(
-  name: string,
-  sweep: () => Promise<number>
-): Layer.Layer<never, never, AppDatabase> {
-  return Layer.scopedDiscard(
-    Effect.gen(function* () {
-      // Depending on AppDatabase is what orders the first sweep after schema
-      // initialization. Without it this layer declares no dependencies, and
-      // mergeAll starts the boot sweep concurrently with initializeDatabase().
-      yield* AppDatabase
-
-      yield* Effect.promise(sweep).pipe(
-        // One failed sweep must not stop the schedule — log and try again
-        // tomorrow.
-        Effect.catchAllCause((cause) =>
-          Effect.logError(`${name} cleanup failed`, cause)
-        ),
-        Effect.repeat(Schedule.fixed(Duration.days(1))),
-        Effect.forkScoped
-      )
-    })
-  )
+interface MaintenanceSweep {
+  name: string
+  run: () => Promise<number>
 }
 
-const queryRetention = dailySweep('Query history', () => deleteExpiredQueries())
+// A plain list, deliberately not a registry: a sweep is a line here, and the
+// order of the lines is the order they run in.
+const sweeps: MaintenanceSweep[] = [
+  { name: 'Query history', run: () => deleteExpiredQueries() },
+  { name: 'Trace span', run: () => deleteExpiredSpans() }
+]
 
-const traceRetention = dailySweep('Trace span', () => deleteExpiredSpans())
+// One pass over the list, in order, so that "daily maintenance" names a single
+// point in time rather than two that are free to drift apart, and so shutdown
+// has one fiber to interrupt rather than two.
+//
+// There is deliberately no per-sweep timeout, which is the one place this
+// departs from the project rule that every external await gets one. That rule
+// is about calls that can hang while this process keeps running; the libsql
+// driver is synchronous and runs on this process's event loop, so a DELETE
+// that is taking a long time is also blocking the timer that would have to
+// fire to abandon it. A timeout here would read as protection and deliver
+// none. It becomes worth adding once `AppDatabase.execute` can carry a real
+// cancellation signal.
+const runSweeps = Effect.forEach(
+  sweeps,
+  (sweep) =>
+    Effect.tryPromise(sweep.run).pipe(
+      // A failed sweep must stop neither the sweeps after it nor the schedule
+      // — name it in the log and try again tomorrow.
+      Effect.catchAllCause((cause) =>
+        Effect.logError(`${sweep.name} cleanup failed`, cause)
+      )
+    ),
+  { discard: true }
+)
 
-export const RetentionLive = Layer.mergeAll(queryRetention, traceRetention)
+export const RetentionLive = Layer.scopedDiscard(
+  Effect.gen(function* () {
+    // Nothing here uses the client. The dependency is what states, in the type
+    // system, that retention runs against an initialized schema.
+    // `Layer.provideMerge` in `runtime.ts` already builds it that way, so this
+    // line changes no behaviour today — it is what keeps the ordering true if
+    // that composition is ever rearranged.
+    yield* AppDatabase
+
+    yield* runSweeps.pipe(
+      // `fixed`, not `spaced`: the cadence is anchored to when a pass started,
+      // so a slow sweep does not push every later day's maintenance back by
+      // however long it took.
+      Effect.repeat(Schedule.fixed(Duration.days(1))),
+      Effect.forkScoped
+    )
+  })
+)

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -1,7 +1,7 @@
 // Assembles the full backend into one layer and hands Electron a
 // ManagedRuntime that owns it: building the runtime initializes the app
 // database, runs the boot effects, starts the HTTP server, and forks the
-// retention fibers; disposing it tears all of that down in reverse.
+// retention fiber; disposing it tears all of that down in reverse.
 import { ConfigProvider, Layer, ManagedRuntime, Redacted } from 'effect'
 
 import { boot } from './boot'


### PR DESCRIPTION
Closes #86.

Retention was a `dailySweep(name, run)` factory called twice and merged: one concept — daily maintenance — as two layers, two scoped fibers and two independent schedules. The only thing that varied between the two calls was a name and a function. It is now one layer, one fiber, and one `MaintenanceSweep[]`, where a sweep is a line and the order of the lines is the order it runs in.

## What actually changes at runtime

Less than the shape suggests, and the PR is careful not to overclaim it.

`Layer.mergeAll` did start the two fibers concurrently, so the sweeps interleaved on the event loop — but the libsql driver is synchronous (`src/database/index.ts:20`), so the two DELETEs could never overlap. They were already serialized by the driver.

The real wins are that "daily maintenance" now names one point in time instead of two schedules anchored independently at whenever each fiber first came round, and that shutdown has one fiber to interrupt rather than two.

## No per-sweep timeout, deliberately

An earlier revision of this branch added `Effect.timeout(5 minutes)` per sweep, citing the project rule that every external await gets a timeout. Review showed that timer can never fire: the driver is synchronous and runs on this process's event loop, so a DELETE that is taking a long time is also blocking the timer that would abandon it. It would have read as protection and delivered none, so it is gone, and the comment at the code says why. It becomes worth adding once `AppDatabase.execute` can carry a real cancellation signal.

`Effect.tryPromise` replaces `Effect.promise`: a locked or full database is an outcome these functions can genuinely produce, not a defect.

## Tests

New `src/server/retention.test.ts`, 10 tests on `TestClock`. Every mutation below was applied to the shipped `retention.ts` and killed by the suite:

| Mutation | |
|---|---|
| sweeps run concurrently | killed |
| sweeps in the other order | killed |
| a failure stops the pass | killed |
| hourly schedule | killed |
| never repeats | killed |
| `forkDaemon` instead of `forkScoped` | killed |
| the sweeps are unnamed | killed |
| a failure is swallowed silently | killed |
| the `AppDatabase` dependency is dropped | killed |
| `Schedule.spaced` instead of `fixed` | killed |
| the wrong sweep is named in the log | killed |

The last five came out of review. Two are worth calling out: nothing in the fiber reads the database client, so the dependency that orders retention after schema creation could be deleted and still compile — `refuses to build without the app database` is what notices. And `fixed` versus `spaced` only diverges once a pass takes real time, which is what `does not let a slow pass push the following days back` sets up.

The synchronisation helper is `TestClock.adjust(Duration.zero)` rather than a fixed number of `Effect.yieldNow()`s, because the number of yields a pass needs grows with the list — a count that is right today turns into false failures the day someone adds a sweep. Verified by adding three extra sweeps: suite stays green.

## Known gap, not fixed here

The sweeps reach SQLite through the `@/database` singleton rather than through `AppDatabase`, which is why their tests mock the two modules instead of substituting an in-memory layer. Threading the client is issue #85.

Backend suite: 188 passed (19 files).