### PR TITLE
fix(worksheets): give "open a worksheet" one definition

### DIFF
--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -31,8 +31,8 @@ import {
   type DropIndicator
 } from '../hooks/use-list-reorder'
 import { useStartQuery } from '../hooks/use-start-query'
+import { useOpenWorksheet } from '../hooks/use-worksheet-commands'
 import { databaseSearchQueryUpdated } from '../store/editor-slice'
-import { tabsActions } from '../store/tabs-slice'
 import { uiActions } from '../store/ui-slice'
 import { cn } from '../lib/utils'
 import { useAppDispatch, useAppSelector } from '../store'
@@ -232,9 +232,8 @@ function useQueryTableWorksheet(
   hasMultipleSchemas: boolean
 ): (table: TableInfo) => void {
   const createWorksheet = useCreateWorksheet()
-  const dispatch = useAppDispatch()
+  const openWorksheet = useOpenWorksheet()
   const startQuery = useStartQuery()
-  const { worksheets: worksheetsCollection } = useCollections()
 
   return useCallback(
     (table: TableInfo) => {
@@ -248,18 +247,7 @@ function useQueryTableWorksheet(
         },
         {
           onSuccess: (worksheet) => {
-            dispatch(tabsActions.tabOpened(worksheet.id))
-
-            if (worksheetsCollection.status === 'ready') {
-              const transaction = worksheetsCollection.update(
-                worksheet.id,
-                (draft) => {
-                  draft.lastOpenedAt = Date.now()
-                }
-              )
-
-              void transaction.isPersisted.promise.catch((): void => undefined)
-            }
+            openWorksheet(worksheet.id)
 
             // The tab is already open, so the results land in front of the
             // user. `notifyOnError` covers the case where they look away.
@@ -279,14 +267,7 @@ function useQueryTableWorksheet(
         }
       )
     },
-    [
-      createWorksheet,
-      database,
-      dispatch,
-      hasMultipleSchemas,
-      startQuery,
-      worksheetsCollection
-    ]
+    [createWorksheet, database, hasMultipleSchemas, openWorksheet, startQuery]
   )
 }
 

--- a/src/app/components/WorksheetExplorer.test.tsx
+++ b/src/app/components/WorksheetExplorer.test.tsx
@@ -43,6 +43,16 @@ const testWorksheet: WorksheetDto = {
   sortOrder: null
 }
 
+const secondWorksheet: WorksheetDto = {
+  content: '',
+  createdAt: 1704067300000,
+  databaseId: null,
+  id: 'ws-456',
+  lastOpenedAt: null,
+  name: 'Second Worksheet',
+  sortOrder: null
+}
+
 describe('WorksheetExplorer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -113,15 +123,6 @@ describe('WorksheetExplorer', () => {
 
   it('persists the last-opened time when a worksheet is selected', async () => {
     const user = userEvent.setup()
-    const secondWorksheet: WorksheetDto = {
-      content: '',
-      createdAt: 1704067300000,
-      databaseId: null,
-      id: 'ws-456',
-      lastOpenedAt: null,
-      name: 'Second Worksheet',
-      sortOrder: null
-    }
 
     renderWithProviders(<WorksheetExplorer />, {
       databases: [],
@@ -136,6 +137,36 @@ describe('WorksheetExplorer', () => {
         lastOpenedAt: expect.any(Number)
       })
     })
+  })
+
+  // The tab is already open by the time the PATCH is sent, and what it costs is
+  // the MRU order. Rejecting the promise unhandled would surface as a
+  // `renderer.error` trace for something the user never asked for.
+  it('opens the worksheet anyway when recording the time fails', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.updateWorksheet).mockRejectedValue(
+      new Error('Database is locked')
+    )
+
+    const { store } = renderWithProviders(<WorksheetExplorer />, {
+      databases: [],
+      openWorksheetId: 'ws-123',
+      worksheets: [testWorksheet, secondWorksheet]
+    })
+
+    await user.click(screen.getByText('Second Worksheet'))
+
+    await waitFor(() => {
+      expect(apiClient.updateWorksheet).toHaveBeenCalledWith('ws-456', {
+        lastOpenedAt: expect.any(Number)
+      })
+    })
+
+    expect({
+      activeWorksheetId: store.getState().tabs.activeWorksheetId,
+      alerts: screen.queryAllByRole('alert').map((alert) => alert.textContent)
+    }).toEqual({ activeWorksheetId: 'ws-456', alerts: [] })
   })
 
   describe('rename', () => {

--- a/src/app/components/WorksheetExplorer.tsx
+++ b/src/app/components/WorksheetExplorer.tsx
@@ -5,25 +5,22 @@ import { FileBracesIcon, Pencil, PlusIcon, Trash2 } from 'lucide-react'
 import { ReactElement, ReactNode, useCallback } from 'react'
 import { toast } from 'sonner'
 
-import { useCollections } from '../collections-context'
 import { useDatabases, useWorksheets } from '../hooks/queries'
-import {
-  useCreateWorksheet,
-  useDeleteWorksheet,
-  useReorderWorksheets
-} from '../hooks/mutations'
+import { useDeleteWorksheet, useReorderWorksheets } from '../hooks/mutations'
 import {
   staticListStrategy,
   useListReorder,
   type DropIndicator
 } from '../hooks/use-list-reorder'
+import {
+  useCreateAndOpenWorksheet,
+  useOpenWorksheet
+} from '../hooks/use-worksheet-commands'
 import { useWorksheetRename } from '../hooks/use-worksheet-rename'
 import { cn } from '../lib/utils'
 import { useAppDispatch, useAppSelector } from '../store'
 import { worksheetSearchQueryUpdated } from '../store/editor-slice'
-import { selectActiveWorksheetId, tabsActions } from '../store/tabs-slice'
-import { getNextUntitledName } from '../worksheet-naming'
-import { pickDatabaseForNewWorksheet } from '../worksheet-selection'
+import { selectActiveWorksheetId } from '../store/tabs-slice'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -69,79 +66,6 @@ function useConfirmedWorksheetDeletion(): (worksheet: WorksheetDto) => void {
   )
 }
 
-/**
- * What the user can do to a worksheet from the explorer: open one (which also
- * marks it most-recently-used) and create a new one. Both need the same tab
- * dispatch and touch, so they live together rather than in the component body.
- */
-function useWorksheetActions(
-  worksheets: WorksheetDto[],
-  startEditing: (worksheet: WorksheetDto) => void
-) {
-  const dispatch = useAppDispatch()
-  const createWorksheet = useCreateWorksheet()
-  const activeWorksheetId = useAppSelector(selectActiveWorksheetId)
-  const { worksheets: worksheetsCollection } = useCollections()
-
-  const touchWorksheet = useCallback(
-    (worksheetId: string) => {
-      const transaction = worksheetsCollection.update(worksheetId, (draft) => {
-        draft.lastOpenedAt = Date.now()
-      })
-
-      void transaction.isPersisted.promise.catch((): void => undefined)
-    },
-    [worksheetsCollection]
-  )
-
-  const handleSelectWorksheet = useCallback(
-    (worksheetId: string) => {
-      dispatch(tabsActions.tabOpened(worksheetId))
-      touchWorksheet(worksheetId)
-    },
-    [dispatch, touchWorksheet]
-  )
-
-  const handleNewWorksheet = useCallback(() => {
-    const databaseId = pickDatabaseForNewWorksheet(
-      worksheets,
-      activeWorksheetId
-    )
-    const name = getNextUntitledName(worksheets)
-
-    createWorksheet.mutate(
-      {
-        // `databaseId` is optional rather than nullable, so an unset one has to
-        // be left out instead of sent as null.
-        ...(databaseId === undefined ? {} : { databaseId }),
-        name
-      },
-      {
-        onSuccess: (worksheet) => {
-          dispatch(tabsActions.tabOpened(worksheet.id))
-          touchWorksheet(worksheet.id)
-          startEditing(worksheet)
-        },
-        onError: (error) => {
-          const message =
-            error instanceof Error ? error.message : 'Unknown error'
-
-          toast.error('Failed to create worksheet', { description: message })
-        }
-      }
-    )
-  }, [
-    activeWorksheetId,
-    createWorksheet,
-    dispatch,
-    startEditing,
-    touchWorksheet,
-    worksheets
-  ])
-
-  return { handleNewWorksheet, handleSelectWorksheet }
-}
-
 export function WorksheetExplorer(): ReactElement {
   const dispatch = useAppDispatch()
   const databases = useDatabases()
@@ -161,10 +85,10 @@ export function WorksheetExplorer(): ReactElement {
     startEditing
   } = useWorksheetRename(worksheets.data, 'explorer')
 
-  const { handleNewWorksheet, handleSelectWorksheet } = useWorksheetActions(
-    worksheets.data,
-    startEditing
-  )
+  const handleNewWorksheet = useCreateAndOpenWorksheet({
+    onCreated: startEditing
+  })
+  const handleSelectWorksheet = useOpenWorksheet()
 
   const handleDeleteWorksheet = useConfirmedWorksheetDeletion()
 

--- a/src/app/components/WorksheetTabs.test.tsx
+++ b/src/app/components/WorksheetTabs.test.tsx
@@ -181,6 +181,107 @@ describe('WorksheetTabs', () => {
     })
   })
 
