### PR TITLE
fix(updates): claim the install when the request asks, not when it fires

### DIFF
--- a/src/main/updates/updater.test.ts
+++ b/src/main/updates/updater.test.ts
@@ -329,47 +329,107 @@ describe('createUpdater', () => {
     expect(ready.state.checks).toEqual(1)
   })
 
-  it('installs only when an update is ready', () => {
+  it('refuses a claim until an update is ready', () => {
     const subject = makeSubject()
 
-    expect(subject.updater.install()).toEqual(false)
+    expect(subject.updater.beginInstall()).toEqual(null)
+
+    subject.updater.check()
+    subject.emit.downloaded('1.3.0')
+
+    expect(subject.updater.beginInstall()).toEqual(subject.updater.status())
+  })
+
+  it('hands nothing to the backend until the claim is completed', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.downloaded('1.3.0')
+    subject.updater.beginInstall()
+
+    // The hand-off is deliberately later than the claim: the HTTP response has
+    // to reach the renderer before the app starts quitting under it.
     expect(subject.state.installs).toEqual(0)
 
-    subject.updater.check()
-    subject.emit.downloaded('1.3.0')
+    subject.updater.completeInstall()
 
-    expect(subject.updater.install()).toEqual(true)
     expect(subject.state.installs).toEqual(1)
   })
 
-  // The install is handed to the backend on a delay so the HTTP response can
-  // leave first, which opens a window for a retry or a second client to ask
-  // again. Squirrel spawns its installer per quitAndInstall call.
-  it('only ever hands one install to the backend', () => {
+  // The gap between the claim and the hand-off is the window a retry or a
+  // second client can ask in. A latch taken at hand-off time refuses the
+  // duplicate hand-off but closes too late to say so, and the second request is
+  // answered with a success for an install that was dropped.
+  it('refuses a second claim before the first has been handed over', () => {
     const subject = makeSubject()
 
     subject.updater.check()
     subject.emit.downloaded('1.3.0')
 
-    expect(subject.updater.install()).toEqual(true)
-    expect(subject.updater.install()).toEqual(false)
-    expect(subject.updater.install()).toEqual(false)
-    expect(subject.state.installs).toEqual(1)
+    const claims = [
+      subject.updater.beginInstall(),
+      subject.updater.beginInstall(),
+      subject.updater.beginInstall()
+    ]
+
+    subject.updater.completeInstall()
+
+    expect({ claims, installs: subject.state.installs }).toEqual({
+      claims: [subject.updater.status(), null, null],
+      installs: 1
+    })
   })
 
-  it('does not let a later check reopen installing', () => {
+  it('refuses a claim while an update is only available', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.found('1.3.0', updateMessages.linux)
+
+    // `available` is the state packaged Linux sits in: a newer version exists
+    // and this platform cannot install it, so the GitHub backend's install()
+    // throws by design. Nothing between the button and that defect but this
+    // guard, and every other refusal here comes from the claim instead.
+    expect({
+      claim: subject.updater.beginInstall(),
+      installs: subject.state.installs,
+      state: subject.updater.status().state
+    }).toEqual({ claim: null, installs: 0, state: 'available' })
+  })
+
+  it('does not let a later check reopen the claim', () => {
     const subject = makeSubject()
 
     subject.updater.check()
     subject.emit.downloaded('1.3.0')
-    subject.updater.install()
+    subject.updater.beginInstall()
 
     // A check cannot start while an update is ready, but the events behind one
     // can still arrive — a second downloaded must not license a second swap.
     subject.emit.downloaded('1.4.0')
 
-    expect(subject.updater.install()).toEqual(false)
-    expect(subject.state.installs).toEqual(1)
+    expect(subject.updater.beginInstall()).toEqual(null)
+  })
+
+  it('does not let a later download reopen the claim', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.downloaded('1.3.0')
+    subject.updater.beginInstall()
+
+    // A ready update blocks `check`, but a failure afterwards unblocks it, so
+    // the scheduled check can run and land a second download while the first
+    // install is still on its way to the backend. The claim is one-way: the app
+    // is already being replaced, and Squirrel would swap the bundle twice.
+    subject.emit.failed(new Error('the feed went away'))
+    subject.updater.check()
+    subject.emit.downloaded('1.4.0')
+
+    expect({
+      claim: subject.updater.beginInstall(),
+      state: subject.updater.status().state
+    }).toEqual({ claim: null, state: 'ready' })
   })
 
   it('removes its listeners when disposed', () => {
@@ -394,14 +454,14 @@ describe('createUpdater', () => {
       expect(subject.state.subscribed).toEqual(false)
     })
 
-    it('never checks or installs', () => {
+    it('never checks or claims an install', () => {
       const subject = makeSubject({
         unsupported: updateMessages.notInApplicationsFolder
       })
 
       subject.updater.check()
 
-      expect(subject.updater.install()).toEqual(false)
+      expect(subject.updater.beginInstall()).toEqual(null)
       expect(subject.state).toEqual({
         checks: 0,
         installs: 0,

--- a/src/main/updates/updater.ts
+++ b/src/main/updates/updater.ts
@@ -9,6 +9,8 @@
 // arrive through an UpdateBackend, so the transitions can be driven by a fake.
 // `src/main/updates/electron-updater.ts` builds the real backends.
 
+import invariant from 'tiny-invariant'
+
 export type UpdateState =
   // A newer version exists but this platform cannot install it itself.
   | 'available'
@@ -63,13 +65,16 @@ export interface UpdaterOptions {
 }
 
 export interface Updater {
+  // Claims the install: the ready status when this caller got it, null when
+  // nothing is ready or someone already holds it — the caller's cue to answer
+  // the request with an error rather than restarting the app. Only one caller
+  // can ever hold the claim, so the app can only be told to swap itself once.
+  beginInstall(): UpdateStatus | null
   check(): void
+  // Hands the claimed install to the backend. Reachable only by whoever
+  // `beginInstall` said yes to.
+  completeInstall(): void
   dispose(): void
-  // False when nothing is ready to install — the caller's cue to answer the
-  // request with an error rather than restarting the app — and also false for
-  // every call after the first, so the app can only ever be told to swap
-  // itself once.
-  install(): boolean
   status(): UpdateStatus
 }
 
@@ -81,6 +86,8 @@ export const updateMessages = {
   developmentBuild: 'Updates are only available in a packaged build.',
   downloadFailed:
     'The update could not be downloaded. Squeal will try again later, or you can download it from the release page.',
+  installUnderway:
+    'Squeal is already installing an update — it will restart on its own in a moment.',
   linux:
     'Squeal cannot update itself on Linux. Download the latest .deb or .rpm from the release page.',
   notInApplicationsFolder:
@@ -170,9 +177,12 @@ export function createUpdater(options: UpdaterOptions): Updater {
       ? idleStatus
       : { ...idleStatus, message: unsupported, state: 'unsupported' }
 
-  // One-way: once the app has been told to replace itself there is nothing to
-  // reset it for, and the process is on its way out.
-  let installing = false
+  // One-way: once someone holds the claim there is nothing to release it for,
+  // and the process is on its way out. Nothing resets it if the holder is
+  // interrupted before handing the install over — that costs the user an update
+  // they asked for, but it is only reachable during shutdown, where the install
+  // was going to be abandoned anyway.
+  let claimed = false
 
   function fail(error: unknown, message: string): void {
     status = { ...status, lastCheckedAt: now(), message, state: 'error' }
@@ -229,6 +239,23 @@ export function createUpdater(options: UpdaterOptions): Updater {
       : (): void => undefined
 
   return {
+    beginInstall(): UpdateStatus | null {
+      // The claim is taken here, at ask time, rather than at hand-off time.
+      // The install reaches the backend on a short delay so the HTTP response
+      // can leave first, and that gap is exactly the window a retry or a second
+      // client can ask in — a latch taken on the far side of it still refuses
+      // the duplicate hand-off, so the bundle was never swapped twice. What it
+      // cannot do is say so: it closes after the answer has already gone out,
+      // and the second caller is told 200 for an install that was dropped.
+      if (status.state !== 'ready' || claimed) {
+        return null
+      }
+
+      claimed = true
+
+      return status
+    },
+
     check(): void {
       // Squirrel downloads the update again for every extra `checkForUpdates()`
       // call, and once one is ready there is nothing left to learn.
@@ -251,25 +278,14 @@ export function createUpdater(options: UpdaterOptions): Updater {
       }
     },
 
-    dispose(): void {
-      unsubscribe()
-    },
-
-    install(): boolean {
-      // Idempotent rather than merely guarded. The install is handed to the
-      // backend on a short delay so the HTTP response can reach the renderer
-      // first, which leaves a window where a retry or a second client can ask
-      // again — and Squirrel spawns its installer per quitAndInstall call, so
-      // the second one buys a redundant swap of the bundle being replaced.
-      if (status.state !== 'ready' || installing) {
-        return false
-      }
-
-      installing = true
+    completeInstall(): void {
+      invariant(claimed, 'The install was claimed before it was handed over.')
 
       backend.install()
+    },
 
-      return true
+    dispose(): void {
+      unsubscribe()
     },
 
     status(): UpdateStatus {

--- a/src/server/services/updater.test.ts
+++ b/src/server/services/updater.test.ts
@@ -1,0 +1,165 @@
+// Builds the shipped `Updater.Default` with `makeElectronUpdater` replaced by a
+// real `createUpdater` over a fake backend. That substitution is what makes the
+// claim window visible: the gap between answering the request and handing the
+// install over is where a second request arrives, and the `effect-test-helper`
+// stub used by the HTTP tests re-implements the predicate rather than running
+// the one that ships.
+import { Duration, Effect, Exit, Fiber, TestClock } from 'effect'
+import { TestContext } from 'effect/TestContext'
+import invariant from 'tiny-invariant'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { updateMessages, type UpdateHandlers } from '@/main/updates/updater'
+import { Updater } from './updater'
+
+const harness = vi.hoisted(() => ({
+  emit: null as UpdateHandlers | null,
+  installs: 0
+}))
+
+vi.mock('@/main/updates/electron-updater', async () => {
+  // `vi.importActual` rather than the module's own import, because this factory
+  // is hoisted above it. `electron-updater` imports Electron at module scope,
+  // so mocking it is also what keeps this file runnable outside the app.
+  const { createUpdater } = await vi.importActual<
+    typeof import('@/main/updates/updater')
+  >('@/main/updates/updater')
+
+  return {
+    makeElectronUpdater: () =>
+      createUpdater({
+        backend: {
+          check: () => undefined,
+          install: () => {
+            harness.installs += 1
+          },
+          subscribe: (handlers: UpdateHandlers) => {
+            harness.emit = handlers
+
+            return () => {
+              harness.emit = null
+            }
+          }
+        },
+        currentVersion: '1.2.0',
+        logError: () => undefined,
+        now: () => 1700000000000,
+        unsupported: null
+      })
+  }
+})
+
+function run<A, E>(
+  body: (updater: Updater) => Effect.Effect<A, E>
+): Promise<Exit.Exit<A, E>> {
+  return Effect.runPromiseExit(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const updater = yield* Updater
+
+        return yield* body(updater)
+      }).pipe(Effect.provide(Updater.Default))
+    ).pipe(Effect.provide(TestContext))
+  )
+}
+
+// The backend reports a finished download, which is what puts the updater in
+// the only state an install can be claimed from.
+const readyForInstall = Effect.sync(() => {
+  invariant(harness.emit, 'The updater subscribed to the backend.')
+
+  harness.emit.downloaded('1.3.0')
+})
+
+describe('Updater.install', () => {
+  beforeEach(() => {
+    harness.emit = null
+    harness.installs = 0
+  })
+
+  it('refuses when nothing is ready', async () => {
+    const exit = await run((updater) =>
+      Effect.gen(function* () {
+        const error = yield* Effect.flip(updater.install())
+
+        // The message is pulled out as a string rather than compared through
+        // the error: `toEqual` on two `UpdateNotReadyError`s passes whatever
+        // they say, so an assertion on the instance cannot tell this refusal
+        // from the one below it.
+        return { installs: harness.installs, message: error.message }
+      })
+    )
+
+    expect(exit).toEqual(
+      Exit.succeed({ installs: 0, message: updateMessages.notReady })
+    )
+  })
+
+  it('answers before handing the install to the backend', async () => {
+    const exit = await run((updater) =>
+      Effect.gen(function* () {
+        yield* readyForInstall
+
+        // Forked and joined rather than yielded here, because in production
+        // the request fiber is gone before the timer fires. A timer forked
+        // into the request's own scope would be interrupted at that point and
+        // every install would answer 200 and then quietly do nothing -- a
+        // change that typechecks, and that a test holding the parent fiber
+        // open across the clock adjustment cannot see.
+        const request = yield* Effect.fork(updater.install())
+        const status = yield* Fiber.join(request)
+
+        // quitAndInstall closes every window and the before-quit handler then
+        // disposes the HTTP server, so an install that reached the backend by
+        // the time this returned would tear down the server still answering
+        // the request.
+        const whenAnswered = harness.installs
+
+        yield* TestClock.adjust(Duration.millis(250))
+
+        return {
+          onceDelayed: harness.installs,
+          state: status.state,
+          whenAnswered
+        }
+      })
+    )
+
+    expect(exit).toEqual(
+      Exit.succeed({ onceDelayed: 1, state: 'ready', whenAnswered: 0 })
+    )
+  })
+
+  it('refuses a second request inside the delay window', async () => {
+    const exit = await run((updater) =>
+      Effect.gen(function* () {
+        yield* readyForInstall
+
+        const first = yield* updater.install()
+
+        // A retry, or a second window. The clock has not moved, so the first
+        // install has not reached the backend yet and the updater still reports
+        // `ready` -- a decision that consults the status rather than the claim
+        // answers this one with a 200 and then silently drops it. The message
+        // has to match the situation too: nothing here is "not ready".
+        const error = yield* Effect.flip(updater.install())
+
+        yield* TestClock.adjust(Duration.millis(250))
+
+        return {
+          installs: harness.installs,
+          message: error.message,
+          state: first.state
+        }
+      })
+    )
+
+    expect(exit).toEqual(
+      Exit.succeed({
+        installs: 1,
+        message: updateMessages.installUnderway,
+        state: 'ready'
+      })
+    )
+  })
+})

--- a/src/server/services/updater.ts
+++ b/src/server/services/updater.ts
@@ -35,20 +35,31 @@ export class Updater extends Effect.Service<Updater>()('Updater', {
     const status = Effect.sync(() => updater.status())
 
     const install = Effect.fn('Updater.install')(function* () {
-      const current = updater.status()
+      // One evaluation decides both the response and the claim, so a second
+      // request inside the delay below is refused with the 409 the contract
+      // promises rather than being handed a 200 and silently dropped.
+      const claimed = yield* Effect.sync(() => updater.beginInstall())
 
-      if (current.state !== 'ready') {
+      if (claimed === null) {
+        // The status is read only to pick the prose. It has no say in the
+        // refusal — that was already decided above — so the two cannot
+        // disagree the way the guard this replaced could.
+        const { state } = yield* status
+
         return yield* new UpdateNotReadyError({
-          message: updateMessages.notReady
+          message:
+            state === 'ready'
+              ? updateMessages.installUnderway
+              : updateMessages.notReady
         })
       }
 
       yield* Effect.sleep(installDelay).pipe(
-        Effect.andThen(Effect.sync(() => updater.install())),
+        Effect.andThen(Effect.sync(() => updater.completeInstall())),
         Effect.forkIn(scope)
       )
 
-      return current
+      return claimed
     })
 
     return { check, install, status }


### PR DESCRIPTION
Closes #51

## The duplication

"Is an update ready to install" was decided twice and the authoritative answer thrown away. `updater.install()` documented its boolean as the caller's cue to answer with an error instead of restarting the app, and `services/updater.ts` dropped it on the floor — it had already made the same decision itself from `updater.status()`. `effect-test-helper.ts` re-implements the predicate a third time.

## The consequence

The install is handed to the backend after a 250ms delay so the HTTP response can leave before the app starts quitting under it, and the latch was claimed on the far side of that delay. Two POSTs inside that window both saw `state: 'ready'`, both got a 200, and both forked.

The bundle was never swapped twice — the latch still refused the second hand-off. But it closed *after* the second answer had already gone out, so that caller was told 200 for an install that was silently dropped. The contract promises a 409 `UpdateNotReadyError`.

## The change

`install(): boolean` becomes `beginInstall(): UpdateStatus | null` plus `completeInstall(): void`. The claim is taken at ask time, so one evaluation produces both the response and the latch, and the service has nothing left to re-decide. The dead boolean goes with it.

The refusal picks its prose from the status without letting the status have a say in the refusal itself: `ready` means someone else is already installing, anything else means nothing is ready. The two can no longer disagree the way the guard this replaced could.

The claim stays one-way. Nothing releases it if the holder is interrupted between claiming and handing over, which costs the user an update they asked for — reachable only during shutdown, where the install was going to be abandoned anyway. Noted at the latch.

The service's public interface is unchanged, so `handlers/updates.ts` and the test stub are untouched.

## Tests

New `src/server/services/updater.test.ts` builds the shipped `Updater.Default` with `makeElectronUpdater` mocked out for a real `createUpdater` over a fake backend — the service body had no test seam at all before, which is why three mutations survived until it existed.

Its race test forks the request and joins it rather than yielding the install inline: in production the request fiber is gone before the timer fires, so a timer forked into the request's own scope would answer 200 and then quietly do nothing — and a test holding the parent fiber open across the clock adjustment cannot see that.

Refusal messages are asserted as strings rather than through the error. `toEqual` on two `UpdateNotReadyError`s passes whatever they say, so comparing instances could not tell the two refusals apart.

Fifteen mutations tried across both files; fourteen killed. The survivor is deleting the `invariant` in `completeInstall` — it guards a hand-off without a claim, which no shipped caller can reach now that the two come from the same evaluation.

`yarn test` (backend 181, renderer updater state machine 31), `yarn typecheck`, and `eslint` are clean.
