### PR TITLE
fix(postgres): hold one lifecycle so a cancel is never dropped

### DIFF
--- a/src/databases/postgres-adapter.test.ts
+++ b/src/databases/postgres-adapter.test.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance
+} from 'vitest'
 
 interface CursorFixture {
   error?: Error
@@ -14,29 +22,36 @@ interface CursorFixture {
   rows: Record<string, unknown>[]
 }
 
-const { cursorState, mockConnect, mockEnd, mockQuery } = vi.hoisted(() => ({
-  cursorState: {
-    closeCount: 0,
-    createdWith: [] as string[],
-    fixtures: [] as CursorFixture[],
-    readRequests: [] as number[]
-  },
-  mockConnect: vi.fn(),
-  mockEnd: vi.fn(),
-  mockQuery: vi.fn()
-}))
+const { clientState, cursorState, mockConnect, mockEnd, mockQuery } =
+  vi.hoisted(() => ({
+    // node-postgres learns the backend process id during connect, so a client
+    // only carries one once the server has answered. Undefined is the default
+    // because that is what a client that never connected looks like.
+    clientState: { processId: undefined as number | undefined },
+    cursorState: {
+      closeCount: 0,
+      createdWith: [] as string[],
+      fixtures: [] as CursorFixture[],
+      readRequests: [] as number[]
+    },
+    mockConnect: vi.fn(),
+    mockEnd: vi.fn(),
+    mockQuery: vi.fn()
+  }))
 
 vi.mock('pg', () => {
   // Constructor-function mock, so `this` needs the shape it assigns.
   interface MockClientInstance {
     connect: typeof mockConnect
     end: typeof mockEnd
+    processID: number | undefined
     query: typeof mockQuery
   }
 
   function MockClient(this: MockClientInstance) {
     this.connect = mockConnect
     this.end = mockEnd
+    this.processID = clientState.processId
     this.query = mockQuery
   }
 
@@ -758,15 +773,27 @@ describe('connectWithRetry', () => {
 })
 
 describe('PostgresAdapter cancellation', () => {
+  // Silenced for the whole suite rather than the one test that asserts on it:
+  // the failing-cancel path logs, so a test merely exercising it would print a
+  // real outage line during a green run.
+  let logged: MockInstance<typeof console.log>
+
   beforeEach(() => {
     vi.clearAllMocks()
 
+    clientState.processId = undefined
     cursorState.closeCount = 0
     cursorState.createdWith.length = 0
     cursorState.fixtures.length = 0
     cursorState.readRequests.length = 0
 
+    logged = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
     mockQuery.mockImplementation((input: unknown) => input)
+  })
+
+  afterEach(() => {
+    logged.mockRestore()
   })
 
   it('fails fast when canceled before connecting', async () => {
@@ -899,5 +926,210 @@ describe('PostgresAdapter cancellation', () => {
 
     expect(mockConnect).not.toHaveBeenCalled()
     expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  it('asks the server to cancel the running backend', async () => {
+    clientState.processId = 4242
+
+    const adapter = new PostgresAdapter(connectionInfo)
+
+    let cancelPromise: Promise<void> | undefined
+
+    cursorState.fixtures.push({
+      error: driverError('canceling statement due to user request', '57014'),
+      fields: [],
+      onRead: () => {
+        cancelPromise ??= adapter.cancel()
+      },
+      rows: []
+    })
+
+    await expect(adapter.runQuery('SELECT pg_sleep(60)')).rejects.toEqual(
+      new QueryCanceledError()
+    )
+
+    await cancelPromise
+
+    // The connection running the statement is busy, so the request has to come
+    // over a second one — and it has to name the backend, or the server is
+    // asked to cancel nothing at all.
+    expect({
+      clientsConstructed: vi.mocked(Client).mock.calls.length,
+      statements: mockQuery.mock.calls.filter(
+        ([statement]) => typeof statement === 'string'
+      )
+    }).toEqual({
+      clientsConstructed: 2,
+      statements: [['SELECT pg_cancel_backend($1)', [4242]]]
+    })
+  })
+
+  it('resolves even when the cancel connection cannot be opened', async () => {
+    clientState.processId = 4242
+
+    // The query's own client connects; the throwaway one the cancel opens does
+    // not.
+    mockConnect.mockResolvedValueOnce(undefined)
+    mockConnect.mockRejectedValueOnce(new Error('Connection refused'))
+
+    const adapter = new PostgresAdapter(connectionInfo)
+
+    let cancelPromise: Promise<void> | undefined
+
+    cursorState.fixtures.push({
+      error: driverError('canceling statement due to user request', '57014'),
+      fields: [],
+      onRead: () => {
+        cancelPromise ??= adapter.cancel()
+      },
+      rows: []
+    })
+
+    await expect(adapter.runQuery('SELECT pg_sleep(60)')).rejects.toEqual(
+      new QueryCanceledError()
+    )
+
+    // A cancel that cannot reach the server is reported, not thrown: the route
+    // answers, the query keeps running, and the user can ask again.
+    await expect(cancelPromise).resolves.toBeUndefined()
+    expect(logged.mock.calls.map(String).join(' ')).toContain(
+      'Could not cancel the running query'
+    )
+  })
+
+  // The connect resolving and the statement starting are not the same instant.
+  // The adapter used to let go of the connecting client and only take hold of
+  // the running one several turns later, and a cancel arriving in between found
+  // nothing to act on — so the query the user had just canceled ran to
+  // completion and was recorded as a success.
+  it('reports a cancel that lands between connecting and executing', async () => {
+    clientState.processId = 4242
+
+    let finishConnecting: (() => void) | undefined
+
+    mockConnect.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishConnecting = () => resolve()
+        })
+    )
+
+    cursorState.fixtures.push({
+      fields: [{ name: 'id' }],
+      rowCount: 1,
+      rows: [{ id: 1 }]
+    })
+
+    const adapter = new PostgresAdapter(connectionInfo)
+    const runPromise = adapter.runQuery('SELECT id FROM users')
+
+    await vi.waitFor(() => {
+      expect(mockConnect).toHaveBeenCalled()
+    })
+
+    finishConnecting?.()
+
+    // One turn of the microtask queue: the earliest moment anything outside the
+    // adapter can look, and still long before `runQuery` resumes to send the
+    // statement. The connection is already owned as the running one by then —
+    // the request below is what proves it, since a handover left for later would
+    // have this cancel tearing down a connecting socket instead.
+    //
+    // Measured: this test passes at one, two, and three turns and fails at zero
+    // and at four. The count is load-bearing, so a refactor that adds or removes
+    // an async frame in `acquireConnection` will fail this — loudly, but looking
+    // like a product bug. Both edges are real: at zero the cancel takes the
+    // `connecting` branch and never asks the server, at four the statement has
+    // already gone out.
+    await Promise.resolve()
+
+    const cancelPromise = adapter.cancel()
+
+    await expect(runPromise).rejects.toEqual(new QueryCanceledError())
+
+    await cancelPromise
+
+    expect({
+      requested: mockQuery.mock.calls.filter(
+        ([statement]) => typeof statement === 'string'
+      ),
+      statements: cursorState.createdWith
+    }).toEqual({
+      requested: [['SELECT pg_cancel_backend($1)', [4242]]],
+      statements: []
+    })
+  })
+
+  // The other side of the same instant: the user gives up while the connect is
+  // still in flight and the server answers anyway. Aborting the socket comes too
+  // late to matter, so all that is left is the record that they asked — and a
+  // handover that overwrites it hands the query a connection to run on.
+  it('reports a cancel the connection beat by a moment', async () => {
+    let finishConnecting: (() => void) | undefined
+
+    mockConnect.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishConnecting = () => resolve()
+        })
+    )
+
+    cursorState.fixtures.push({
+      fields: [{ name: 'id' }],
+      rowCount: 1,
+      rows: [{ id: 1 }]
+    })
+
+    const adapter = new PostgresAdapter(connectionInfo)
+    const runPromise = adapter.runQuery('SELECT id FROM users')
+
+    await vi.waitFor(() => {
+      expect(mockConnect).toHaveBeenCalled()
+    })
+
+    const cancelPromise = adapter.cancel()
+
+    finishConnecting?.()
+
+    await expect(runPromise).rejects.toEqual(new QueryCanceledError())
+
+    await cancelPromise
+
+    // No request over a second connection is the half that says which branch
+    // ran: this cancel tore down a socket that was still connecting, rather
+    // than naming a backend that was never reached.
+    expect({
+      requested: mockQuery.mock.calls.filter(
+        ([statement]) => typeof statement === 'string'
+      ),
+      statements: cursorState.createdWith
+    }).toEqual({ requested: [], statements: [] })
+  })
+
+  // The backoff between two connect attempts is the longest stretch in which
+  // the adapter holds nothing at all, so a cancel landing there has only the
+  // record of itself to leave behind — and the top of the next attempt is the
+  // one place that record can be read. Without it, giving up on a server that
+  // is refusing connections still waits out the whole retry schedule.
+  it('answers a cancel that lands during the backoff', async () => {
+    mockConnect.mockRejectedValueOnce(
+      new Error('sorry, too many clients already')
+    )
+
+    const adapter = new PostgresAdapter(connectionInfo)
+    const runPromise = adapter.runQuery('SELECT id FROM users')
+
+    await vi.waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledTimes(1)
+    })
+
+    await adapter.cancel()
+
+    await expect(runPromise).rejects.toEqual(new QueryCanceledError())
+
+    expect({
+      connects: mockConnect.mock.calls.length,
+      statements: cursorState.createdWith
+    }).toEqual({ connects: 1, statements: [] })
   })
 })

