### PR TITLE
refactor(tracing): declare the span shape once

### DIFF
--- a/src/glue/api/schemas.ts
+++ b/src/glue/api/schemas.ts
@@ -2,7 +2,8 @@
 // main-process imports — the renderer bundles it.
 import { Schema } from 'effect'
 
-import { isValidSpanId, isValidTraceId } from '../tracing/traceparent'
+import { SpanRecord } from '../tracing/spans'
+import { isValidTraceId } from '../tracing/traceparent'
 
 // --- Request ids ---------------------------------------------------------------
 // Validated but deliberately unbranded: ids round-trip through DTOs and the
@@ -357,51 +358,15 @@ export type ConnectionTestResponse = Schema.Schema.Type<
 // All-zero ids are rejected as well as malformed ones: they are unusable as a
 // lookup key, so accepting them would merge unrelated spans into one
 // unopenable trace.
-const SpanIdField = Schema.String.pipe(
-  Schema.filter(isValidSpanId, {
-    message: () => 'Expected a 16-character hexadecimal span id.'
-  })
-)
-
-const TraceIdField = Schema.String.pipe(
-  Schema.filter(isValidTraceId, {
-    message: () => 'Expected a 32-character hexadecimal trace id.'
-  })
-)
-
-const SpanAttributesDto = Schema.mutable(
-  Schema.Record({
-    key: Schema.String,
-    value: Schema.Union(Schema.Boolean, Schema.Number, Schema.String)
-  })
-)
-
-const SpanEventDto = Schema.Struct({
-  attributes: Schema.optional(SpanAttributesDto),
-  name: Schema.String,
-  time: Schema.Number
-})
-
-const SpanDto = Schema.Struct({
-  attributes: SpanAttributesDto,
-  durationMs: Schema.Number.pipe(Schema.greaterThanOrEqualTo(0)),
-  events: Schema.mutable(Schema.Array(SpanEventDto)),
-  id: SpanIdField,
-  kind: Schema.Literal('client', 'internal', 'server'),
-  name: Schema.String.pipe(Schema.minLength(1)),
-  parentSpanId: Schema.NullOr(SpanIdField),
-  serviceName: Schema.Literal('main', 'renderer'),
-  startedAt: Schema.Number,
-  status: Schema.Literal('error', 'ok', 'unset'),
-  statusMessage: Schema.NullOr(Schema.String),
-  traceId: TraceIdField
-})
-export type SpanDto = Schema.Schema.Type<typeof SpanDto>
+// The same declaration under the name the renderer's trace UI imports it by.
+// The shape lives in `glue/tracing/spans.ts` because that is where the span is
+// built; this contract only carries it.
+export type SpanDto = SpanRecord
 
 const maxIngestBatchSize = 200
 
 export const IngestSpansRequest = Schema.Struct({
-  spans: Schema.Array(SpanDto).pipe(Schema.maxItems(maxIngestBatchSize))
+  spans: Schema.Array(SpanRecord).pipe(Schema.maxItems(maxIngestBatchSize))
 })
 
 const TraceSummaryDto = Schema.Struct({
@@ -585,7 +550,7 @@ export const GetTracesResponse = Schema.Struct({
 })
 
 export const GetTraceResponse = Schema.Struct({
-  spans: Schema.mutable(Schema.Array(SpanDto))
+  spans: Schema.mutable(Schema.Array(SpanRecord))
 })
 
 export const IngestSpansResponse = Schema.Struct({

--- a/src/glue/tracing/span-draft.test.ts
+++ b/src/glue/tracing/span-draft.test.ts
@@ -1,0 +1,130 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { IngestSpansRequest } from '../api/schemas'
+import { SpanDraft } from './span-draft'
+
+// What the renderer ships is exactly what `finish()` returns, and the server
+// validates it against the ingest contract before writing a row. Nothing
+// between the two converts anything, so a span the drafter can build and the
+// contract will not accept is a batch that fails forever: the exporter retries
+// it and logs once per outage, and the spans are simply lost.
+function ingest(spans: unknown[]): unknown {
+  return Schema.decodeUnknownSync(IngestSpansRequest)({ spans })
+}
+
+describe('SpanDraft', () => {
+  // Attribute values are not all strings: `api-client.ts` sets a numeric
+  // `http.status_code` and `query-traces.ts` sends a boolean `query.success` on
+  // an event. Narrowing the contract to strings would compile, pass a
+  // string-only test, and then reject every batch the renderer sends.
+  it('finishes a root span the ingest contract accepts', () => {
+    const draft = new SpanDraft('query.run', { serviceName: 'renderer' })
+
+    draft.setAttribute('database.id', 'pagila')
+    draft.setAttribute('http.status_code', 200)
+    draft.setAttribute('query.cached', false)
+    draft.addEvent('query.sent', { 'query.success': true, 'row.count': 42 })
+
+    const record = draft.finish()
+
+    expect({
+      attributes: record?.attributes,
+      events: record?.events?.map((event) => event.attributes)
+    }).toEqual({
+      attributes: {
+        'database.id': 'pagila',
+        'http.status_code': 200,
+        'query.cached': false
+      },
+      events: [{ 'query.success': true, 'row.count': 42 }]
+    })
+    expect(ingest([record])).toEqual({ spans: [record] })
+  })
+
+  // A root span carries no parent and no status message, and both fields have
+  // to survive the round trip as null rather than being dropped or refused.
+  it('finishes a root span with nothing to say about its parent or status', () => {
+    const record = new SpanDraft('boot', { serviceName: 'main' }).finish()
+
+    expect(record).toEqual({
+      attributes: {},
+      durationMs: expect.any(Number),
+      events: [],
+      id: expect.any(String),
+      kind: 'internal',
+      name: 'boot',
+      parentSpanId: null,
+      serviceName: 'main',
+      startedAt: expect.any(Number),
+      status: 'unset',
+      statusMessage: null,
+      traceId: expect.any(String)
+    })
+    expect(ingest([record])).toEqual({ spans: [record] })
+  })
+
+  it('finishes a child span the ingest contract accepts', () => {
+    const parent = new SpanDraft('query.run', { serviceName: 'renderer' })
+    const child = new SpanDraft('db.query', {
+      kind: 'client',
+      parent: parent.context,
+      serviceName: 'renderer'
+    })
+
+    const record = child.finish()
+
+    expect({
+      kind: record?.kind,
+      parentSpanId: record?.parentSpanId,
+      traceId: record?.traceId
+    }).toEqual({
+      kind: 'client',
+      parentSpanId: parent.context.spanId,
+      traceId: parent.context.traceId
+    })
+    expect(ingest([record])).toEqual({ spans: [record] })
+  })
+
+  // The heaviest span the drafter can produce: an exception event carries three
+  // attributes and a stack trace, and the failure sets a status message.
+  it('finishes a failed span the ingest contract accepts', () => {
+    const draft = new SpanDraft('db.query', {
+      attributes: { 'db.system': 'postgres' },
+      kind: 'server',
+      serviceName: 'main'
+    })
+
+    draft.recordException(new Error('relation "users" does not exist'))
+
+    const record = draft.finish()
+
+    expect({
+      status: record?.status,
+      statusMessage: record?.statusMessage
+    }).toEqual({
+      status: 'error',
+      statusMessage: 'relation "users" does not exist'
+    })
+    expect(ingest([record])).toEqual({ spans: [record] })
+  })
+
+  // The one span shape the contract must refuse. An all-zero id is what a
+  // malformed `traceparent` decays to, and the ingest boundary is the last
+  // place that can keep it out of the table.
+  it('is refused by the ingest contract with an all-zero id', () => {
+    const record = new SpanDraft('boot', { serviceName: 'main' }).finish()
+
+    expect(() => ingest([{ ...record, id: '0'.repeat(16) }])).toThrow()
+    expect(() => ingest([{ ...record, traceId: '0'.repeat(32) }])).toThrow()
+  })
+
+  it('finishes once and returns nothing afterwards', () => {
+    const draft = new SpanDraft('query.run', { serviceName: 'renderer' })
+
+    expect({
+      first: draft.finish() === undefined,
+      second: draft.finish() === undefined
+    }).toEqual({ first: false, second: true })
+  })
+})

--- a/src/glue/tracing/spans.ts
+++ b/src/glue/tracing/spans.ts
@@ -1,42 +1,77 @@
 // Shared between the main process and the renderer. Keep this module free of
 // main-process imports — the renderer bundles it.
 
+import { Schema } from 'effect'
+
+import { isValidSpanId, isValidTraceId } from './traceparent'
+
 export const maxAttributeValueLength = 2000
 export const maxStacktraceLength = 8000
 
-export type SpanAttributeValue = boolean | number | string
+const SpanIdField = Schema.String.pipe(
+  Schema.filter(isValidSpanId, {
+    message: () => 'Expected a 16-character hexadecimal span id.'
+  })
+)
 
-export type SpanAttributes = Record<string, SpanAttributeValue>
+const TraceIdField = Schema.String.pipe(
+  Schema.filter(isValidTraceId, {
+    message: () => 'Expected a 32-character hexadecimal trace id.'
+  })
+)
 
+const SpanAttributesField = Schema.mutable(
+  Schema.Record({
+    key: Schema.String,
+    value: Schema.Union(Schema.Boolean, Schema.Number, Schema.String)
+  })
+)
+
+const SpanEventField = Schema.Struct({
+  attributes: Schema.optional(SpanAttributesField),
+  name: Schema.String,
+  time: Schema.Number
+})
+
+// A finished span, and the only declaration of that shape. The renderer builds
+// one, ships it, and the server validates the bytes it receives against this
+// same schema before writing the row — so the producer's type and the
+// consumer's validation cannot drift apart into an ingest that rejects every
+// batch the exporter sends.
+export const SpanRecord = Schema.Struct({
+  attributes: SpanAttributesField,
+  durationMs: Schema.Number.pipe(Schema.greaterThanOrEqualTo(0)),
+  events: Schema.mutable(Schema.Array(SpanEventField)),
+  id: SpanIdField,
+  kind: Schema.Literal('client', 'internal', 'server'),
+  name: Schema.String.pipe(Schema.minLength(1)),
+  parentSpanId: Schema.NullOr(SpanIdField),
+  serviceName: Schema.Literal('main', 'renderer'),
+  startedAt: Schema.Number,
+  status: Schema.Literal('error', 'ok', 'unset'),
+  statusMessage: Schema.NullOr(Schema.String),
+  traceId: TraceIdField
+})
+export type SpanRecord = Schema.Schema.Type<typeof SpanRecord>
+
+// Read back off the record rather than written out again, so widening a field
+// here is one edit rather than two that can disagree.
+export type SpanAttributes = SpanRecord['attributes']
+
+export type SpanAttributeValue = SpanAttributes[string]
+
+export type SpanEvent = SpanRecord['events'][number]
+
+export type SpanKind = SpanRecord['kind']
+
+export type SpanStatus = SpanRecord['status']
+
+export type TraceServiceName = SpanRecord['serviceName']
+
+// Not part of the record: a span carries its parent's id, while this is how a
+// live span identifies itself to whatever it starts next.
 export interface SpanContext {
   spanId: string
-  traceId: string
-}
-
-export interface SpanEvent {
-  attributes?: SpanAttributes
-  name: string
-  time: number
-}
-
-export type SpanKind = 'client' | 'internal' | 'server'
-
-export type SpanStatus = 'error' | 'ok' | 'unset'
-
-export type TraceServiceName = 'main' | 'renderer'
-
-export interface SpanRecord {
-  attributes: SpanAttributes
-  durationMs: number
-  events: SpanEvent[]
-  id: string
-  kind: SpanKind
-  name: string
-  parentSpanId: string | null
-  serviceName: TraceServiceName
-  startedAt: number
-  status: SpanStatus
-  statusMessage: string | null
   traceId: string
 }
 

--- a/src/glue/tracing/traceparent.ts
+++ b/src/glue/tracing/traceparent.ts
@@ -1,7 +1,9 @@
 // Shared between the main process and the renderer. Keep this module free of
 // main-process imports — the renderer bundles it.
 
-import { SpanContext } from './spans'
+// Type-only on purpose: `spans.ts` needs the id validators below to build
+// its schema, and importing the value back would make that a real cycle.
+import type { SpanContext } from './spans'
 
 const spanIdPattern = /^[0-9a-f]{16}$/
 const traceIdPattern = /^[0-9a-f]{32}$/

--- a/src/server/http/handlers/traces.ts
+++ b/src/server/http/handlers/traces.ts
@@ -2,7 +2,7 @@ import { HttpApiBuilder } from '@effect/platform'
 import { Effect } from 'effect'
 
 import { SquealApi } from '@/glue/api/api'
-import { SpanRecord } from '@/glue/tracing/spans'
+import type { SpanRecord } from '@/glue/tracing/spans'
 import { TraceStore } from '@/server/services/trace-store'
 import { orDieInternal } from '../internal-errors'
 
@@ -33,10 +33,9 @@ export const TracesLive = HttpApiBuilder.group(
         Effect.gen(function* () {
           const store = yield* TraceStore
 
-          const spans: SpanRecord[] = payload.spans.map((span) => ({
-            ...span,
-            events: span.events.map((event) => ({ ...event }))
-          }))
+          // A copy only because `Schema.Array` hands back a readonly one; the
+          // payload is already `SpanRecord`, so there is nothing to convert.
+          const spans: SpanRecord[] = [...payload.spans]
 
           const insertedCount = yield* store.ingestSpans(spans)
 


### PR DESCRIPTION
Closes #75.

`SpanRecord` (`glue/tracing/spans.ts`) and `SpanDto` (`glue/api/schemas.ts`) were the same twelve fields declared twice — the producer of the span bytes and the consumer of them, kept in step by hand. The `Schema.Struct` now lives in `spans.ts` and the contract imports it; `export type SpanDto = SpanRecord` keeps the name the trace UI reads it by.

This is the issue's mirror-image variant rather than its headline `export type SpanRecord = SpanDto`. The issue recommends it conditionally ("if this lands alongside contract work"); I took it unconditionally because the headline direction makes `spans.ts → api/schemas.ts → traceparent.ts → spans.ts` a runtime cycle. This direction leaves one edge — `traceparent.ts` needing `SpanContext` — and that one is `import type`, erased before anything runs. It matters: `spans.ts` calls `isValidSpanId` at module-init time inside `Schema.filter`.

The issue's optional follow-up is included: `handlers/traces.ts`'s per-span and per-event spreads collapse to the copy that was their only job.

### What is not here

- `trace-store.ts:185-200` still hand-builds the shape from a DB row with `row.kind as SpanKind`. Unchanged and still uncovered by these tests — the coverage below is drafter↔contract, not row↔contract.
- `ingestSpans`/`writeSpans` still take `SpanRecord[]` rather than `ReadonlyArray`, which is the only reason the handler needs `[...payload.spans]` at all. Widening them would delete the copy and its comment; it touches `span-writer.ts:5`, which collides with #85, so it is left alone.
- `exporter.ts`'s `flushBatchSize` (100) and `schemas.ts`'s `maxIngestBatchSize` (200) are the same silent-drift pair one level up, with no reference between them and no test that sends more than two spans. Out of scope here, but it is the nearest neighbour of the bug this fixes.

### Testing

No behaviour change, so this is characterization rather than a red-green cycle. `src/glue/tracing/span-draft.test.ts` is new: six tests decoding real `SpanDraft.finish()` output through `IngestSpansRequest`. All sixteen mutations run against the **pre-refactor** code are killed — ten tightening or loosening the contract, six breaking the drafter.

Two of those started out surviving and were found by the review, not by me:

- Nothing produced a non-string attribute value, so narrowing the union to `Schema.String` passed the whole 90-file suite — while 400-ing every real renderer batch (`api-client.ts:252` sends a numeric `http.status_code`, `query-traces.ts:40` a boolean `query.success`). Now covered.
- Nothing asserted the contract *refuses* anything, so deleting the hex-id filters outright also passed. There is now a negative case for the all-zero span id and trace id.

`tsc` clean on both projects, eslint and prettier clean, full suite 957 passed with the one pre-existing Windows `sqlite-adapter` failure that is also on `main`.
