### PR TITLE
refactor(server): give the two runtime knobs a typed tag

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,0 +1,23 @@
+import { Context } from 'effect'
+
+// The two deployment knobs the main process decides at boot: which origins the
+// renderer may call from, and whether trace reads are open to tooling that
+// sends no Origin. Both are read straight off this tag, so a layer that forgets
+// to supply them fails to compile rather than falling back to a default nobody
+// chose -- and the values arrive as themselves, not as strings to be parsed.
+//
+// A separate module because `runtime.ts`, the only producer in the app, imports
+// `http/server.ts`, one of the two consumers.
+//
+// Deliberately not the home of the session token, which has its own tag: this
+// pair is plain deployment configuration, and keeping the secret out of the
+// record is what stops the CORS layer from being able to read it.
+interface ServerConfiguration {
+  readonly allowedOrigins: ReadonlyArray<string>
+  readonly publicTraceReads: boolean
+}
+
+export class ServerConfig extends Context.Tag('ServerConfig')<
+  ServerConfig,
+  ServerConfiguration
+>() {}

--- a/src/server/http/api.test.ts
+++ b/src/server/http/api.test.ts
@@ -220,6 +220,21 @@ describe('cors', () => {
     expect(headers['access-control-allow-origin']).toEqual('null')
   })
 
