### PR TITLE
fix(traces): make the dashboard's three screens one value

### DIFF
--- a/src/app/components/traces/TraceDashboard.test.tsx
+++ b/src/app/components/traces/TraceDashboard.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'react-redux'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,6 +14,7 @@ vi.mock('@/app/api-client', () => ({
 }))
 
 import { apiClient } from '@/app/api-client'
+import { queryKeys } from '@/app/query-keys'
 import { createStore } from '@/app/store'
 import { uiActions } from '@/app/store/ui-slice'
 
@@ -82,7 +83,7 @@ function renderDashboard() {
     </QueryClientProvider>
   )
 
-  return { store }
+  return { queryClient, store }
 }
 
 describe('TraceDashboard', () => {
@@ -148,7 +149,7 @@ describe('TraceDashboard', () => {
     await user.keyboard('{Escape}')
 
     await waitFor(() => {
-      expect(screen.queryByText('Attributes')).not.toBeInTheDocument()
+      expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
     })
     expect(screen.getByText('db.query')).toBeInTheDocument()
 
@@ -161,5 +162,237 @@ describe('TraceDashboard', () => {
     await waitFor(() => {
       expect(store.getState().ui.traceDashboardOpen).toEqual(false)
     })
+  })
+
+  // TanStack Query keeps the last successful `data` when a background refetch
+  // fails, and the dashboard polls every two seconds. The sidebar was rendered
+  // from that kept data while the waterfall beside it had already been replaced
+  // by an error, so one failed poll put a stale span next to "Could not load
+  // this trace."
+  it('takes the span sidebar down with the waterfall when a poll fails', async () => {
+    mockedApiClient.getTraces.mockResolvedValue([traceFixture])
+    mockedApiClient.getTraceSpans.mockResolvedValue(spanFixtures)
+
+    const { queryClient } = renderDashboard()
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByText('query.run'))
+    await user.click(await screen.findByText('db.query'))
+
+    expect(await screen.findByText('Attributes')).toBeInTheDocument()
+
+    mockedApiClient.getTraceSpans.mockRejectedValue(new Error('server down'))
+
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: queryKeys.traceSpans(traceFixture.traceId)
+      })
+    })
+
+    await waitFor(() => {
+      expect({
+        error: screen.queryByText('Could not load this trace.')?.textContent,
+        sidebar: screen.queryByRole('complementary')
+      }).toEqual({ error: 'Could not load this trace.', sidebar: null })
+    })
+
+    // The selection went with the sidebar, so escape has one rung left rather
+    // than a silent one to spend first.
+    await user.keyboard('{Escape}')
+
+    expect(await screen.findByText('Spans')).toBeInTheDocument()
+  })
+
+  // Retention trims spans out from under an open sidebar. The selection then
+  // named a span nobody could see, and the escape ladder still stepped through
+  // it, so the first press did nothing the user could observe.
+  it('gives up a selected span that a later poll no longer returns', async () => {
+    mockedApiClient.getTraces.mockResolvedValue([traceFixture])
+    mockedApiClient.getTraceSpans.mockResolvedValue(spanFixtures)
+
+    const { queryClient } = renderDashboard()
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByText('query.run'))
+    await user.click(await screen.findByText('db.query'))
+
+    expect(await screen.findByText('Attributes')).toBeInTheDocument()
+
+    mockedApiClient.getTraceSpans.mockResolvedValue([
+      buildSpan({ durationMs: 100, id: 'root', name: 'query.run' })
+    ])
+
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: queryKeys.traceSpans(traceFixture.traceId)
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+    })
+
+    await user.keyboard('{Escape}')
+
+    expect(await screen.findByText('Spans')).toBeInTheDocument()
+  })
+
+  // The split render this component was rearranged around only happens because
+  // the spans reload behind the open trace, so the interval is part of the fix
+  // rather than a detail of it.
+  it('reloads the spans of the open trace on a timer', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      mockedApiClient.getTraces.mockResolvedValue([traceFixture])
+      mockedApiClient.getTraceSpans.mockResolvedValue(spanFixtures)
+
+      renderDashboard()
+
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      await user.click(await screen.findByText('query.run'))
+
+      expect(await screen.findByText('db.query')).toBeInTheDocument()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000)
+      })
+
+      expect(mockedApiClient.getTraceSpans.mock.calls).toEqual([
+        [traceFixture.traceId],
+        [traceFixture.traceId]
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The waterfall decides what a click means by comparing the row against the
+  // selection it was given, so a panel that keeps the selection to itself turns
+  // clicking the open span into a no-op instead of a close.
+  it('closes the sidebar when the open span is clicked again', async () => {
+    mockedApiClient.getTraces.mockResolvedValue([traceFixture])
+    mockedApiClient.getTraceSpans.mockResolvedValue(spanFixtures)
+
+    renderDashboard()
+
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByText('query.run'))
+    await user.click(await screen.findByText('db.query'))
+
+    expect(await screen.findByText('Attributes')).toBeInTheDocument()
+
+    // By title, not by text: the sidebar shows the span name too.
+    await user.click(screen.getByTitle('db.query'))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+    })
+  })
+
+  // Opening a trace opens the waterfall and nothing else, and the header trades
+  // the filters for the trace it is showing.
+  it('names the open trace in the header without opening a span', async () => {
+    mockedApiClient.getTraces.mockResolvedValue([traceFixture])
+    mockedApiClient.getTraceSpans.mockResolvedValue(spanFixtures)
+
+    renderDashboard()
+
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByText('query.run'))
+
+    expect(await screen.findByText('db.query')).toBeInTheDocument()
+
+    const header = within(screen.getByRole('banner'))
+
+    expect({
+      duration: header.getByText('100ms').textContent,
+      heading: header.getByRole('heading').textContent,
+      sidebar: screen.queryByRole('complementary'),
+      traceId: header.getByTitle('Copy trace ID').textContent
+    }).toEqual({
+      duration: '100ms',
+      heading: 'query.run',
+      sidebar: null,
+      traceId: 'aaaaaaaaaaaaaaaa…'
+    })
+  })
+
+  // The other direction of the same effect, and the one with no visible
+  // symptom to notice: the sidebar polls every two seconds behind the user, and
+  // a reconciliation that fired on a successful poll would close it under them.
+  it('keeps the open span through a poll that returns it again', async () => {
+    mockedApiClient.getTraces.mockResolvedValue([traceFixture])
+    mockedApiClient.getTraceSpans.mockResolvedValue(spanFixtures)
+
+    const { queryClient } = renderDashboard()
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByText('query.run'))
+    await user.click(await screen.findByText('db.query'))
+
+    expect(await screen.findByText('Attributes')).toBeInTheDocument()
+
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: queryKeys.traceSpans(traceFixture.traceId)
+      })
+    })
+
+    expect(screen.getByRole('complementary')).toBeInTheDocument()
+
+    // Still three rungs: the span is open, so the first press closes it rather
+    // than leaving the waterfall.
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByText('db.query')).toBeInTheDocument()
+  })
+
+  // The span belongs to the trace, not to the dashboard: leaving one trace and
+  // opening another must not reopen a sidebar for a span the second trace has
+  // never heard of.
+  it('opens a second trace with no sidebar from the first', async () => {
+    const secondTrace = {
+      ...traceFixture,
+      name: 'query.cancel',
+      traceId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    }
+
+    mockedApiClient.getTraces.mockResolvedValue([traceFixture, secondTrace])
+    mockedApiClient.getTraceSpans.mockImplementation(async (traceId) =>
+      traceId === traceFixture.traceId
+        ? spanFixtures
+        : [
+            buildSpan({
+              id: 'child',
+              name: 'db.cancel',
+              traceId: secondTrace.traceId
+            })
+          ]
+    )
+
+    renderDashboard()
+
+    const user = userEvent.setup()
+
+    await user.click(await screen.findByText('query.run'))
+    await user.click(await screen.findByText('db.query'))
+
+    expect(await screen.findByText('Attributes')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    await user.keyboard('{Escape}')
+
+    await user.click(await screen.findByText('query.cancel'))
+
+    expect(await screen.findByText('db.cancel')).toBeInTheDocument()
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
   })
 })