+  // The naming rule is unit-tested on its own; what is untested is that the
+  // tab strip still asks for it rather than hardcoding the first name.
+  it('numbers a new worksheet past the untitled ones already there', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.createWorksheet).mockResolvedValue(
+      worksheet('ws-new', 'Untitled 2')
+    )
+
+    renderWithProviders(<WorksheetTabs />, {
+      tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1'] },
+      worksheets: [worksheet('ws-1', 'Untitled')]
+    })
+
+    await user.click(screen.getByRole('button', { name: 'New worksheet' }))
+
+    await waitFor(() => {
+      expect(apiClient.createWorksheet).toHaveBeenCalledWith({
+        name: 'Untitled 2'
+      })
+    })
+  })
+
+  // The list the name is counted from has to be the one the first click just
+  // added to. Reading it at render time instead names both new worksheets
+  // "Untitled 2", which is the exact collision the numbering exists to avoid.
+  it('numbers the second new worksheet past the first', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.createWorksheet)
+      .mockResolvedValueOnce(worksheet('ws-new', 'Untitled 2'))
+      .mockResolvedValueOnce(worksheet('ws-newer', 'Untitled 3'))
+
+    renderWithProviders(<WorksheetTabs />, {
+      tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1'] },
+      worksheets: [worksheet('ws-1', 'Untitled')]
+    })
+
+    await user.click(screen.getByRole('button', { name: 'New worksheet' }))
+
+    expect(await screen.findByRole('tab', { name: 'Untitled 2' })).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: 'New worksheet' }))
+
+    await waitFor(() => {
+      expect(vi.mocked(apiClient.createWorksheet).mock.calls).toEqual([
+        [{ name: 'Untitled 2' }],
+        [{ name: 'Untitled 3' }]
+      ])
+    })
+  })
+
+  // Clicking "+" and getting nothing is the failure the user is most likely to
+  // hit twice, so it has to say why rather than looking like a dead button.
+  it('says why when the worksheet could not be created', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.createWorksheet).mockRejectedValue(
+      new Error('Database is locked')
+    )
+
+    renderWithProviders(<WorksheetTabs />, {
+      tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1'] },
+      worksheets: [revenue]
+    })
+
+    await user.click(screen.getByRole('button', { name: 'New worksheet' }))
+
+    expect(await screen.findByText('Failed to create worksheet')).toBeVisible()
+    expect(await screen.findByText('Database is locked')).toBeVisible()
+  })
+
+  // `lastOpenedAt` is the only input the startup pick and the next new
+  // worksheet's database pick have for "where the user was". A worksheet
+  // created here used to stay null until someone clicked it in the sidebar,
+  // which made it invisible to both.
+  it('records the last-opened time for a worksheet created from the tab strip', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.createWorksheet).mockResolvedValue(
+      worksheet('ws-new', 'Untitled')
+    )
+    vi.mocked(apiClient.updateWorksheet).mockResolvedValue({
+      ...worksheet('ws-new', 'Untitled'),
+      lastOpenedAt: 1704070800000
+    })
+
+    renderWithProviders(<WorksheetTabs />, {
+      tabs: { activeWorksheetId: 'ws-1', openWorksheetIds: ['ws-1'] },
+      worksheets: [revenue]
+    })
+
+    await user.click(screen.getByRole('button', { name: 'New worksheet' }))
+
+    await waitFor(() => {
+      expect(apiClient.updateWorksheet).toHaveBeenCalledWith('ws-new', {
+        lastOpenedAt: expect.any(Number)
+      })
+    })
+  })
+
   it('renders only the new-tab button when nothing is open', () => {
     renderWithProviders(<WorksheetTabs />, {
       tabs: { openWorksheetIds: [] },

--- a/src/app/components/WorksheetTabs.tsx
+++ b/src/app/components/WorksheetTabs.tsx
@@ -4,15 +4,14 @@ import { CSS } from '@dnd-kit/utilities'
 import { Pencil, PlusIcon, XIcon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { toast } from 'sonner'
 
-import { useCreateWorksheet } from '../hooks/mutations'
 import { useWorksheets } from '../hooks/queries'
 import {
   staticListStrategy,
   useListReorder,
   type DropIndicator
 } from '../hooks/use-list-reorder'
+import { useCreateAndOpenWorksheet } from '../hooks/use-worksheet-commands'
 import {
   useWorksheetRename,
   type WorksheetRenameControls
@@ -24,8 +23,6 @@ import {
   selectOpenWorksheetIds,
   tabsActions
 } from '../store/tabs-slice'
-import { getNextUntitledName } from '../worksheet-naming'
-import { pickDatabaseForNewWorksheet } from '../worksheet-selection'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -93,42 +90,6 @@ function useActiveTabScroll(
   }, [activeWorksheetId])
 
   return registerElement
-}
-
-/** Creates a worksheet on the current connection and opens it in a tab. */
-function useNewWorksheet(
-  activeWorksheetId: string | undefined,
-  worksheets: WorksheetDto[]
-): () => void {
-  const dispatch = useAppDispatch()
-  const createWorksheet = useCreateWorksheet()
-
-  return useCallback(() => {
-    const databaseId = pickDatabaseForNewWorksheet(
-      worksheets,
-      activeWorksheetId
-    )
-
-    createWorksheet.mutate(
-      {
-        // `databaseId` is optional rather than nullable, so an unset one has to
-        // be left out instead of sent as null.
-        ...(databaseId === undefined ? {} : { databaseId }),
-        name: getNextUntitledName(worksheets)
-      },
-      {
-        onError: (error: unknown) => {
-          const message =
-            error instanceof Error ? error.message : 'Unknown error'
-
-          toast.error('Failed to create worksheet', { description: message })
-        },
-        onSuccess: (worksheet) => {
-          dispatch(tabsActions.tabOpened(worksheet.id))
-        }
-      }
-    )
-  }, [activeWorksheetId, createWorksheet, dispatch, worksheets])
 }
 
 interface TabHotkeysOptions {
@@ -231,7 +192,7 @@ export function WorksheetTabs(): ReactElement {
   const openTabIds = openTabs.map((worksheet) => worksheet.id)
 
   const registerTabElement = useActiveTabScroll(activeWorksheetId)
-  const handleNewWorksheet = useNewWorksheet(activeWorksheetId, worksheets.data)
+  const handleNewWorksheet = useCreateAndOpenWorksheet()
 
   const handleActivate = useCallback(
     (worksheetId: string) => {

--- a/src/app/hooks/use-worksheet-commands.test.tsx
+++ b/src/app/hooks/use-worksheet-commands.test.tsx
@@ -1,0 +1,116 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReactElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { WorksheetDto } from '@/glue/worksheets'
+
+import { renderWithProviders } from '../test-utils'
+import { useWorksheets } from './queries'
+import { useOpenWorksheet } from './use-worksheet-commands'
+
+vi.mock('../api-client', () => ({
+  apiClient: {
+    createWorksheet: vi.fn(),
+    getDatabases: vi.fn(async () => []),
+    getWorksheets: vi.fn(async () => []),
+    updateWorksheet: vi.fn()
+  }
+}))
+
+// Nothing here reads the worksheet list, so the collection is never subscribed
+// and sits at `idle` holding nothing — which is what the guard is about. The
+// real screens read it above their click handlers and so skip this state; a
+// worksheet deleted in another window reaches the same missing key from
+// `ready`, and that one has no such escape.
+function OpenWorksheetProbe(): ReactElement {
+  const openWorksheet = useOpenWorksheet()
+
+  return (
+    <button
+      onClick={() => openWorksheet('ws-1')}
+      type="button"
+    >
+      Open
+    </button>
+  )
+}
+
+// Reads the list, so the collection syncs and reaches `ready` — and still does
+// not hold `ws-1`. That is where a worksheet deleted in another window between
+// render and click leaves the handler, and no status can tell you about it.
+function SubscribedOpenWorksheetProbe(): ReactElement {
+  useWorksheets()
+
+  return <OpenWorksheetProbe />
+}
+
+const otherWorksheet: WorksheetDto = {
+  content: '',
+  createdAt: 1704067200000,
+  databaseId: null,
+  id: 'ws-2',
+  lastOpenedAt: null,
+  name: 'Revenue',
+  sortOrder: null
+}
+
+describe('useOpenWorksheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // `update` throws `CollectionOperationError` on a key the collection does not
+  // hold, so an unguarded touch throws past the rest of the click handler. The
+  // tab survives — it is dispatched first — but the rename that the create path
+  // opens afterwards would not, and the error reaches the user as a
+  // `renderer.error` trace. Only the timestamp is worth losing here.
+  it('opens the tab without touching a worksheet the collection does not hold', async () => {
+    const user = userEvent.setup()
+
+    const { collections, store } = renderWithProviders(<OpenWorksheetProbe />)
+    const update = vi.spyOn(collections.worksheets, 'update')
+
+    await user.click(screen.getByRole('button', { name: 'Open' }))
+
+    expect({
+      status: collections.worksheets.status,
+      tabs: store.getState().tabs,
+      updates: update.mock.calls
+    }).toEqual({
+      status: 'idle',
+      tabs: {
+        activeWorksheetId: 'ws-1',
+        openWorksheetIds: ['ws-1'],
+        status: 'reconciled'
+      },
+      updates: []
+    })
+  })
+
+  it('opens the tab without touching a worksheet a ready collection has lost', async () => {
+    const user = userEvent.setup()
+
+    const { collections, store } = renderWithProviders(
+      <SubscribedOpenWorksheetProbe />,
+      { worksheets: [otherWorksheet] }
+    )
+    const update = vi.spyOn(collections.worksheets, 'update')
+
+    await user.click(await screen.findByRole('button', { name: 'Open' }))
+
+    expect({
+      status: collections.worksheets.status,
+      tabs: store.getState().tabs,
+      updates: update.mock.calls
+    }).toEqual({
+      status: 'ready',
+      tabs: {
+        activeWorksheetId: 'ws-1',
+        openWorksheetIds: ['ws-1'],
+        status: 'reconciled'
+      },
+      updates: []
+    })
+  })
+})

--- a/src/app/hooks/use-worksheet-commands.ts
+++ b/src/app/hooks/use-worksheet-commands.ts
@@ -1,0 +1,101 @@
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+
+import { WorksheetDto } from '@/glue/worksheets'
+
+import { useCollections } from '../collections-context'
+import { useAppDispatch, useAppSelector } from '../store'
+import { selectActiveWorksheetId, tabsActions } from '../store/tabs-slice'
+import { getNextUntitledName } from '../worksheet-naming'
+import { pickDatabaseForNewWorksheet } from '../worksheet-selection'
+import { useCreateWorksheet } from './mutations'
+
+interface CreateAndOpenWorksheetOptions {
+  /** The explorer renames the new worksheet in place; the tab strip does not. */
+  onCreated?: (worksheet: WorksheetDto) => void
+}
+
+/**
+ * Creating a worksheet is opening one plus everything above it: which database
+ * it inherits, what it is called, and what to say when the write fails. The
+ * explorer and the tab strip both do this, and only one of them remembered to
+ * open it properly.
+ */
+export function useCreateAndOpenWorksheet(
+  options: CreateAndOpenWorksheetOptions = {}
+): () => void {
+  const activeWorksheetId = useAppSelector(selectActiveWorksheetId)
+  const createWorksheet = useCreateWorksheet()
+  const openWorksheet = useOpenWorksheet()
+  const { worksheets } = useCollections()
+
+  const { onCreated } = options
+
+  return useCallback(() => {
+    // The collection, not a `useWorksheets()` live query: every call site of
+    // that hook builds its own sorted derived collection, and neither the name
+    // nor the database depends on the order. Reading it at click time is also
+    // what stops two clicks in a row from both landing on `Untitled 2`.
+    const existing = Array.from(worksheets.values())
+    const databaseId = pickDatabaseForNewWorksheet(existing, activeWorksheetId)
+
+    createWorksheet.mutate(
+      {
+        // `databaseId` is optional rather than nullable, so an unset one has to
+        // be left out instead of sent as null.
+        ...(databaseId === undefined ? {} : { databaseId }),
+        name: getNextUntitledName(existing)
+      },
+      {
+        onError: (error: unknown) => {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error'
+
+          toast.error('Failed to create worksheet', { description: message })
+        },
+        // The server-assigned worksheet, not an optimistic one — the explorer
+        // opens a rename on it and needs the real id.
+        onSuccess: (worksheet) => {
+          openWorksheet(worksheet.id)
+          onCreated?.(worksheet)
+        }
+      }
+    )
+  }, [activeWorksheetId, createWorksheet, onCreated, openWorksheet, worksheets])
+}
+
+/**
+ * Opening a worksheet is two writes, not one. The tab has to appear, and
+ * `lastOpenedAt` has to move — it is the sole input to both MRU fallbacks in
+ * `worksheet-selection.ts`, whose whole job is resuming where the user was. A
+ * worksheet opened without the touch is invisible to them.
+ */
+export function useOpenWorksheet(): (worksheetId: string) => void {
+  const dispatch = useAppDispatch()
+  const { worksheets } = useCollections()
+
+  return useCallback(
+    (worksheetId: string) => {
+      dispatch(tabsActions.tabOpened(worksheetId))
+
+      // `update` throws on a key the collection does not hold — a collection
+      // that has not started syncing holds nothing, and a worksheet deleted in
+      // another window is gone from one that has. The tab is already open by
+      // the line above, so what the throw would cost is the rest of the
+      // handler: the timestamp here, and the rename that follows on the create
+      // path. Asking for the key is the whole precondition; the status is not.
+      if (!worksheets.has(worksheetId)) {
+        return
+      }
+
+      const transaction = worksheets.update(worksheetId, (draft) => {
+        draft.lastOpenedAt = Date.now()
+      })
+
+      // The tab is already open. A failed touch costs the MRU order and nothing
+      // the user asked for, so it is not worth a toast in front of them.
+      void transaction.isPersisted.promise.catch((): void => undefined)
+    },
+    [dispatch, worksheets]
+  )
+}


### PR DESCRIPTION
Closes #62.

Three call sites each remembered a different subset of what "open a worksheet" means. `useOpenWorksheet` and `useCreateAndOpenWorksheet` in `src/app/hooks/use-worksheet-commands.ts` now own the set, and the tab strip, the worksheet explorer, and `DatabaseExplorer`'s table shortcut all call them.

## Behaviour changes

- A worksheet created from the tab strip **"+"** now records `lastOpenedAt`. It did not before, which made it invisible to both MRU loops in `worksheet-selection.ts` — the startup pick and the "inherit the database of the most recently opened worksheet" pick. Cost: one extra `PATCH /worksheets/:id` per create.
- The explorer's touch is now guarded. `collection.update()` throws `CollectionOperationError` synchronously on a key the collection does not hold; the throw took out the rest of the click handler, which on the create path is the inline rename.
- The guard is `worksheets.has(worksheetId)`, not a status check. A status check covers the collection that has not synced yet; it does not cover a worksheet deleted in another window between render and click, which is missing from a collection that is `ready`.
- `useCreateAndOpenWorksheet` reads the collection directly instead of a `useWorksheets()` live query. Every call site of that hook builds its own sorted derived collection; neither the untitled-numbering nor the database pick depends on order; and reading at click time is what stops two clicks in a row from both landing on `Untitled 2`.

## Tests

TDD: the tab-strip touch test was written first and failed with `expected "vi.fn()" to be called with arguments: [ 'ws-new', …(1) ]`.

Renderer 779 passed / 1 failed, backend 178 passed. The one failure is the pre-existing `src/databases/sqlite-adapter.test.ts` Windows path case, present on `main`.

Thirteen mutations of the new module: **twelve killed**, including the weakened `status !== 'ready'` guard, a hardcoded `Untitled`, a dropped error toast, a touch aimed at the wrong id, and reading the worksheet list at render time. The survivor is dropping `.catch()` from the touch transaction — nothing in the renderer test environment turns that unhandled rejection into a failure, so the handler stays as documentation of an accepted failure rather than as tested behaviour.

## Known gap, not addressed here

`tabsActions.tabActivated` — clicking an already-open tab, middle-click, and `mod+1..9` — still does not record `lastOpenedAt`. That is the most common way a user resumes, so the tab strip continues to under-report MRU. Pre-existing, and a bigger change than this issue asks for.