+  // The allowlist is a list of origins, not one delimited string, so a comma
+  // inside a configured origin names no second origin. It cannot happen with
+  // the two profiles the app ships, and that is the point: the encoding must
+  // not be able to invent an allowed origin nobody configured.
+  it('does not read a comma inside a configured origin as a separator', async () => {
+    const headers = await rawHeaders(
+      HttpClientRequest.get('/health').pipe(
+        HttpClientRequest.setHeader('origin', 'https://evil.example')
+      ),
+      { allowedOrigins: ['https://squeal.example,https://evil.example'] }
+    )
+
+    expect(headers['access-control-allow-origin']).toBeUndefined()
+  })
+
   it('allows a configured development origin', async () => {
     const headers = await rawHeaders(
       HttpClientRequest.get('/health').pipe(

--- a/src/server/http/authorization-live.ts
+++ b/src/server/http/authorization-live.ts
@@ -1,8 +1,9 @@
 import { HttpServerRequest } from '@effect/platform'
-import { Config, Effect, Layer, Redacted } from 'effect'
+import { Effect, Layer, Redacted } from 'effect'
 
 import { UnauthorizedError } from '@/glue/api/errors'
 import { Authorization, TraceReadAuthorization } from '@/glue/api/security'
+import { ServerConfig } from '../config'
 import { ApiToken } from './api-token'
 import { presentsToken } from './authorization'
 
@@ -40,9 +41,7 @@ export const AuthorizationLive = Layer.effect(
 export const TraceReadAuthorizationLive = Layer.effect(
   TraceReadAuthorization,
   Effect.gen(function* () {
-    const publicTraceReads = yield* Config.boolean('PUBLIC_TRACE_READS').pipe(
-      Config.withDefault(false)
-    )
+    const { publicTraceReads } = yield* ServerConfig
     const token = yield* ApiToken
 
     return Effect.gen(function* () {

--- a/src/server/http/server.ts
+++ b/src/server/http/server.ts
@@ -9,10 +9,11 @@ import {
 // Subpath import on purpose: the package barrel pulls in cluster modules
 // whose optional peers are not installed.
 import * as NodeHttpServer from '@effect/platform-node/NodeHttpServer'
-import { Config, Effect, Layer, Option } from 'effect'
+import { Effect, Layer, Option } from 'effect'
 import { createServer } from 'node:http'
 
 import { SquealApi } from '@/glue/api/api'
+import { ServerConfig } from '../config'
 import { shouldSkipTracing } from '../tracing/trace-skip'
 import {
   AuthorizationLive,
@@ -53,10 +54,7 @@ export const ApiLive = HttpApiBuilder.api(SquealApi).pipe(
 // Origin a packaged renderer sends when loaded from file://.
 export const CorsLive = Layer.unwrapEffect(
   Effect.gen(function* () {
-    const allowedOrigins = yield* Config.string('ALLOWED_ORIGINS').pipe(
-      Config.withDefault('null')
-    )
-    const allowed = allowedOrigins.split(',')
+    const { allowedOrigins } = yield* ServerConfig
 
     return HttpApiBuilder.middlewareCors({
       allowedHeaders: ['Authorization', 'Content-Type', 'traceparent'],
@@ -74,7 +72,12 @@ export const CorsLive = Layer.unwrapEffect(
       // comparing the request's Origin, so a packaged build (whose only allowed
       // origin is 'null') would answer every caller with
       // `access-control-allow-origin: null`.
-      allowedOrigins: (origin) => allowed.includes(origin)
+      // `origin` is typed `string` but the middleware passes
+      // `request.headers['origin']`, which is undefined whenever the request
+      // sends no Origin at all. `includes(undefined)` is false, which is the
+      // answer we want -- but anything that dereferences it here would throw on
+      // every such request instead.
+      allowedOrigins: (origin) => allowedOrigins.includes(origin)
     })
   })
 )

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -2,9 +2,10 @@
 // ManagedRuntime that owns it: building the runtime initializes the app
 // database, runs the boot effects, starts the HTTP server, and forks the
 // retention fiber; disposing it tears all of that down in reverse.
-import { ConfigProvider, Layer, ManagedRuntime, Redacted } from 'effect'
+import { Layer, ManagedRuntime, Redacted } from 'effect'
 
 import { boot } from './boot'
+import { ServerConfig } from './config'
 import { ApiToken } from './http/api-token'
 import { HttpLive } from './http/server'
 import { RetentionLive } from './retention'
@@ -21,7 +22,7 @@ import { TracerLive } from './tracing/effect-tracer'
 import { UpdaterLive } from './updates'
 
 export interface MainRuntimeOptions {
-  allowedOrigins: string[]
+  allowedOrigins: ReadonlyArray<string>
   publicTraceReads: boolean
   token: string
 }
@@ -44,15 +45,6 @@ const ServicesLive = Layer.mergeAll(
 const BootLive = Layer.effectDiscard(boot)
 
 export function makeMainRuntime(options: MainRuntimeOptions) {
-  const configuration = Layer.setConfigProvider(
-    ConfigProvider.fromMap(
-      new Map([
-        ['ALLOWED_ORIGINS', options.allowedOrigins.join(',')],
-        ['PUBLIC_TRACE_READS', String(options.publicTraceReads)]
-      ])
-    )
-  )
-
   // Order matters and is not obvious: `provideMerge` builds right to left, so
   // ServicesLive (and with it AppDatabase) is acquired first and released last.
   // TracerLive sits inside it deliberately — the tracer must flush its queued
@@ -66,7 +58,12 @@ export function makeMainRuntime(options: MainRuntimeOptions) {
     Layer.provideMerge(TracerLive),
     Layer.provideMerge(ServicesLive),
     Layer.provide(Layer.succeed(ApiToken, Redacted.make(options.token))),
-    Layer.provide(configuration)
+    Layer.provide(
+      Layer.succeed(ServerConfig, {
+        allowedOrigins: options.allowedOrigins,
+        publicTraceReads: options.publicTraceReads
+      })
+    )
   )
 
   return ManagedRuntime.make(MainLive)

--- a/src/test/effect-test-helper.ts
+++ b/src/test/effect-test-helper.ts
@@ -6,7 +6,7 @@ import { HttpApiClient, HttpClient, HttpClientRequest } from '@effect/platform'
 // whose optional peers are not installed.
 import * as NodeHttpServer from '@effect/platform-node/NodeHttpServer'
 import { drizzle } from 'drizzle-orm/libsql'
-import { ConfigProvider, Effect, Layer, Redacted } from 'effect'
+import { Effect, Layer, Redacted } from 'effect'
 
 import { createTables } from '@/database/tables'
 import type { SchemaInfo, QueryResult } from '@/databases/adapter'
@@ -15,6 +15,7 @@ import { UpdateNotReadyError } from '@/glue/api/errors'
 import type { DatabaseConnection, SecretStorageMode } from '@/glue/api/schemas'
 import type { KeychainProbeResult } from '@/main/databases/secret-storage'
 import { updateMessages } from '@/main/updates/updater'
+import { ServerConfig } from '@/server/config'
 import { ApiToken } from '@/server/http/api-token'
 import { ApiLive, CorsLive, ServeLive } from '@/server/http/server'
 import {
@@ -202,7 +203,7 @@ export interface TestApiOptions {
   adapter?: TestAdapterConfig
   // Defaults to the packaged profile: one allowed origin, so the CORS fast-path
   // regression stays covered.
-  allowedOrigins?: string[]
+  allowedOrigins?: ReadonlyArray<string>
   publicTraceReads?: boolean
   // What the keychain answers when the user asks for encryption.
   secretStorageProbe?: KeychainProbeResult
@@ -227,14 +228,10 @@ export function makeTestApi(options: TestApiOptions = {}) {
     Layer.provideMerge(updater.layer)
   )
 
-  const configuration = Layer.setConfigProvider(
-    ConfigProvider.fromMap(
-      new Map([
-        ['ALLOWED_ORIGINS', (options.allowedOrigins ?? ['null']).join(',')],
-        ['PUBLIC_TRACE_READS', String(options.publicTraceReads ?? false)]
-      ])
-    )
-  )
+  const configuration = Layer.succeed(ServerConfig, {
+    allowedOrigins: options.allowedOrigins ?? ['null'],
+    publicTraceReads: options.publicTraceReads ?? false
+  })
 
   // ServeLive and CorsLive come from the production module so the harness runs
   // the real host guard, body limit, and CORS behaviour.


### PR DESCRIPTION
Closes #79.

Two values the main process already holds as `ReadonlyArray<string>` and `boolean` were encoded into a `ConfigProvider.fromMap` string map and decoded back by their two consumers: `join(',')` → `split(',')` for the CORS allowlist, `String(...)` → `Config.boolean` for the trace-read carve-out. Those were the only two `Config` reads in `src/server/**`, so the provider layer existed to serve that round trip and nothing else — and `src/test/effect-test-helper.ts` re-implemented the same encoding a second time, with no type link to the first.

They now travel on one `Context.Tag` in a new `src/server/config.ts`, supplied with `Layer.succeed`.

## Why both keys in one commit

Leaving one on the old channel would have given the trace-read carve-out two possible sources and no way to tell which one answered. There are now zero `ConfigProvider`, `ALLOWED_ORIGINS` and `PUBLIC_TRACE_READS` references left in `src/`.

## What this buys

**A dropped `Layer.provide` is a compile error.** Each consumer used to declare its own `withDefault`, unreachable in production because `MainRuntimeOptions` makes both fields required. Their only effect was to turn a key typo or a dropped provide into silent degradation — CORS narrowing to `'null'`-only, trace reads falling back to token-required. Verified as a real hazard on the parent commit: deleting `Layer.provide(configuration)` there compiled and all 179 tests passed. On this commit it is `TS2345` in both producers.

**The encoding can no longer invent an allowlist entry.** A comma inside a configured origin named a second allowed origin. Not reachable — the two producers emit `'null'` and a `URL.origin`, neither of which can contain a comma — and that is exactly why it is worth pinning: the CORS allowlist must only ever contain what was configured. `does not read a comma inside a configured origin as a separator` is the regression test.

## The session token deliberately stays on its own tag

The issue ruled out folding `ApiToken` into a fat config record, and that holds: `src/server/http/api-token.ts` is untouched and `ServerConfiguration` has exactly the two fields. Keeping the secret out of the record is what makes "the CORS layer cannot read the session token" a typed fact rather than a convention.

A separate module rather than living in `runtime.ts`, because `runtime.ts` imports `http/server.ts`, one of the two consumers.

## Behaviour

Unchanged for both shipped profiles — `join(',')`/`split(',')` was an identity round trip for comma-free values, and `String(bool)`/`Config.boolean` round-tripped exactly. The empty-list edge improves: `[].join(',').split(',')` used to yield `['']`, an allowlist containing the empty string; now it is `[]`.

## Verification

Backend suite 179 passed (18 files). Mutation testing on the touched lines — comma re-split, substring matching, case-insensitive compare, `&&` → `||` in the carve-out, a tag-identifier collision with `ApiToken`, and a widened test-helper default — all killed. The library fast path was confirmed against `@effect/platform` source: it fires only for a non-function array of length 1, so passing a predicate always reaches the comparing branch.

Review also confirmed `Layer.setConfigProvider` is gone with no remaining `Config` reads anywhere in `src/` or in the `@effect/platform*` / `@effect/sql` packages, so nothing silently starts reading environment variables.

## Not fixed here

`runtime.ts` supplying a wrong constant still survives mutation, unchanged from before this commit. The higher-value target is `src/main.ts` — `corsAllowedOrigins()` is pure and `!app.isPackaged` is the actual security policy — but both need moving out of a module with top-level `electron` imports first. Separate issue.