### PR TITLE
fix(tracing): take the batch out of the buffer instead of copying it

### DIFF
--- a/src/app/tracing/exporter.test.ts
+++ b/src/app/tracing/exporter.test.ts
@@ -1,17 +1,35 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance
+} from 'vitest'
 
 import { SpanRecord } from '@/glue/tracing/spans'
 
 let exporter: typeof import('./exporter')
 
+// Silenced for every test, not only the two that assert on it. The failure
+// path warns, so a test that merely exercises it would otherwise print a real
+// outage line during a green run -- and a spy restored at the end of a test
+// body is not restored when an assertion above it throws, which leaks the
+// previous test's recorded calls into the next one.
+let warn: MockInstance<typeof console.warn>
+
 beforeEach(async () => {
   vi.resetModules()
+
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
   exporter = await import('./exporter')
 })
 
 afterEach(() => {
   exporter.stopExporter()
+  warn.mockRestore()
   vi.useRealTimers()
 })
 
@@ -84,6 +102,170 @@ describe('flushSpans', () => {
 
     expect(sent.length).toEqual(1000)
     expect(sent[0]?.name).toEqual('span-1')
+  })
+
+  // Any user action ends a traced span, so enqueueSpan runs during the POST
+  // the exporter is awaiting. The exporter must therefore own its batch from
+  // the moment it takes it -- identifying it by position in a buffer that the
+  // overflow trim can shorten underneath it loses spans that were never sent,
+  // which is silent loss beyond the documented drop-oldest policy.
+  it('keeps the spans enqueued while a batch was in flight', async () => {
+    let releaseTheFirstBatch: () => void = () => undefined
+
+    const send = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          releaseTheFirstBatch = () => resolve({ insertedCount: 100 })
+        })
+      )
+      .mockResolvedValue({ insertedCount: 0 })
+
+    exporter.startExporter({ send })
+
+    for (let index = 0; index < 100; index += 1) {
+      exporter.enqueueSpan(buildRecord(`early-${index}`))
+    }
+
+    const flushed = exporter.flushSpans()
+
+    // Enough to refill the buffer to capacity while the first batch is still
+    // unacknowledged, which is the only window the loss can happen in.
+    for (let index = 0; index < 1000; index += 1) {
+      exporter.enqueueSpan(buildRecord(`late-${index}`))
+    }
+
+    releaseTheFirstBatch()
+
+    await flushed
+
+    const sent = send.mock.calls.flatMap(
+      (call) => call[0] as { name: string }[]
+    )
+    const sentNames = new Set(sent.map((span) => span.name))
+    const neverSent = Array.from(
+      { length: 1000 },
+      (_unused, index) => `late-${index}`
+    ).filter((name) => !sentNames.has(name))
+
+    expect({ neverSent, sentCount: sent.length }).toEqual({
+      neverSent: [],
+      sentCount: 1100
+    })
+  })
+
+  it('drops the oldest spans overall when a failed batch comes back full', async () => {
+    let rejectTheFirstBatch: () => void = () => undefined
+
+    const send = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise((_resolve, reject) => {
+          rejectTheFirstBatch = () => reject(new Error('server down'))
+        })
+      )
+      .mockResolvedValue({ insertedCount: 0 })
+
+    exporter.startExporter({ send })
+
+    for (let index = 0; index < 100; index += 1) {
+      exporter.enqueueSpan(buildRecord(`early-${index}`))
+    }
+
+    const flushed = exporter.flushSpans()
+
+    for (let index = 0; index < 1000; index += 1) {
+      exporter.enqueueSpan(buildRecord(`late-${index}`))
+    }
+
+    rejectTheFirstBatch()
+
+    await flushed
+    await exporter.flushSpans()
+
+    const retried = send.mock.calls
+      .slice(1)
+      .flatMap((call) => call[0] as { name: string }[])
+
+    // A batch handed back to a buffer that filled up behind it puts the buffer
+    // over capacity, so it is trimmed again -- and because the batch goes back
+    // to the head first, the spans that go are the oldest of the whole 1100
+    // rather than the hundred just returned.
+    expect({
+      first: retried[0]?.name,
+      last: retried[retried.length - 1]?.name,
+      retriedCount: retried.length
+    }).toEqual({ first: 'late-0', last: 'late-999', retriedCount: 1000 })
+  })
+
+  it('reports an outage once, and again after the next one', async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('server down'))
+      .mockRejectedValueOnce(new Error('still down'))
+      .mockResolvedValueOnce({ insertedCount: 1 })
+      .mockRejectedValueOnce(new Error('down again'))
+
+    exporter.startExporter({ send })
+    exporter.enqueueSpan(buildRecord('kept'))
+
+    await exporter.flushSpans()
+    await exporter.flushSpans()
+    await exporter.flushSpans()
+
+    exporter.enqueueSpan(buildRecord('later'))
+
+    await exporter.flushSpans()
+
+    // Once per outage rather than once every two seconds for as long as the
+    // server is down, and a successful send ends the outage.
+    expect(warn.mock.calls.map((call) => call[1])).toEqual([
+      new Error('server down'),
+      new Error('down again')
+    ])
+  })
+
+  it('does not start a second flush while one is in flight', async () => {
+    let releaseTheFirstSend: () => void = () => undefined
+
+    const send = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseTheFirstSend = () => resolve({ insertedCount: 100 })
+          })
+      )
+      .mockResolvedValue({ insertedCount: 100 })
+
+    exporter.startExporter({ send })
+
+    for (let index = 0; index < 200; index += 1) {
+      exporter.enqueueSpan(buildRecord(`span-${index}`))
+    }
+
+    const theFirstFlush = exporter.flushSpans()
+
+    // The interval keeps firing while a slow server holds the POST open, so a
+    // server taking ten seconds would collect five concurrent requests from a
+    // renderer that is meant to be sending one batch at a time -- and each of
+    // them would hand a failed batch back to the head of the same buffer, in
+    // whatever order they happened to fail.
+    await exporter.flushSpans()
+
+    const whileTheFirstIsInFlight = send.mock.calls.length
+
+    releaseTheFirstSend()
+
+    await theFirstFlush
+
+    expect({
+      onceTheFirstResolved: send.mock.calls.length,
+      whileTheFirstIsInFlight
+    }).toEqual({
+      onceTheFirstResolved: 2,
+      whileTheFirstIsInFlight: 1
+    })
   })
 
   it('does nothing before the exporter is started', async () => {

--- a/src/app/tracing/exporter.ts
+++ b/src/app/tracing/exporter.ts
@@ -6,19 +6,28 @@ const maxBufferedSpans = 1000
 
 type SendSpans = (spans: SpanRecord[]) => Promise<unknown>
 
-let buffer: SpanRecord[] = []
-let failureStreak = 0
+// Never reassigned: the flush below hands its batch back into this same array
+// on failure, so a second array would strand whichever one the exporter was
+// not holding.
+const buffer: SpanRecord[] = []
+
 let flushInFlight = false
 let flushTimer: ReturnType<typeof setInterval> | undefined
+let hasReportedOutage = false
 let sendSpans: SendSpans | undefined
+
+// A dead server must not grow renderer memory without bound. The only place a
+// span is ever dropped, so the drop-oldest policy is stated once.
+function trimToCapacity(): void {
+  if (buffer.length > maxBufferedSpans) {
+    buffer.splice(0, buffer.length - maxBufferedSpans)
+  }
+}
 
 export function enqueueSpan(record: SpanRecord): void {
   buffer.push(record)
 
-  // A dead server must not grow renderer memory without bound.
-  if (buffer.length > maxBufferedSpans) {
-    buffer.splice(0, buffer.length - maxBufferedSpans)
-  }
+  trimToCapacity()
 }
 
 export async function flushSpans(): Promise<void> {
@@ -30,23 +39,33 @@ export async function flushSpans(): Promise<void> {
 
   try {
     while (buffer.length > 0) {
-      const batch = buffer.slice(0, flushBatchSize)
+      // Taken out of the buffer rather than copied from it. enqueueSpan runs
+      // while the POST below is awaited -- any user action ends a traced span
+      // -- so a batch identified by its position would be a different hundred
+      // spans by the time the request resolved, and dropping that many from
+      // the head would discard spans that were never sent.
+      const batch = buffer.splice(0, flushBatchSize)
 
       try {
         await sendSpans(batch)
       } catch (error) {
-        failureStreak += 1
+        // Back onto the head before the trim, so drop-oldest still drops the
+        // oldest spans overall rather than the ones just handed back.
+        buffer.unshift(...batch)
+
+        trimToCapacity()
 
         // Log once per outage instead of every two seconds.
-        if (failureStreak === 1) {
+        if (!hasReportedOutage) {
+          hasReportedOutage = true
+
           console.warn('Could not export trace spans; will retry.', error)
         }
 
         return
       }
 
-      failureStreak = 0
-      buffer = buffer.slice(batch.length)
+      hasReportedOutage = false
     }
   } finally {
     flushInFlight = false


### PR DESCRIPTION
Closes #57.

The span exporter identified its in-flight batch by **position** in a buffer that mutates while the request is open:

```ts
const batch = buffer.slice(0, flushBatchSize)   // build by position
await sendSpans(batch)
buffer = buffer.slice(batch.length)             // remove by position
```

The only link between the two was the assumption that the first hundred elements were still the same hundred when the POST resolved.

## The loss

`enqueueSpan` runs during that await — any user action ends a traced span. Every span that arrives while the buffer is at its 1000-span capacity trims one off the head, and the positional removal afterwards then drops one that was never sent. One span lost per arrival, up to the whole batch.

The trigger is not exotic: the buffer sits *at* capacity for as long as it takes to drain after any server outage — which is exactly when there is a backlog worth keeping. Silent, beyond the documented drop-oldest policy, and nothing logged.

## The fix

`splice(0, flushBatchSize)` takes ownership at take time. A failed batch goes back with `unshift` — before the trim, so drop-oldest still drops the oldest spans overall rather than the ones just handed back — and capacity is enforced in one `trimToCapacity()` that both paths call. No invariant spans the await, and `buffer` becomes a `const`.

`failureStreak` was a counter only ever compared against `1`, so it is now `hasReportedOutage`.

All four exported signatures are unchanged, so `tracer.ts`, `init.ts` and `api-client.test.ts` are untouched. The diff is two files.

## Tests

Four added. **One is the regression test** — a deferred first send with 100 spans in flight and 1000 enqueued behind them; against the previous shape 100 spans never reach the server. The other three are mutation coverage for behaviour that already existed, and pass against the old code too.

Eleven mutations applied to the shipped module, all killed:

| | |
|---|---|
| the pre-change positional batch | killed |
| no trim after the batch comes back | killed |
| trim before the batch comes back | killed |
| the failed batch goes to the tail | killed |
| the failed batch is not handed back | killed |
| the outage never ends | killed |
| every failure is reported | killed |
| no capacity limit on enqueue | killed |
| the newest spans are dropped instead | killed |
| half-sized batches | killed |
| concurrent flushes allowed | killed |

The last one covers the pre-existing `flushInFlight` guard, which had **no** coverage before this branch — verified by removing it and watching the old test file still pass. Without it the two-second interval starts another POST on every tick a slow server holds one open.

Review also moved the `console.warn` spy into the test hooks: restoring it at the end of a test body leaves it installed when an assertion above it throws, and `vi.spyOn` hands back the *existing* spy, so the next test inherits the previous one's recorded calls and fails for the wrong reason. That was producing real cascading false failures during the mutation runs.

## Deliberately not fixed here

`flushInFlight` guards an **untimed** external await, so a POST that never settles still wedges the exporter permanently. Adding a timeout makes a slow-but-alive server retry and therefore duplicate spans; `span-writer.ts` does `onConflictDoNothing()` on the span-id primary key, so the dedupe exists, but it wants confirming end to end first. Separate change, as the issue asks.

Renderer suite: 777 passed. The one failure in `src/databases/sqlite-adapter.test.ts` is pre-existing on the base commit (a Windows file-URL path artifact) and untouched by this branch.