--- a/src/app/components/traces/TraceDashboard.tsx
+++ b/src/app/components/traces/TraceDashboard.tsx
@@ -11,6 +11,7 @@ import {
   ReactElement,
   ReactNode,
   useCallback,
+  useEffect,
   useState
 } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -32,9 +33,19 @@ const dashboardRefetchIntervalMs = 2000
 
 // Derived from the child components rather than imported, so this file does not
 // need to know where the DTOs live.
-type Spans = ComponentProps<typeof TraceWaterfall>['spans']
 type Traces = ComponentProps<typeof TraceList>['traces']
 type Trace = Traces[number]
+
+/**
+ * The three screens the dashboard has, stated once. A span is only selectable
+ * inside a trace, and saying so here is what lets the spans query take a
+ * definite id and lets the sidebar be produced from the same status branch as
+ * the waterfall it belongs to.
+ */
+type TraceView =
+  | { kind: 'list' }
+  | { kind: 'span'; spanId: string; traceId: string }
+  | { kind: 'spans'; traceId: string }
 
 function CenteredState({ children }: { children: ReactNode }): ReactElement {
   return (
@@ -83,43 +94,60 @@ function ErrorState({
 function useTraceSelection() {
   const dispatch = useAppDispatch()
 
-  const [selectedSpanId, setSelectedSpanId] = useState<string | undefined>()
-  const [selectedTraceId, setSelectedTraceId] = useState<string | undefined>()
+  const [view, setView] = useState<TraceView>({ kind: 'list' })
 
   const handleClose = useCallback(() => {
     dispatch(uiActions.closeTraceDashboard())
   }, [dispatch])
 
   const handleBack = useCallback(() => {
-    setSelectedSpanId(undefined)
-    setSelectedTraceId(undefined)
+    setView({ kind: 'list' })
+  }, [])
+
+  const handleOpenTrace = useCallback((traceId: string) => {
+    setView({ kind: 'spans', traceId })
+  }, [])
+
+  // Takes undefined as well: the waterfall clears the selection by calling it
+  // with undefined when the already-selected row is clicked again.
+  const handleSelectSpan = useCallback((spanId: string | undefined) => {
+    setView((current) => {
+      if (current.kind === 'list') {
+        return current
+      }
+
+      if (spanId === undefined) {
+        return { kind: 'spans', traceId: current.traceId }
+      }
+
+      return { kind: 'span', spanId, traceId: current.traceId }
+    })
   }, [])
 
   const handleEscape = useCallback(() => {
-    if (selectedSpanId) {
-      setSelectedSpanId(undefined)
+    if (view.kind === 'span') {
+      handleSelectSpan(undefined)
 
       return
     }
 
-    if (selectedTraceId) {
+    if (view.kind === 'spans') {
       handleBack()
 
       return
     }
 
     handleClose()
-  }, [handleBack, handleClose, selectedSpanId, selectedTraceId])
+  }, [handleBack, handleClose, handleSelectSpan, view.kind])
 
   useHotkeys('escape', handleEscape, { enableOnFormTags: true })
 
   return {
     handleBack,
     handleClose,
-    selectedSpanId,
-    selectedTraceId,
-    setSelectedSpanId,
-    setSelectedTraceId
+    handleOpenTrace,
+    handleSelectSpan,
+    view
   }
 }
 
@@ -261,36 +289,80 @@ function TraceDashboardHeader({
   )
 }
 
+/**
+ * Owns the spans of one trace: the query, the waterfall, and the detail sidebar
+ * that reads the same rows. Keeping the sidebar in here is the point — it is
+ * rendered from the success branch, so a failed poll cannot leave it standing
+ * beside an error. TanStack Query keeps the last successful `data` through a
+ * failed refetch, which is exactly how that used to happen.
+ */
 function TraceSpansPanel({
   onSelectSpan,
   selectedSpanId,
-  traceSpans
+  traceId
 }: {
   // Takes undefined as well: the waterfall calls it with undefined to clear
   // the selection when the already-selected row is clicked again.
   onSelectSpan: (spanId: string | undefined) => void
   selectedSpanId: string | undefined
-  traceSpans: UseQueryResult<Spans>
+  traceId: string
 }): ReactElement {
+  const traceSpans = useQuery({
+    queryFn: () => apiClient.getTraceSpans(traceId),
+    queryKey: queryKeys.traceSpans(traceId),
+    refetchInterval: dashboardRefetchIntervalMs
+  })
+
+  // Only from a successful load: TanStack Query keeps the last `data` through a
+  // failed refetch, and rendering the sidebar from rows the waterfall beside it
+  // has already replaced with an error is the split screen this component was
+  // taking apart.
+  const spans = traceSpans.isSuccess ? traceSpans.data : undefined
+  const selectedSpan = spans?.find((span) => span.id === selectedSpanId)
+
+  // No span to show means no span is selected. Retention trimming the span and
+  // a poll that failed both arrive here, and in both the id names something the
+  // user cannot see — which the escape ladder would otherwise still step
+  // through, spending its first press on nothing.
+  useEffect(() => {
+    if (selectedSpanId !== undefined && selectedSpan === undefined) {
+      onSelectSpan(undefined)
+    }
+  }, [onSelectSpan, selectedSpan, selectedSpanId])
+
+  // Each branch carries the same wrapper: it is what gives the panel its width
+  // in the row, and `CenteredState` centres inside whatever it is given.
   if (traceSpans.isPending) {
-    return <LoadingState label="Loading trace" />
+    return (
+      <div className="flex-1 overflow-auto p-6">
+        <LoadingState label="Loading trace" />
+      </div>
+    )
   }
 
   if (traceSpans.isError) {
     return (
-      <ErrorState
-        message="Could not load this trace."
-        onRetry={() => void traceSpans.refetch()}
-      />
+      <div className="flex-1 overflow-auto p-6">
+        <ErrorState
+          message="Could not load this trace."
+          onRetry={() => void traceSpans.refetch()}
+        />
+      </div>
     )
   }
 
   return (
-    <TraceWaterfall
-      onSelectSpan={onSelectSpan}
-      spans={traceSpans.data}
-      {...(selectedSpanId ? { selectedSpanId } : {})}
-    />
+    <>
+      <div className="flex-1 overflow-auto p-6">
+        <TraceWaterfall
+          onSelectSpan={onSelectSpan}
+          selectedSpanId={selectedSpanId}
+          spans={traceSpans.data}
+        />
+      </div>
+
+      {selectedSpan ? <SpanDetailPanel span={selectedSpan} /> : null}
+    </>
   )
 }
 
@@ -340,14 +412,8 @@ export function TraceDashboard(): ReactElement {
   const [errorOnly, setErrorOnly] = useState(false)
   const [search, setSearch] = useState('')
 
-  const {
-    handleBack,
-    handleClose,
-    selectedSpanId,
-    selectedTraceId,
-    setSelectedSpanId,
-    setSelectedTraceId
-  } = useTraceSelection()
+  const { handleBack, handleClose, handleOpenTrace, handleSelectSpan, view } =
+    useTraceSelection()
 
   const traces = useQuery({
     queryFn: () =>
@@ -360,22 +426,10 @@ export function TraceDashboard(): ReactElement {
     refetchInterval: dashboardRefetchIntervalMs
   })
 
-  const traceSpans = useQuery({
-    enabled: Boolean(selectedTraceId),
-    queryFn: () => {
-      if (!selectedTraceId) {
-        throw new Error('Trace id is required')
-      }
+  const selectedTraceId = view.kind === 'list' ? undefined : view.traceId
 
-      return apiClient.getTraceSpans(selectedTraceId)
-    },
-    queryKey: queryKeys.traceSpans(selectedTraceId ?? ''),
-    refetchInterval: dashboardRefetchIntervalMs
-  })
-
-  const selectedSpan = traceSpans.data?.find(
-    (span) => span.id === selectedSpanId
-  )
+  // The traces list, not the spans query — the header keeps naming the trace
+  // while its spans are still loading, or failing to.
   const selectedTrace = traces.data?.find(
     (trace) => trace.traceId === selectedTraceId
   )
@@ -394,26 +448,20 @@ export function TraceDashboard(): ReactElement {
       />
 
       <div className="flex flex-1 overflow-hidden">
-        {selectedTraceId ? (
-          <>
-            <div className="flex-1 overflow-auto p-6">
-              <TraceSpansPanel
-                onSelectSpan={setSelectedSpanId}
-                selectedSpanId={selectedSpanId}
-                traceSpans={traceSpans}
-              />
-            </div>
-
-            {selectedSpan ? <SpanDetailPanel span={selectedSpan} /> : null}
-          </>
-        ) : (
+        {view.kind === 'list' ? (
           <div className="flex-1 overflow-auto">
             <TraceListPanel
               hasActiveFilters={errorOnly || search !== ''}
-              onSelect={setSelectedTraceId}
+              onSelect={handleOpenTrace}
               traces={traces}
             />
           </div>
+        ) : (
+          <TraceSpansPanel
+            onSelectSpan={handleSelectSpan}
+            selectedSpanId={view.kind === 'span' ? view.spanId : undefined}
+            traceId={view.traceId}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
Closes #67.

## The bug

The trace dashboard polls the open trace's spans every two seconds. TanStack Query keeps the last successful `data` through a failed refetch while flipping the query to `isError`, so a failed poll replaced the waterfall with "Could not load this trace." while the detail sidebar stayed open beside it, still rendering rows from the load that had just been superseded. Escape then spent its first press closing a sidebar the user was not looking at.

The dashboard's `retry: 3` means this takes a few seconds of backoff to appear in the running app rather than the first failed request — the state is reachable, not instant.

## The change

`TraceView` is one value with three variants — `list`, `spans`, `span` — replacing two independent `useState<string | undefined>`s. A span id can now only exist alongside the trace it belongs to, which is what lets the spans query take a definite `traceId` instead of `selectedTraceId ?? ''` behind an `enabled` flag.

`TraceSpansPanel` now owns the query, the waterfall and the sidebar. Both come out of the same status branch, so they cannot disagree. The panel gives up a selected span whenever there is no span to show it from, which covers retention trimming the span as well as the failed poll.

## Tests

TDD: two failing tests first — the failed-poll split screen, and a span a later poll no longer returns — then the union. Mutation testing on the result found a real remaining defect (`spans` still read `traceSpans.data`, so `selectedSpan` survived the error state), which is why the sidebar now reads from `isSuccess`. Four more tests were added to kill the mutants that survived, plus one in the other direction: a poll that succeeds must *not* close the open sidebar, which nothing else in the file would have caught.

11 tests, 11 of 13 mutants killed. The two survivors are equivalent by construction and named in the commit message.

## Verification

- `TraceDashboard.test.tsx` 11/11
- renderer suite 780 passed, 1 failed — `sqlite-adapter.test.ts`, which fails on `main` too
- backend suite 178 passed
- `tsc` on both projects, eslint and prettier clean

## Note

The removed `{...(selectedSpanId ? { selectedSpanId } : {})}` spread was never needed: `exactOptionalPropertyTypes` is not set, and `TraceWaterfall`'s prop is optional.
