### PR TITLE
refactor(tracing): give the tracer one span sink it cannot fail

### DIFF
--- a/src/server/services/query-runner.test.ts
+++ b/src/server/services/query-runner.test.ts
@@ -437,10 +437,8 @@ describe('QueryRunner', () => {
   it('emits the query span pipeline into the span store', async () => {
     const written: SpanRecord[] = []
     const tracer = makeSquealTracer({
-      persist: (records) => {
-        written.push(...records)
-
-        return Promise.resolve(records.length)
+      emit: (record) => {
+        written.push(record)
       }
     })
 

--- a/src/server/tracing/effect-tracer.test.ts
+++ b/src/server/tracing/effect-tracer.test.ts
@@ -1,14 +1,17 @@
 import {
   Cause,
+  Chunk,
   Context,
   Effect,
   Exit,
   FiberId,
   Layer,
   Option,
+  Queue,
   Tracer
 } from 'effect'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { log } from 'tiny-typescript-logger'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { spansTable } from '@/database/schema'
 import { SpanRecord } from '@/glue/tracing/spans'
@@ -36,7 +39,7 @@ vi.mock('@/main/tracing/span-writer', async (importOriginal) => {
   }
 })
 
-import { makeSquealTracer, TracerLive } from './effect-tracer'
+import { makeQueuedEmit, makeSquealTracer, TracerLive } from './effect-tracer'
 
 const startNanos = 1_700_000_000_000_000_000n
 const endNanos = startNanos + 25_000_000n
@@ -44,14 +47,29 @@ const endNanos = startNanos + 25_000_000n
 function makeCollector() {
   const written: SpanRecord[] = []
   const tracer = makeSquealTracer({
-    persist: (records) => {
-      written.push(...records)
-
-      return Promise.resolve(records.length)
+    emit: (record) => {
+      written.push(record)
     }
   })
 
   return { tracer, written }
+}
+
+function makeRecord(name: string): SpanRecord {
+  return {
+    attributes: {},
+    durationMs: 1,
+    events: [],
+    id: 'a'.repeat(16),
+    kind: 'internal',
+    name,
+    parentSpanId: null,
+    serviceName: 'main',
+    startedAt: 1_700_000_000_000,
+    status: 'ok',
+    statusMessage: null,
+    traceId: 'b'.repeat(32)
+  }
 }
 
 function startSpan(
@@ -332,6 +350,113 @@ describe('TracerLive', () => {
     expect(rows.map((row) => row.name).sort()).toEqual([
       'queued.child',
       'queued.parent'
+    ])
+  })
+})
+
+// Offering never blocks, so a writer that has fallen behind has to be answered
+// by dropping rather than by retaining — and the only record that the drop
+// happened is the counter and its log line. Nothing else in the app can observe
+// a span that was never written.
+describe('makeQueuedEmit', () => {
+  beforeEach(() => {
+    vi.spyOn(log, 'warn').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('offers each span to the queue in order', async () => {
+    const queue = Effect.runSync(Queue.bounded<SpanRecord>(4))
+    const emit = makeQueuedEmit(queue)
+
+    emit(makeRecord('first'))
+    emit(makeRecord('second'))
+
+    const queued = await Effect.runPromise(Queue.takeAll(queue))
+
+    // The silence is half the assertion. Counting a span that was accepted as
+    // dropped shifts every later count by exactly one, which cancels against
+    // the `% 100 === 1` offset and leaves the drop tests below green.
+    expect({
+      queued: Chunk.toReadonlyArray(queued).map((record) => record.name),
+      warnings: vi.mocked(log.warn).mock.calls
+    }).toEqual({ queued: ['first', 'second'], warnings: [] })
+  })
+
+  // The span that does not fit is the one dropped — the queue keeps what it
+  // already accepted, so a burst loses its tail rather than its head.
+  it('drops the span a full queue has no room for', async () => {
+    const queue = Effect.runSync(Queue.bounded<SpanRecord>(1))
+    const emit = makeQueuedEmit(queue)
+
+    emit(makeRecord('kept'))
+    emit(makeRecord('dropped'))
+
+    const queued = await Effect.runPromise(Queue.takeAll(queue))
+
+    expect({
+      queued: Chunk.toReadonlyArray(queued).map((record) => record.name),
+      warnings: vi.mocked(log.warn).mock.calls
+    }).toEqual({
+      queued: ['kept'],
+      warnings: [['Span queue is full; dropped 1 span(s).']]
+    })
+  })
+
+  // Dropping is what a full queue does, not a mode the sink latches into: the
+  // moment the drain takes one off, the next span goes in.
+  it('accepts spans again once the queue has room', async () => {
+    const queue = Effect.runSync(Queue.bounded<SpanRecord>(1))
+    const emit = makeQueuedEmit(queue)
+
+    emit(makeRecord('kept'))
+    emit(makeRecord('dropped'))
+
+    await Effect.runPromise(Queue.take(queue))
+
+    emit(makeRecord('kept again'))
+
+    const queued = await Effect.runPromise(Queue.takeAll(queue))
+
+    expect(Chunk.toReadonlyArray(queued).map((record) => record.name)).toEqual([
+      'kept again'
+    ])
+  })
+
+  // A writer far enough behind to drop is far enough behind to drop thousands,
+  // and a line each would bury whatever is actually wrong. The first one still
+  // has to appear immediately, or the first hundred losses are silent.
+  it('logs the first drop and then only every hundredth', () => {
+    const queue = Effect.runSync(Queue.bounded<SpanRecord>(1))
+    const emit = makeQueuedEmit(queue)
+
+    for (let index = 0; index < 202; index += 1) {
+      emit(makeRecord(`span.${index}`))
+    }
+
+    expect(vi.mocked(log.warn).mock.calls).toEqual([
+      ['Span queue is full; dropped 1 span(s).'],
+      ['Span queue is full; dropped 101 span(s).'],
+      ['Span queue is full; dropped 201 span(s).']
+    ])
+  })
+
+  // Each tracer gets its own counter, so one instance's drops cannot silence
+  // another's first warning.
+  it('counts drops per sink rather than across all of them', () => {
+    const first = makeQueuedEmit(Effect.runSync(Queue.bounded<SpanRecord>(1)))
+    const second = makeQueuedEmit(Effect.runSync(Queue.bounded<SpanRecord>(1)))
+
+    first(makeRecord('one'))
+    first(makeRecord('one too many'))
+    second(makeRecord('two'))
+    second(makeRecord('two too many'))
+
+    expect(vi.mocked(log.warn).mock.calls).toEqual([
+      ['Span queue is full; dropped 1 span(s).'],
+      ['Span queue is full; dropped 1 span(s).']
     ])
   })
 })

--- a/src/server/tracing/effect-tracer.ts
+++ b/src/server/tracing/effect-tracer.ts
@@ -1,5 +1,5 @@
 // The bridge between Effect's tracing and Squeal's span store: a custom
-// Tracer whose spans persist straight into the spans table via writeSpans.
+// Tracer whose finished spans are queued for the batched writer in TracerLive.
 // Effect already generates W3C-format ids, so the renderer's traceparent
 // propagation and the existing dashboard keep working unchanged.
 import {
@@ -31,19 +31,30 @@ import {
 import { writeSpans } from '@/main/tracing/span-writer'
 
 export interface SquealTracerOptions {
-  // Injectable for tests; defaults to the spans-table writer.
-  persist?: (records: SpanRecord[]) => Promise<unknown>
+  // Required, and one span at a time. Durability is `TracerLive`'s business:
+  // this sink hands the span over and cannot report back, because the only
+  // sink ever wired up offers it to a queue and returns. A default here used to
+  // make a second, fully-formed write path representable — a bare
+  // `makeSquealTracer()` would have written each span inline against the
+  // `@/database` singleton, bypassing `AppDatabase`, the bounded queue, the
+  // drop counter and the teardown ordering below, all of which this module
+  // exists to impose.
+  emit: (record: SpanRecord) => void
 }
 
-export function makeSquealTracer(
-  options: SquealTracerOptions = {}
-): Tracer.Tracer {
-  const persist = options.persist ?? writeSpans
-
+export function makeSquealTracer(options: SquealTracerOptions): Tracer.Tracer {
   return Tracer.make({
     context: (execution) => execution(),
     span: (name, parent, _context, links, startTime, kind) =>
-      new SquealSpan(name, parent, _context, links, startTime, kind, persist)
+      new SquealSpan(
+        name,
+        parent,
+        _context,
+        links,
+        startTime,
+        kind,
+        options.emit
+      )
   })
 }
 
@@ -66,23 +77,21 @@ const droppedSpanLogInterval = 100
 // operation it measures, and unbounded in-flight writes are exactly what this
 // queue exists to prevent. A full queue means the writer has fallen far
 // behind, so spans are dropped — loudly — instead of being retained.
-function makeQueuedPersist(
+export function makeQueuedEmit(
   queue: Queue.Queue<SpanRecord>
-): (records: SpanRecord[]) => Promise<unknown> {
+): (record: SpanRecord) => void {
   let dropped = 0
 
-  return (records) => {
-    for (const record of records) {
-      if (!Queue.unsafeOffer(queue, record)) {
-        dropped += 1
-
-        if (dropped % droppedSpanLogInterval === 1) {
-          log.warn(`Span queue is full; dropped ${dropped} span(s).`)
-        }
-      }
+  return (record) => {
+    if (Queue.unsafeOffer(queue, record)) {
+      return
     }
 
-    return Promise.resolve()
+    dropped += 1
+
+    if (dropped % droppedSpanLogInterval === 1) {
+      log.warn(`Span queue is full; dropped ${dropped} span(s).`)
+    }
   }
 }
 
@@ -138,9 +147,7 @@ export const TracerLive = Layer.unwrapScoped(
 
     yield* Effect.forkScoped(Effect.forever(drainBatch))
 
-    return Layer.setTracer(
-      makeSquealTracer({ persist: makeQueuedPersist(queue) })
-    )
+    return Layer.setTracer(makeSquealTracer({ emit: makeQueuedEmit(queue) }))
   })
 )
 
@@ -157,8 +164,8 @@ class SquealSpan implements Tracer.Span {
   readonly traceId: string
   status: Tracer.SpanStatus
 
+  private readonly emit: (record: SpanRecord) => void
   private readonly events: SpanEvent[] = []
-  private readonly persist: (records: SpanRecord[]) => Promise<unknown>
 
   constructor(
     name: string,
@@ -167,7 +174,7 @@ class SquealSpan implements Tracer.Span {
     links: ReadonlyArray<Tracer.SpanLink>,
     startTime: bigint,
     kind: Tracer.SpanKind,
-    persist: (records: SpanRecord[]) => Promise<unknown>
+    emit: (record: SpanRecord) => void
   ) {
     // Inbound parents come from client headers, and the platform's b3 fallback
     // does not validate them at all. An unusable id would produce a trace the
@@ -180,11 +187,11 @@ class SquealSpan implements Tracer.Span {
     )
 
     this.context = context
+    this.emit = emit
     this.kind = kind
     this.links = links.slice()
     this.name = name
     this.parent = usableParent
-    this.persist = persist
     this.sampled = Option.match(usableParent, {
       onNone: () => true,
       onSome: (span) => span.sampled
@@ -214,17 +221,10 @@ class SquealSpan implements Tracer.Span {
 
     this.status = { _tag: 'Ended', endTime, exit, startTime }
 
-    const record = this.toRecord(startTime, endTime, exit)
-
-    // A failed write is logged and swallowed — tracing must never take the
-    // traced operation down with it.
-    void this.persist([record]).then(undefined, (error: unknown) => {
-      log.error(
-        `Could not write span ${record.name}: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      )
-    })
+    // Handed over and forgotten. Ending a span must not be able to fail the
+    // operation it measures, and the queued sink does not: writing is the drain
+    // fiber's job, and its error policy lives with the write.
+    this.emit(this.toRecord(startTime, endTime, exit))
   }
 
   event(


### PR DESCRIPTION
Closes #83.

`makeSquealTracer`'s sink option was `persist?: (records: SpanRecord[]) => Promise<unknown>` — optional, batched, asynchronous, failable. None of those four were real: `end()` only ever called it with one span, the queued sink offers and returns, and it could not reject, so the rejection handler in `end()` was dead code.

The optional part was the one that mattered. `options.persist ?? writeSpans` made a bare `makeSquealTracer()` a legal second write path that would have written each span inline against the `@/database` singleton, bypassing `AppDatabase`, the bounded queue, the drop counter and the teardown ordering this module exists to impose — the configuration the module's own notes forbid, offered as the default. Nothing used it.

It is now a required `emit: (record: SpanRecord) => void`, and `makeQueuedPersist` becomes `makeQueuedEmit` with the loop and the `Promise.resolve()` gone. Durability is `TracerLive`'s concern alone. No runtime change to `TracerLive`; the drain fiber, the flush finalizer and the shutdown drain are untouched.

The issue's optional `writeSpans` → `ReadonlyArray` widening is deliberately left out, so `span-writer.ts` is untouched and this does not collide with #85. The issue's cross-file note (`query-runner.test.ts`) is the one-line change it says it is.

### Testing

The drop path was the entire justification for the seam and had zero coverage. It has five tests now, driving the real exported `makeQueuedEmit` against a real `Queue.bounded` — the only mock is `log.warn`, because the log line is the observable. Eleven mutations of that path and of `end()`'s hand-off are killed.

`makeQueuedEmit` is newly exported to make that possible; reaching the drop path through `TracerLive` would mean queuing 2048 spans.

One mutant was **found surviving by the review, not by me**: a sink that increments the counter for every span, accepted or dropped, passed all four tests I first wrote. The arithmetic cancels — the one span that fits shifts each count by exactly one, against a `% 100 === 1` offset. The happy-path test now asserts `warnings: []` alongside the queued order, which kills it. A "drops are not sticky" case was added at the same time.

Three comments the review caught as inaccurate are corrected: the file header still said spans "persist straight into the spans table" (they have been queued since the batched writer landed, and this commit removes the tracer's last direct write path); "the only sink that ever existed" contradicted "a second, fully-formed write path" two lines below it; and "the sink cannot fail it either" claimed a guarantee the type does not give, since a `void`-returning sink can still throw synchronously.

`tsc` clean on both projects, eslint and prettier clean, full suite 956 passed with the one pre-existing Windows `sqlite-adapter` failure that is also on `main`.