--- a/src/databases/postgres-adapter.ts
+++ b/src/databases/postgres-adapter.ts
@@ -27,66 +27,66 @@ import {
 } from './server-version'
 import { createSslOptions } from './ssl-options'
 
+// One adapter runs one operation at a time — the factory builds a fresh one
+// per connection — so its whole lifecycle is a single value. Three independent
+// fields could not say that: a client handed on from connecting to running
+// passed through a moment where every field read as "nothing here", and a
+// cancel arriving in it had nothing to act on.
+type AdapterState =
+  | { kind: 'canceled' }
+  | { client: Client; kind: 'connecting' }
+  | { kind: 'idle' }
+  | { client: Client; kind: 'running' }
+
 export class PostgresAdapter implements DatabaseAdapter {
   protected readonly connectionInfo: PostgresConnectionInfo
 
-  private activeClient: Client | null = null
-
-  private canceled = false
-
-  private connectingClient: Client | null = null
+  private state: AdapterState = { kind: 'idle' }
 
   constructor(connectionInfo: PostgresConnectionInfo) {
     this.connectionInfo = connectionInfo
   }
 
+  // Every branch has to be non-throwing: shutdown cancels running queries
+  // inside a five second budget, and a rejection there would abort the rest of
+  // it.
   async cancel(): Promise<void> {
-    this.canceled = true
+    const state = this.state
 
-    // A connect still in flight can simply be aborted — ending the client
-    // tears down the socket and the pending connect rejects.
-    const connectingClient = this.connectingClient
+    // Recorded before anything is awaited, and never cleared. The steps this
+    // query still has ahead of it each check it, so an answer that only lived
+    // as long as a handle would be lost exactly in the moments no handle
+    // exists.
+    this.state = { kind: 'canceled' }
 
-    if (connectingClient) {
-      try {
-        await connectingClient.end()
-      } catch {
-        // Aborting is best-effort; the connect rejecting is what matters.
+    switch (state.kind) {
+      case 'canceled':
+      case 'idle': {
+        return
       }
 
-      return
-    }
+      // A connect still in flight can simply be aborted — ending the client
+      // tears down the socket and the pending connect rejects.
+      case 'connecting': {
+        try {
+          await state.client.end()
+        } catch {
+          // Aborting is best-effort; the connect rejecting is what matters.
+        }
 
-    const backendProcessId = getBackendProcessId(this.activeClient)
+        return
+      }
 
-    if (!backendProcessId) {
-      return
-    }
+      case 'running': {
+        return await this.cancelBackend(state.client)
+      }
 
-    // Postgres cancellation must be issued over a separate connection — the
-    // one running the query is busy — so we open a throwaway client and ask
-    // the server to cancel the running backend. A failed cancel must not
-    // reject the cancel route: the query keeps running and can be canceled
-    // again.
-    const cancelClient = new Client(createClientConfig(this.connectionInfo))
+      // A fifth kind would otherwise fall out of the switch and return as if
+      // there had been nothing to cancel.
+      default: {
+        const unhandled: never = state
 
-    try {
-      await cancelClient.connect()
-
-      await cancelClient.query('SELECT pg_cancel_backend($1)', [
-        backendProcessId
-      ])
-    } catch (error) {
-      log.warn(
-        `Could not cancel the running query: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      )
-    } finally {
-      try {
-        await cancelClient.end()
-      } catch {
-        // Cleanup is best-effort.
+        return unhandled
       }
     }
   }
@@ -99,6 +99,8 @@ export class PostgresAdapter implements DatabaseAdapter {
     try {
       return await this.getSchemaWithClient(client)
     } finally {
+      this.release()
+
       await closeQuietly(() => client.end(), 'schema')
     }
   }
@@ -133,9 +135,17 @@ export class PostgresAdapter implements DatabaseAdapter {
   async runQuery(query: string): Promise<QueryResult> {
     const client = await this.acquireConnection()
 
-    this.activeClient = client
-
     try {
+      // Asked once, here, rather than left to the statement to notice: a
+      // cancel that lands while the connection is being handed over reaches
+      // the server before any statement does, so there is nothing running for
+      // pg_cancel_backend to stop and no 57014 coming back. Without this the
+      // query the user just canceled runs to completion and is recorded as a
+      // success.
+      if (this.canceled) {
+        throw new QueryCanceledError()
+      }
+
       return await this.executeWithIdentifierRetry(client, query)
     } catch (error) {
       // Wraps the whole attempt rather than the statement alone, so it also
@@ -148,7 +158,7 @@ export class PostgresAdapter implements DatabaseAdapter {
 
       throw error
     } finally {
-      this.activeClient = null
+      this.release()
 
       await closeQuietly(() => client.end(), 'query')
     }
@@ -163,6 +173,9 @@ export class PostgresAdapter implements DatabaseAdapter {
   ): Promise<Client> {
     return connectWithRetry(
       async () => {
+        // Each attempt re-enters `connecting` with its own client, and this is
+        // also where a cancel that landed during the backoff between two of
+        // them stops the next one from being opened at all.
         if (this.canceled) {
           throw new QueryCanceledError()
         }
@@ -172,14 +185,12 @@ export class PostgresAdapter implements DatabaseAdapter {
           ...configOverrides
         })
 
-        // Exposed so cancel() can abort a connect still in flight instead of
+        // Held so cancel() can abort a connect still in flight instead of
         // silently doing nothing before the query reaches the server.
-        this.connectingClient = client
+        this.state = { client, kind: 'connecting' }
 
         try {
           await client.connect()
-
-          return client
         } catch (error) {
           // A client that failed to connect can't be reused; drop it before
           // the next attempt so we never leak a half-open connection.
@@ -193,10 +204,23 @@ export class PostgresAdapter implements DatabaseAdapter {
             throw new QueryCanceledError()
           }
 
+          // Nothing is in flight between attempts, so there is nothing for a
+          // cancel arriving now to tear down — only the check above to find.
+          this.state = { kind: 'idle' }
+
           throw error
-        } finally {
-          this.connectingClient = null
         }
+
+        // In the same step the connect resolves in, with nothing awaited
+        // between: the handle goes straight from one state to the next rather
+        // than through a gap where the adapter is holding nothing.
+        if (this.canceled) {
+          throw new QueryCanceledError()
+        }
+
+        this.state = { client, kind: 'running' }
+
+        return client
       },
       {
         delays: connectionRetryDelays,
@@ -207,6 +231,54 @@ export class PostgresAdapter implements DatabaseAdapter {
           )
       }
     )
+  }
+
+  // Postgres cancellation must be issued over a separate connection — the one
+  // running the query is busy — so we open a throwaway client and ask the
+  // server to cancel the running backend. A failed cancel must not reject the
+  // cancel route: the query keeps running and can be canceled again.
+  private async cancelBackend(client: Client): Promise<void> {
+    const backendProcessId = getBackendProcessId(client)
+
+    if (!backendProcessId) {
+      return
+    }
+
+    // Inside the try because building the config reads the CA file off disk:
+    // a certificate moved or deleted since the query started would otherwise
+    // throw out of `cancel()` itself, which every branch here promises not to
+    // do.
+    let cancelClient: Client | undefined
+
+    try {
+      cancelClient = new Client(createClientConfig(this.connectionInfo))
+
+      await cancelClient.connect()
+
+      await cancelClient.query('SELECT pg_cancel_backend($1)', [
+        backendProcessId
+      ])
+    } catch (error) {
+      log.warn(
+        `Could not cancel the running query: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    } finally {
+      try {
+        await cancelClient?.end()
+      } catch {
+        // Cleanup is best-effort.
+      }
+    }
+  }
+
+  // Read through a getter rather than by comparing `this.state` at each call
+  // site: the compiler narrows a field it has just seen assigned, and calls two
+  // of these five checks unreachable — the opposite of the truth, since both
+  // exist because a cancel can land between the assignment and the check.
+  private get canceled(): boolean {
+    return this.state.kind === 'canceled'
   }
 
   private async executeQuery(
@@ -303,6 +375,15 @@ export class PostgresAdapter implements DatabaseAdapter {
       columnsResult.rows,
       foreignKeysResult.rows
     )
+  }
+
+  // Only from `running`: `canceled` is terminal, so an operation finishing
+  // after the user asked to stop it must not hand the adapter back as if
+  // nothing had been asked.
+  private release(): void {
+    if (this.state.kind === 'running') {
+      this.state = { kind: 'idle' }
+    }
   }
 
   async testConnection(): Promise<void> {
@@ -467,8 +548,8 @@ function toQueryResult(
 
 // node-postgres exposes the backend process id at runtime, but it is not
 // present on the published Client type.
-function getBackendProcessId(client: Client | null): number | undefined {
-  if (!client || !('processID' in client)) {
+function getBackendProcessId(client: Client): number | undefined {
+  if (!('processID' in client)) {
     return undefined
   }
 


### PR DESCRIPTION
Closes #54.

`PostgresAdapter` tracked its connection in two independent fields — a connecting handle and a running one — plus a boolean. Handing a client from one to the other was not a single step: the connecting handle was released, `runQuery` resumed several turns later, and only then was the running one taken. A cancel arriving in that gap found nothing to act on.

It did not merely do nothing. `cancel()` reaches the server over a second connection and asks it to stop the running backend; the query notices by catching a 57014 back from its own statement. In the gap there is no backend to name and no statement in flight, so nothing is sent and nothing comes back. The row is still written as canceled — `QueryRunner.cancel` sets `isCanceled` before it ever asks the adapter, and `execute` re-reads it after the statement returns — so the user sees the right answer. What they do not get is the thing they asked for: the statement runs to completion on the server, holding its locks and burning its CPU, and the cancel only appears once it is finished on its own.

## The change

The three fields become one `AdapterState` union: `idle`, `connecting`, `running`, `canceled`.

The union is what makes the gap unrepresentable — the client moves from `connecting` to `running` in the same step the connect resolves in, with nothing awaited between, so there is no moment where the adapter is holding nothing. `canceled` is terminal and carries no client, which is what lets a cancel that lands before any connection exists still be answered: `runQuery` asks once more after acquiring the connection, and `cancel()` becomes one exhaustive switch instead of two nullable checks in sequence.

The check after acquiring is read through a `canceled` getter rather than by comparing `this.state` directly. The compiler narrows a field it has just seen assigned and calls two of the five checks unreachable — the opposite of the truth, since both exist because a cancel can land between the assignment and the check.

## Tests

Two regression tests pin the two sides of that instant:

- a cancel landing after the connect resolves but before the statement is sent, which must reach `pg_cancel_backend`
- a cancel landing while the connect is still in flight and answered anyway, which must not let the query run

Both fail against the previous shape (verified: 2 failed | 40 passed against `main`'s adapter).

A third — a cancel landing in the backoff between two connect attempts — passes against the previous shape too. It is there to pin behaviour this rewrite could easily have dropped, not to report a bug that existed.

Twelve mutations tried, ten killed. The two survivors are unobservable through the public surface: leaving a failed attempt in `connecting` (both shapes end in the same place through non-throwing branches) and letting `release()` clear a cancel (an adapter runs one operation and `AdapterFactory.create` builds a fresh one per connection, so nothing reuses it afterwards).

`postgres-adapter.test.ts`: 42 passed. Full renderer suite: 778 passed, 1 pre-existing failure (`sqlite-adapter.test.ts > testConnection`, a Windows file-URL path artifact present on `main`).
