### PR TITLE
refactor(main): ask Electron for the window instead of remembering it

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockAppOn,
+  mockGetAllWindows,
+  mockIpcHandle,
+  mockBrowserWindowConstructor
+} = vi.hoisted(() => ({
+  mockAppOn: vi.fn(),
+  mockGetAllWindows: vi.fn(),
+  mockIpcHandle: vi.fn(),
+  mockBrowserWindowConstructor: vi.fn()
+}))
+
+vi.mock('electron', () => {
+  class BrowserWindow {
+    webContents = {
+      on: vi.fn(),
+      setWindowOpenHandler: vi.fn()
+    }
+
+    static getAllWindows = mockGetAllWindows
+
+    constructor(options: unknown) {
+      mockBrowserWindowConstructor(options)
+    }
+
+    loadFile = vi.fn()
+    loadURL = vi.fn()
+  }
+
+  return {
+    app: {
+      commandLine: { appendSwitch: vi.fn() },
+      exit: vi.fn(),
+      getAppPath: () => '/app',
+      getPath: () => '/tmp',
+      isPackaged: false,
+      on: mockAppOn,
+      quit: vi.fn(),
+      requestSingleInstanceLock: () => true
+    },
+    BrowserWindow,
+    dialog: { showErrorBox: vi.fn(), showOpenDialog: vi.fn() },
+    ipcMain: { handle: mockIpcHandle },
+    shell: { openExternal: vi.fn() }
+  }
+})
+
+vi.mock('electron-squirrel-startup', () => ({ default: false }))
+
+vi.mock('./server/runtime', () => ({
+  makeMainRuntime: vi.fn()
+}))
+
+// Injected by the Forge Vite plugin at build time, so nothing defines them when
+// the module is imported directly. An empty dev-server URL is the packaged
+// shape, which is the one that does not need a running server to load.
+Object.assign(globalThis, {
+  MAIN_WINDOW_VITE_DEV_SERVER_URL: '',
+  MAIN_WINDOW_VITE_NAME: 'main_window'
+})
+
+type FakeWindow = {
+  close: ReturnType<typeof vi.fn>
+  focus: ReturnType<typeof vi.fn>
+  isDestroyed: () => boolean
+  isMaximized: () => boolean
+  isMinimized: () => boolean
+  maximize: ReturnType<typeof vi.fn>
+  minimize: ReturnType<typeof vi.fn>
+  restore: ReturnType<typeof vi.fn>
+  unmaximize: ReturnType<typeof vi.fn>
+}
+
+function createWindow(
+  state: { maximized?: boolean; minimized?: boolean } = {}
+): FakeWindow {
+  return {
+    close: vi.fn(),
+    focus: vi.fn(),
+    isDestroyed: () => false,
+    isMaximized: () => state.maximized === true,
+    isMinimized: () => state.minimized === true,
+    maximize: vi.fn(),
+    minimize: vi.fn(),
+    restore: vi.fn(),
+    unmaximize: vi.fn()
+  }
+}
+
+// The registrations happen while the module body runs, so the import is what
+// produces them and it has to happen after the mocks are in place.
+async function bootMain(): Promise<void> {
+  vi.resetModules()
+
+  await import('./main')
+}
+
+function appHandler(event: string): () => void {
+  const registration = mockAppOn.mock.calls.find(([name]) => name === event)
+
+  if (!registration) {
+    throw new Error(`No handler was registered for the ${event} app event.`)
+  }
+
+  return registration[1] as () => void
+}
+
+function ipcHandler(channel: string): () => void {
+  const registration = mockIpcHandle.mock.calls.find(
+    ([name]) => name === channel
+  )
+
+  if (!registration) {
+    throw new Error(`No handler was registered for the ${channel} channel.`)
+  }
+
+  return registration[1] as () => void
+}
+
+// The window functions are unit tested in `main/window.test.ts`; what is left
+// untested by those is the wiring — which channel reaches which function. A
+// minimize wired to close is a data-losing bug that every test over there still
+// passes.
+describe('main', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAllWindows.mockReturnValue([])
+  })
+
+  it('closes the window from the title bar', async () => {
+    const browserWindow = createWindow()
+
+    mockGetAllWindows.mockReturnValue([browserWindow])
+
+    await bootMain()
+
+    ipcHandler('window-close')()
+
+    expect({
+      closed: browserWindow.close.mock.calls.length,
+      maximized: browserWindow.maximize.mock.calls.length,
+      minimized: browserWindow.minimize.mock.calls.length
+    }).toEqual({ closed: 1, maximized: 0, minimized: 0 })
+  })
+
+  it('maximizes the window from the title bar', async () => {
+    const browserWindow = createWindow()
+
+    mockGetAllWindows.mockReturnValue([browserWindow])
+
+    await bootMain()
+
+    ipcHandler('window-maximize')()
+
+    expect({
+      closed: browserWindow.close.mock.calls.length,
+      maximized: browserWindow.maximize.mock.calls.length,
+      minimized: browserWindow.minimize.mock.calls.length
+    }).toEqual({ closed: 0, maximized: 1, minimized: 0 })
+  })
+
+  it('minimizes the window from the title bar', async () => {
+    const browserWindow = createWindow()
+
+    mockGetAllWindows.mockReturnValue([browserWindow])
+
+    await bootMain()
+
+    ipcHandler('window-minimize')()
+
+    expect({
+      closed: browserWindow.close.mock.calls.length,
+      maximized: browserWindow.maximize.mock.calls.length,
+      minimized: browserWindow.minimize.mock.calls.length
+    }).toEqual({ closed: 0, maximized: 0, minimized: 1 })
+  })
+
+  it('opens a window when the app is activated with none open', async () => {
+    await bootMain()
+
+    appHandler('activate')()
+
+    expect(mockBrowserWindowConstructor).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens no second window when the app is activated with one open', async () => {
+    mockGetAllWindows.mockReturnValue([createWindow()])
+
+    await bootMain()
+
+    appHandler('activate')()
+
+    expect(mockBrowserWindowConstructor).toHaveBeenCalledTimes(0)
+  })
+
+  it('raises the running window when a second instance is launched', async () => {
+    const browserWindow = createWindow({ minimized: true })
+
+    mockGetAllWindows.mockReturnValue([browserWindow])
+
+    await bootMain()
+
+    appHandler('second-instance')()
+
+    expect({
+      focused: browserWindow.focus.mock.calls.length,
+      restored: browserWindow.restore.mock.calls.length
+    }).toEqual({ focused: 1, restored: 1 })
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,13 @@ import path from 'node:path'
 import started from 'electron-squirrel-startup'
 import { log } from 'tiny-typescript-logger'
 
+import {
+  closeMainWindow,
+  focusMainWindow,
+  getMainWindow,
+  minimizeMainWindow,
+  toggleMainWindowMaximized
+} from './main/window'
 import { makeMainRuntime, type MainRuntime } from './server/runtime'
 
 if (!app.isPackaged) {
@@ -17,19 +24,15 @@ let apiToken = ''
 ipcMain.handle('get-api-token', () => apiToken)
 
 ipcMain.handle('window-minimize', () => {
-  mainWindow?.minimize()
+  minimizeMainWindow()
 })
 
 ipcMain.handle('window-maximize', () => {
-  if (mainWindow?.isMaximized()) {
-    mainWindow.unmaximize()
-  } else {
-    mainWindow?.maximize()
-  }
+  toggleMainWindowMaximized()
 })
 
 ipcMain.handle('window-close', () => {
-  mainWindow?.close()
+  closeMainWindow()
 })
 
 ipcMain.handle('open-file-dialog', async () => {
@@ -62,8 +65,6 @@ if (!hasSingleInstanceLock) {
   app.quit()
 }
 
-export let mainWindow: BrowserWindow
-
 let runtime: MainRuntime | undefined
 let quitting = false
 let disposed = false
@@ -73,7 +74,7 @@ let disposed = false
 const disposeTimeoutMs = 3_000
 
 const createWindow = async () => {
-  mainWindow = new BrowserWindow({
+  const window = new BrowserWindow({
     frame: false,
     height: 880,
     titleBarStyle: 'hidden',
@@ -93,13 +94,13 @@ const createWindow = async () => {
     ? new URL(MAIN_WINDOW_VITE_DEV_SERVER_URL).origin
     : 'file://'
 
-  mainWindow.webContents.on('will-navigate', (event, url) => {
+  window.webContents.on('will-navigate', (event, url) => {
     if (!url.startsWith(allowedOrigin)) {
       event.preventDefault()
     }
   })
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  window.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith('https://')) {
       void shell.openExternal(url)
     }
@@ -108,9 +109,9 @@ const createWindow = async () => {
   })
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
-    mainWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL)
+    window.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL)
   } else {
-    mainWindow.loadFile(
+    window.loadFile(
       path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`)
     )
   }
@@ -208,15 +209,7 @@ app.on('ready', async () => {
 })
 
 app.on('second-instance', () => {
-  if (mainWindow === undefined) {
-    return
-  }
-
-  if (mainWindow.isMinimized()) {
-    mainWindow.restore()
-  }
-
-  mainWindow.focus()
+  focusMainWindow()
 })
 
 // The first real shutdown path this app has had: disposing the runtime
@@ -263,7 +256,9 @@ app.on('window-all-closed', () => {
 })
 
 app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
+  // Asked through the same lookup as everywhere else, so there is one answer to
+  // "is there a window?" rather than two spellings of it that can drift.
+  if (!getMainWindow()) {
     createWindow()
   }
 })

--- a/src/main/window.test.ts
+++ b/src/main/window.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetAllWindows } = vi.hoisted(() => ({
+  mockGetAllWindows: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: mockGetAllWindows
+  }
+}))
+
+import {
+  closeMainWindow,
+  focusMainWindow,
+  getMainWindow,
+  minimizeMainWindow,
+  toggleMainWindowMaximized
+} from './window'
+
+type FakeWindow = {
+  close: ReturnType<typeof vi.fn>
+  destroyed: boolean
+  focus: ReturnType<typeof vi.fn>
+  isDestroyed: () => boolean
+  isMaximized: () => boolean
+  isMinimized: () => boolean
+  maximize: ReturnType<typeof vi.fn>
+  maximized: boolean
+  minimize: ReturnType<typeof vi.fn>
+  minimized: boolean
+  restore: ReturnType<typeof vi.fn>
+  unmaximize: ReturnType<typeof vi.fn>
+}
+
+// A destroyed window is not a window that politely answers `false` to
+// everything. Electron's remote-object wrapper throws `Object has been
+// destroyed` from every method except `isDestroyed()`, so a fake that answers
+// instead of throwing would let a missing guard pass here and crash the app.
+// Verified against Electron 39.2.3, the version this app ships: every method
+// above throws, and `isDestroyed()` answers true.
+function createWindow(
+  overrides: Partial<
+    Pick<FakeWindow, 'destroyed' | 'maximized' | 'minimized'>
+  > = {}
+): FakeWindow {
+  const live = <Value>(produce: () => Value): (() => Value) => {
+    return () => {
+      if (browserWindow.destroyed) {
+        throw new TypeError('Object has been destroyed')
+      }
+
+      return produce()
+    }
+  }
+
+  const browserWindow: FakeWindow = {
+    close: vi.fn(live(() => undefined)),
+    destroyed: false,
+    focus: vi.fn(live(() => undefined)),
+    isDestroyed: () => browserWindow.destroyed,
+    isMaximized: live(() => browserWindow.maximized),
+    isMinimized: live(() => browserWindow.minimized),
+    maximize: vi.fn(
+      live(() => {
+        browserWindow.maximized = true
+      })
+    ),
+    maximized: false,
+    minimize: vi.fn(
+      live(() => {
+        browserWindow.minimized = true
+      })
+    ),
+    minimized: false,
+    restore: vi.fn(
+      live(() => {
+        browserWindow.minimized = false
+      })
+    ),
+    unmaximize: vi.fn(
+      live(() => {
+        browserWindow.maximized = false
+      })
+    ),
+    ...overrides
+  }
+
+  return browserWindow
+}
+
+function openWindows(...windows: FakeWindow[]): void {
+  mockGetAllWindows.mockReturnValue(windows)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+
+  // Every test says which windows are open; this only keeps a test that forgets
+  // from reading the previous one's list.
+  openWindows()
+})
+
+describe('closeMainWindow', () => {
+  it('closes the open window', () => {
+    const browserWindow = createWindow()
+
+    openWindows(browserWindow)
+    closeMainWindow()
+
+    expect(browserWindow.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when no window is open', () => {
+    expect(() => closeMainWindow()).not.toThrow()
+  })
+
+  it('does nothing when the window has already been destroyed', () => {
+    const browserWindow = createWindow({ destroyed: true })
+
+    openWindows(browserWindow)
+    closeMainWindow()
+
+    expect(browserWindow.close).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('focusMainWindow', () => {
+  it('focuses the open window', () => {
+    const browserWindow = createWindow()
+
+    openWindows(browserWindow)
+    focusMainWindow()
+
+    expect({
+      focused: browserWindow.focus.mock.calls.length,
+      restored: browserWindow.restore.mock.calls.length
+    }).toEqual({ focused: 1, restored: 0 })
+  })
+
+  // Focusing a minimized window leaves it minimized, so the restore has to come
+  // first — a second launch of the app that only focuses raises nothing the
+  // user can see.
+  it('restores a minimized window before focusing it', () => {
+    const browserWindow = createWindow({ minimized: true })
+
+    openWindows(browserWindow)
+    focusMainWindow()
+
+    expect({
+      focused: browserWindow.focus.mock.calls.length,
+      minimized: browserWindow.minimized,
+      restored: browserWindow.restore.mock.calls.length
+    }).toEqual({ focused: 1, minimized: false, restored: 1 })
+  })
+
+  it('does nothing when no window is open', () => {
+    expect(() => focusMainWindow()).not.toThrow()
+  })
+
+  // A second launch of the app raises the running one. With no window left to
+  // raise there is nothing to do, and the reference the app used to keep would
+  // have had it asking a destroyed window whether it was minimized — which
+  // throws, out of an IPC handler that has no one to report to.
+  it('does nothing when the window has been destroyed', () => {
+    const browserWindow = createWindow({ destroyed: true, minimized: true })
+
+    openWindows(browserWindow)
+    focusMainWindow()
+
+    expect({
+      focused: browserWindow.focus.mock.calls.length,
+      restored: browserWindow.restore.mock.calls.length
+    }).toEqual({ focused: 0, restored: 0 })
+  })
+})
+
+describe('getMainWindow', () => {
+  it('returns nothing before a window has been opened', () => {
+    openWindows()
+
+    expect(getMainWindow()).toEqual(undefined)
+  })
+
+  it('returns the open window', () => {
+    const browserWindow = createWindow()
+
+    openWindows(browserWindow)
+
+    expect(getMainWindow()).toEqual(browserWindow)
+  })
+
+  // The whole point of asking Electron each time. A held reference to a closed
+  // window stays non-null forever, so `?.` reads as a guard while it is really
+  // calling into a window that is no longer there.
+  it('returns nothing when the only window has been destroyed', () => {
+    openWindows(createWindow({ destroyed: true }))
+
+    expect(getMainWindow()).toEqual(undefined)
+  })
+
+  it('skips a destroyed window to find one that is still open', () => {
+    const browserWindow = createWindow()
+
+    openWindows(createWindow({ destroyed: true }), browserWindow)
+
+    expect(getMainWindow()).toEqual(browserWindow)
+  })
+})
+
+describe('minimizeMainWindow', () => {
+  it('minimizes the open window', () => {
+    const browserWindow = createWindow()
+
+    openWindows(browserWindow)
+    minimizeMainWindow()
+
+    expect(browserWindow.minimize).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when no window is open', () => {
+    expect(() => minimizeMainWindow()).not.toThrow()
+  })
+
+  it('does nothing when the window has been destroyed', () => {
+    const browserWindow = createWindow({ destroyed: true })
+
+    openWindows(browserWindow)
+    minimizeMainWindow()
+
+    expect(browserWindow.minimize).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('toggleMainWindowMaximized', () => {
+  it('maximizes a window that is not maximized', () => {
+    const browserWindow = createWindow()
+
+    openWindows(browserWindow)
+    toggleMainWindowMaximized()
+
+    expect({
+      maximized: browserWindow.maximize.mock.calls.length,
+      unmaximized: browserWindow.unmaximize.mock.calls.length
+    }).toEqual({ maximized: 1, unmaximized: 0 })
+  })
+
+  it('restores a window that is already maximized', () => {
+    const browserWindow = createWindow({ maximized: true })
+
+    openWindows(browserWindow)
+    toggleMainWindowMaximized()
+
+    expect({
+      maximized: browserWindow.maximize.mock.calls.length,
+      unmaximized: browserWindow.unmaximize.mock.calls.length
+    }).toEqual({ maximized: 0, unmaximized: 1 })
+  })
+
+  it('does nothing when no window is open', () => {
+    expect(() => toggleMainWindowMaximized()).not.toThrow()
+  })
+
+  // The only function here that asks the window a question before acting, so it
+  // is the one that cannot be written with `?.` — and the one where reaching a
+  // destroyed window throws out of `isMaximized()` before any decision is made.
+  it('does nothing when the window has been destroyed', () => {
+    const browserWindow = createWindow({ destroyed: true })
+
+    openWindows(browserWindow)
+    toggleMainWindowMaximized()
+
+    expect({
+      maximized: browserWindow.maximize.mock.calls.length,
+      unmaximized: browserWindow.unmaximize.mock.calls.length
+    }).toEqual({ maximized: 0, unmaximized: 0 })
+  })
+})

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,0 +1,63 @@
+import { BrowserWindow } from 'electron'
+
+// Everything the app does to its own window goes through here, so that the
+// window is looked up at the moment it is used rather than remembered.
+//
+// Electron already keeps the window list, and a second copy of it in a module
+// binding cannot be kept honest: nothing clears the binding when the window
+// closes, so it stays non-null long after the native window is gone. `?.` then
+// reads as a guard while it is really calling into a destroyed window — and
+// every method on one of those throws `Object has been destroyed` rather than
+// answering.
+
+export function closeMainWindow(): void {
+  getMainWindow()?.close()
+}
+
+// Raising the running app when a second copy of it is launched. On macOS a
+// second launch does not start a process, so this is the Windows and Linux
+// path; there, a running app always has its window.
+export function focusMainWindow(): void {
+  const browserWindow = getMainWindow()
+
+  if (!browserWindow) {
+    return
+  }
+
+  if (browserWindow.isMinimized()) {
+    browserWindow.restore()
+  }
+
+  browserWindow.focus()
+}
+
+// The `isDestroyed()` filter is belt-and-braces: Electron drops a window from
+// `getAllWindows()` in the same breath as destroying it, so no destroyed window
+// is expected to appear here. It is kept because it costs one call and it is
+// the single place that decides what the four functions below act on — and what
+// they must not act on, since a destroyed window throws at every method.
+export function getMainWindow(): BrowserWindow | undefined {
+  return BrowserWindow.getAllWindows().find(
+    (browserWindow) => !browserWindow.isDestroyed()
+  )
+}
+
+export function minimizeMainWindow(): void {
+  getMainWindow()?.minimize()
+}
+
+export function toggleMainWindowMaximized(): void {
+  const browserWindow = getMainWindow()
+
+  if (!browserWindow) {
+    return
+  }
+
+  if (browserWindow.isMaximized()) {
+    browserWindow.unmaximize()
+
+    return
+  }
+
+  browserWindow.maximize()
+}


### PR DESCRIPTION
Closes #88.

`src/main.ts` kept `export let mainWindow: BrowserWindow` — exported with no importers anywhere in the repo, and typed as always present despite being undefined for the whole stretch between app start and `createWindow()`. `if (mainWindow === undefined)` at the `second-instance` handler was a check the compiler believed could never be true, which is the tell that the type was wrong.

It was assigned once and never cleared; there is no `'closed'` handler in the file. So after the window is closed the binding still holds it, and the four handlers that reach it — minimize, maximize, close, and the raise on a second launch — call into a window that is gone. `?.` does not help: the reference is non-null, it is the native window that has been destroyed.

Every method on a destroyed `BrowserWindow` throws `TypeError: Object has been destroyed` rather than answering; only `isDestroyed()` still replies. Measured against the Electron this app ships (39.2.3):

```
isDestroyed:  returned true
isMaximized:  threw TypeError: Object has been destroyed
isMinimized:  threw TypeError: Object has been destroyed
close/focus/minimize/maximize/unmaximize/restore: same
```

So the old shape did not quietly do the wrong thing — it threw, out of an IPC handler, where the renderer sees a rejected invoke and the title bar button does nothing at all.

## The change

Electron already owns the window list, so the second copy goes. New `src/main/window.ts` looks the window up at the moment it is used, and the four handlers become calls into it. `activate` goes through the same lookup rather than counting `getAllWindows()`, so there is one answer to "is there a window?" instead of two spellings of it that can drift.

The maximize toggle is the case `?.` was hiding rather than guarding: it has to ask the window a question before it can act, so it is the one that cannot be written as `?.` and the one whose question throws first. Now the absence of a window is the first thing asked.

`getMainWindow` filters out a destroyed window, which is belt-and-braces rather than a fix: measured against the same build, `getAllWindows()` drops a window the moment it is destroyed, including inside a `'closed'` handler. It is kept because it costs one call and it is the single place that decides what the rest of the module acts on — the comment says so rather than claiming a race that does not exist.

`createWindow` takes a local `const browserWindow`, which is the whole of its former use of the binding.

## Tests

Eighteen tests cover the new module over a fake window that throws from every method once destroyed, the way Electron's does — so a missing guard fails here instead of crashing in the app.

Six more in `src/main.test.ts` cover what those cannot: the wiring, that each IPC channel and app event reaches the function it is supposed to. A minimize wired to close passes every test in the other file.

Ten mutations across both files, all killed — including the three wiring swaps and the two guard removals.

Full renderer suite: 797 passed, 1 pre-existing failure (`sqlite-adapter.test.ts > testConnection`, a Windows file-URL path artifact present on `main`).
