### PR TITLE
refactor(secrets): hold the encryption state in one value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,11 +234,29 @@ since Chromium's `IsEncryptionAvailable()` fetches the key from the Keychain. So
   connection's Authentication section. Granting re-encrypts every stored
   password, so it is a complete reversal. The other direction is deliberately
   not offered.
-- **Known gap**: in `keychain` mode, if the keychain later breaks, `encrypt`
-  still falls back to plaintext with a one-time `log.warn` and the mode-driven
-  notice shows nothing, so the user gets no warning before that save. Surfacing
-  the warn latch through `SecretStorageResponse` would close it without probing
-  anything.
+- **Encryption state**: everything the process knows about its own encryption is
+  one value in `secret-storage.ts` — `{ mode: 'keychain', sealing }` or
+  `{ mode: 'plaintext' | 'undecided', warnedAboutPlaintext }`. The union is what
+  keeps a "the keychain is broken" flag from outliving the mode it was learned
+  about: applying a mode replaces the whole value. It is process-local and never
+  persisted, because a `'failed'` written to disk would outlive the restart that
+  fixed the keychain. `sealing` starts at `working` on every mode change, which
+  is optimism at boot (the stored mode probed nothing) and safe only because
+  nothing reports `working` — a warning needs a seal attempt that failed.
+- **A keychain that breaks after permission is granted** — a locked login
+  keyring answers `isEncryptionAvailable()` and then throws — is caught inside
+  `encrypt`, which returns the plaintext it was handed rather than letting a
+  defect turn an otherwise fine save into a 500. It warns on the transition into
+  failure rather than latching, so a keychain that breaks, is repaired, and
+  breaks again says so both times. `POST /secret-storage/grant` reports the same
+  thing to the user: it counts the rows re-encryption left as plaintext and
+  returns `mode: 'keychain'` with a `message`, which both callers check before
+  announcing a success.
+- **Known gap**: an ordinary save (`POST`/`PUT /databases`) that hits a broken
+  keychain still stores the password as plaintext with only a `log.warn` — the
+  response says nothing, so the user is told about it on the next grant and not
+  before. Carrying the sealing state on `DatabaseDto` would close it without
+  probing anything.
 
 ## Updates
 

--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -142,6 +142,42 @@ describe('DatabaseForm', () => {
     expect(request.url).toEqual('http://127.0.0.1:7847/secret-storage/grant')
   })
 
+  // Permission granted and nothing encrypted is the one outcome that used to
+  // read as a success: the mode is `keychain`, so the old check announced that
+  // every saved password was now encrypted while all of them were still
+  // plaintext.
+  it('says so when permission was granted but nothing could be encrypted', async () => {
+    const user = userEvent.setup()
+
+    secretStorageMode = 'plaintext'
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        message:
+          'Squeal has permission to use the macOS Keychain, but it refused to encrypt.',
+        mode: 'keychain',
+        storageName
+      })
+    )
+
+    renderDatabaseForm()
+
+    await user.click(screen.getByRole('button', { name: 'Turn on encryption' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Encryption is on, but some passwords are not')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'Squeal has permission to use the macOS Keychain, but it refused to encrypt.'
+        )
+      ).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Encryption is on')).not.toBeInTheDocument()
+  })
+
   it('explains why turning encryption on did not work', async () => {
     const user = userEvent.setup()
 

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -154,6 +154,17 @@ function UnencryptedPasswordNotice(): ReactElement | null {
       const response = await grant.mutateAsync()
 
       if (response.mode === 'keychain') {
+        // Permission granted and a message means the keychain took the
+        // decision and then refused to seal, so the passwords are still
+        // plaintext. Announcing a success on the mode alone said the opposite.
+        if (response.message !== null) {
+          toast.warning('Encryption is on, but some passwords are not', {
+            description: response.message
+          })
+
+          return
+        }
+
         toast.success('Encryption is on', {
           description: `Your saved passwords are now encrypted with ${response.storageName}.`
         })

--- a/src/app/components/SecretStorageConsentScreen.test.tsx
+++ b/src/app/components/SecretStorageConsentScreen.test.tsx
@@ -159,6 +159,40 @@ describe('SecretStorageConsentScreen', () => {
     ).toBeInTheDocument()
   })
 
+  // Permission granted and a message means the keychain took the decision and
+  // then refused to seal. Recording the mode is what unmounts this screen, so
+  // an alert rendered here would be gone before it could be read — and "Try
+  // again" would offer to redo a grant that worked.
+  it('carries a partial success out of the screen it is about to leave', async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(apiClient.grantSecretStorage).mockResolvedValue({
+      message:
+        'Squeal has permission to use the macOS Keychain, but it refused to encrypt.',
+      mode: 'keychain',
+      storageName
+    })
+
+    renderScreen()
+
+    await user.click(screen.getByRole('button', { name: 'Turn on encryption' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Encryption is on, but some passwords are not')
+      ).toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByText(
+        'Squeal has permission to use the macOS Keychain, but it refused to encrypt.'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Try again' })
+    ).not.toBeInTheDocument()
+  })
+
   it('asks for confirmation before skipping', async () => {
     const user = userEvent.setup()
 

--- a/src/app/components/SecretStorageConsentScreen.tsx
+++ b/src/app/components/SecretStorageConsentScreen.tsx
@@ -1,11 +1,27 @@
 import { Loader2Icon, LockIcon, TriangleAlertIcon } from 'lucide-react'
 import { ReactElement, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+import type { SecretStorageResponse } from '@/glue/api/schemas'
 
 import { useGrantSecretStorage, useSkipSecretStorage } from '../hooks/mutations'
 import { TitleBar } from './TitleBar'
 import { Button } from './ui/button'
 
 type ConsentStep = 'ask' | 'confirmSkip'
+
+// Recording the granted mode is what unmounts this screen, so a partial success
+// has nowhere to be rendered here — it goes to a toast, which outlives the
+// unmount and lands over the app the user is about to see.
+function reportGrant(response: SecretStorageResponse): void {
+  if (response.mode !== 'keychain' || response.message === null) {
+    return
+  }
+
+  toast.warning('Encryption is on, but some passwords are not', {
+    description: response.message
+  })
+}
 
 // Shown before anything else when no decision has been made about the OS
 // keychain, because until then Squeal has nowhere safe to put a connection
@@ -27,8 +43,13 @@ export function SecretStorageConsentScreen({
   const grantButton = useRef<HTMLButtonElement>(null)
 
   // A refused prompt comes back as a successful response carrying a message, not
-  // as a rejection — the request itself worked.
-  const grantMessage = grant.data?.message ?? null
+  // as a rejection — the request itself worked. A message alongside `keychain`
+  // is the other thing entirely: permission was granted and some passwords
+  // could not be encrypted, which is not something to offer "Try again" for.
+  const grantMessage =
+    grant.data !== undefined && grant.data.mode !== 'keychain'
+      ? grant.data.message
+      : null
   const isBusy = grant.isPending || skip.isPending
 
   // Disabling a focused button drops focus to the body, so hand it back when the
@@ -73,7 +94,9 @@ export function SecretStorageConsentScreen({
             <Button
               autoFocus
               disabled={isBusy}
-              onClick={() => grant.mutate()}
+              onClick={() =>
+                grant.mutate(undefined, { onSuccess: reportGrant })
+              }
               ref={grantButton}
               size="lg"
             >

--- a/src/app/components/SecretStorageConsentScreen.tsx
+++ b/src/app/components/SecretStorageConsentScreen.tsx
@@ -1,5 +1,5 @@
 import { Loader2Icon, LockIcon, TriangleAlertIcon } from 'lucide-react'
-import { ReactElement, useEffect, useRef, useState } from 'react'
+import { ReactElement, RefObject, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import type { SecretStorageResponse } from '@/glue/api/schemas'
@@ -21,6 +21,69 @@ function reportGrant(response: SecretStorageResponse): void {
   toast.warning('Encryption is on, but some passwords are not', {
     description: response.message
   })
+}
+
+function GrantRefusal({ message }: { message: string }): ReactElement {
+  return (
+    <p
+      className="flex items-start gap-2 rounded-md border border-err-border bg-err-bg px-3 py-2 text-xs text-err motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200"
+      role="alert"
+    >
+      <TriangleAlertIcon className="size-3 shrink-0 mt-[3px]" />
+      {message}
+    </p>
+  )
+}
+
+interface GrantButtonProps {
+  buttonRef: RefObject<HTMLButtonElement | null>
+  isBusy: boolean
+  isPending: boolean
+  refusal: string | null
+  storageName: string
+  onGrant: () => void
+}
+
+// The button and the line under it are one control: the spinner, the label and
+// the standing hint all answer the same question — what the OS prompt is doing
+// right now. Together they hold every branch this screen has that is not the
+// skip confirmation, which is what leaves the screen around them plain layout.
+function GrantButton({
+  buttonRef,
+  isBusy,
+  isPending,
+  refusal,
+  storageName,
+  onGrant
+}: GrantButtonProps): ReactElement {
+  return (
+    <>
+      <Button
+        autoFocus
+        disabled={isBusy}
+        onClick={onGrant}
+        ref={buttonRef}
+        size="lg"
+      >
+        {isPending && <Loader2Icon className="animate-spin" />}
+        {isPending
+          ? 'Waiting for permission…'
+          : refusal
+            ? 'Try again'
+            : 'Turn on encryption'}
+      </Button>
+
+      {isPending && (
+        <p
+          className="text-xs text-text2"
+          role="status"
+        >
+          Your system is asking whether Squeal may use {storageName}. Choose
+          Allow to continue — the prompt can open behind this window.
+        </p>
+      )}
+    </>
+  )
 }
 
 // Shown before anything else when no decision has been made about the OS
@@ -80,44 +143,19 @@ export function SecretStorageConsentScreen({
             </p>
           </div>
 
-          {grantMessage && (
-            <p
-              className="flex items-start gap-2 rounded-md border border-err-border bg-err-bg px-3 py-2 text-xs text-err motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200"
-              role="alert"
-            >
-              <TriangleAlertIcon className="size-3 shrink-0 mt-[3px]" />
-              {grantMessage}
-            </p>
-          )}
+          {grantMessage && <GrantRefusal message={grantMessage} />}
 
           <div className="flex flex-col gap-3 items-start">
-            <Button
-              autoFocus
-              disabled={isBusy}
-              onClick={() =>
+            <GrantButton
+              buttonRef={grantButton}
+              isBusy={isBusy}
+              isPending={grant.isPending}
+              refusal={grantMessage}
+              storageName={storageName}
+              onGrant={() =>
                 grant.mutate(undefined, { onSuccess: reportGrant })
               }
-              ref={grantButton}
-              size="lg"
-            >
-              {grant.isPending && <Loader2Icon className="animate-spin" />}
-              {grant.isPending
-                ? 'Waiting for permission…'
-                : grantMessage
-                  ? 'Try again'
-                  : 'Turn on encryption'}
-            </Button>
-
-            {grant.isPending && (
-              <p
-                className="text-xs text-text2"
-                role="status"
-              >
-                Your system is asking whether Squeal may use {storageName}.
-                Choose Allow to continue — the prompt can open behind this
-                window.
-              </p>
-            )}
+            />
 
             {step === 'ask' && (
               <Button

--- a/src/glue/api/schemas.ts
+++ b/src/glue/api/schemas.ts
@@ -421,8 +421,10 @@ export type HealthResponse = Schema.Schema.Type<typeof HealthResponse>
 const SecretStorageMode = Schema.Literal('keychain', 'plaintext', 'undecided')
 export type SecretStorageMode = Schema.Schema.Type<typeof SecretStorageMode>
 
-// `message` is set only when a grant was refused, so the consent screen can say
-// what happened and what to do about it. `storageName` is the platform's name
+// `message` is set when a grant was refused, and also when it was granted but
+// the keychain then refused to seal — the mode alone cannot tell that second
+// case from a clean success, so a renderer that is about to announce one has to
+// check the message first. `storageName` is the platform's name
 // for its keychain, filled in by the main process so every string the renderer
 // shows about it has a single source.
 export const SecretStorageResponse = Schema.Struct({

--- a/src/glue/secret-storage.ts
+++ b/src/glue/secret-storage.ts
@@ -24,5 +24,11 @@ export const secretStorageMessages = {
   keychainUnavailable: (storageName: string): string =>
     `Squeal could not get access to ${storageName}. If your system asked for permission, choose Allow and try again — or skip and save your passwords unencrypted.`,
   noKeyring:
-    'This system has no keyring for Squeal to store an encryption key in. Install and unlock GNOME Keyring or KWallet and try again — or skip and save your passwords unencrypted.'
+    'This system has no keyring for Squeal to store an encryption key in. Install and unlock GNOME Keyring or KWallet and try again — or skip and save your passwords unencrypted.',
+  // Permission was granted and then the keychain refused to seal anything, so
+  // the mode says `keychain` while the passwords on disk are still plaintext.
+  // Nothing else in the response can tell the two apart, which is why this is
+  // said rather than inferred.
+  sealingFailed: (count: number, storageName: string): string =>
+    `Squeal has permission to use ${storageName}, but it refused to encrypt, so ${count} saved ${count === 1 ? 'connection is' : 'connections are'} still stored unencrypted. Once ${storageName} is working again, open each connection and save it to encrypt it.`
 }

--- a/src/main/databases/secret-storage.test.ts
+++ b/src/main/databases/secret-storage.test.ts
@@ -1,4 +1,9 @@
+import { log } from 'tiny-typescript-logger'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('tiny-typescript-logger', () => ({
+  log: { warn: vi.fn() }
+}))
 
 const {
   mockDecryptString,
@@ -22,6 +27,7 @@ vi.mock('electron', () => ({
 }))
 
 import {
+  getEncryptionState,
   isEncrypted,
   probeEncryption,
   safeStorageSecretStorage,
@@ -29,6 +35,10 @@ import {
 } from './secret-storage'
 
 const realPlatform = process.platform
+
+function warnings(): string[] {
+  return vi.mocked(log.warn).mock.calls.map(([message]) => message)
+}
 
 function stubPlatform(platform: string): void {
   Object.defineProperty(process, 'platform', {
@@ -186,6 +196,207 @@ describe('secretStorage', () => {
 
       expect(probeEncryption()).toEqual('available')
       expect(mockGetSelectedStorageBackend).not.toHaveBeenCalled()
+    })
+  })
+
+  // Three module-level variables used to hold this, so nothing reset the
+  // "already warned" latches when the mode changed and the one fact the app
+  // learned about a broken keychain went into a boolean nobody read.
+  describe('encryptionState', () => {
+    it('has no decision and nothing to say before the user answers', () => {
+      setSecretStorageMode('undecided')
+
+      expect(getEncryptionState()).toEqual({
+        mode: 'undecided',
+        warnedAboutPlaintext: false
+      })
+    })
+
+    // Granting is a fresh start: whatever this process learned while it was
+    // storing plaintext was learned about the mode being replaced.
+    it('trusts the keychain the moment permission is granted', () => {
+      setSecretStorageMode('plaintext')
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      setSecretStorageMode('keychain')
+
+      expect(getEncryptionState()).toEqual({
+        mode: 'keychain',
+        sealing: 'working'
+      })
+    })
+
+    it('stays working once a secret has actually been sealed', () => {
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(getEncryptionState()).toEqual({
+        mode: 'keychain',
+        sealing: 'working'
+      })
+    })
+
+    it('records a keychain that has stopped offering encryption', () => {
+      mockIsEncryptionAvailable.mockReturnValue(false)
+
+      expect(safeStorageSecretStorage.encrypt('{"password":"x"}')).toEqual(
+        '{"password":"x"}'
+      )
+      expect(getEncryptionState()).toEqual({
+        mode: 'keychain',
+        sealing: 'failed'
+      })
+    })
+
+    // `encryptString` throwing is the likelier shape of a keychain that broke
+    // after permission was granted — a locked login keyring answers the
+    // availability check and then refuses to seal. It used to escape as a
+    // defect, which the caller sees as a 500 on an otherwise fine save.
+    it('records a keychain that throws on the way out', () => {
+      mockEncryptString.mockImplementation(() => {
+        throw new Error('The login keyring is locked.')
+      })
+
+      expect(safeStorageSecretStorage.encrypt('{"password":"x"}')).toEqual(
+        '{"password":"x"}'
+      )
+      expect(getEncryptionState()).toEqual({
+        mode: 'keychain',
+        sealing: 'failed'
+      })
+    })
+
+    it('clears the failure once the keychain seals again', () => {
+      mockIsEncryptionAvailable.mockReturnValue(false)
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      mockIsEncryptionAvailable.mockReturnValue(true)
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(getEncryptionState()).toEqual({
+        mode: 'keychain',
+        sealing: 'working'
+      })
+    })
+
+    it('forgets a failure when the mode is applied again', () => {
+      mockIsEncryptionAvailable.mockReturnValue(false)
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      setSecretStorageMode('keychain')
+
+      expect(getEncryptionState()).toEqual({
+        mode: 'keychain',
+        sealing: 'working'
+      })
+    })
+
+    it('records that plaintext has been stored and warned about', () => {
+      setSecretStorageMode('plaintext')
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(getEncryptionState()).toEqual({
+        mode: 'plaintext',
+        warnedAboutPlaintext: true
+      })
+    })
+  })
+
+  describe('warnings', () => {
+    // One line per break, not one per save: a user with ten connections would
+    // otherwise get ten identical warnings.
+    it('warns once while the keychain stays broken', () => {
+      mockIsEncryptionAvailable.mockReturnValue(false)
+
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+      safeStorageSecretStorage.encrypt('{"password":"y"}')
+
+      expect(warnings()).toEqual([
+        'OS keychain encryption is unavailable — storing connection secrets as plaintext.'
+      ])
+    })
+
+    // The whole point of a transition rather than a latch. A keychain that
+    // breaks, is fixed, and breaks again is two separate things worth saying;
+    // the old permanent latch said the second one to nobody.
+    it('warns again after the keychain recovers and breaks a second time', () => {
+      mockIsEncryptionAvailable.mockReturnValue(false)
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      mockIsEncryptionAvailable.mockReturnValue(true)
+      safeStorageSecretStorage.encrypt('{"password":"y"}')
+
+      mockIsEncryptionAvailable.mockReturnValue(false)
+      safeStorageSecretStorage.encrypt('{"password":"z"}')
+
+      expect(warnings()).toEqual([
+        'OS keychain encryption is unavailable — storing connection secrets as plaintext.',
+        'OS keychain encryption is unavailable — storing connection secrets as plaintext.'
+      ])
+    })
+
+    // What the keychain said is the only clue to what broke — a locked login
+    // keyring and a revoked login item both stop sealing, and the reported
+    // error is what tells them apart in a bug report.
+    it('repeats what the keychain said when sealing threw', () => {
+      mockEncryptString.mockImplementation(() => {
+        throw new Error('The login keyring is locked.')
+      })
+
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(warnings()).toEqual([
+        'OS keychain encryption is unavailable — storing connection secrets as plaintext. The keychain reported: Error: The login keyring is locked.'
+      ])
+    })
+
+    // `throw undefined` is legal and reads as "the keychain said nothing",
+    // which is a different fact from "the keychain answered that encryption is
+    // unavailable" — and the two used to produce the same warning.
+    it('says the keychain reported nothing when it threw nothing', () => {
+      mockEncryptString.mockImplementation(() => {
+        throw undefined
+      })
+
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(warnings()).toEqual([
+        'OS keychain encryption is unavailable — storing connection secrets as plaintext. The keychain reported: undefined'
+      ])
+    })
+
+    it('says nothing while the keychain is sealing', () => {
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      expect(warnings()).toEqual([])
+    })
+
+    it.each(['plaintext', 'undecided'] as const)(
+      'warns once about storing plaintext in %s mode',
+      (mode) => {
+        setSecretStorageMode(mode)
+
+        safeStorageSecretStorage.encrypt('{"password":"x"}')
+        safeStorageSecretStorage.encrypt('{"password":"y"}')
+
+        expect(warnings()).toEqual([
+          'Squeal does not have permission to use the OS keychain — storing connection secrets as plaintext.'
+        ])
+      }
+    )
+
+    // Nothing used to reset the latch, so a session that answered the consent
+    // screen twice fell silent after the first answer.
+    it('warns about plaintext again after the mode is applied again', () => {
+      setSecretStorageMode('plaintext')
+      safeStorageSecretStorage.encrypt('{"password":"x"}')
+
+      setSecretStorageMode('plaintext')
+      safeStorageSecretStorage.encrypt('{"password":"y"}')
+
+      expect(warnings()).toEqual([
+        'Squeal does not have permission to use the OS keychain — storing connection secrets as plaintext.',
+        'Squeal does not have permission to use the OS keychain — storing connection secrets as plaintext.'
+      ])
     })
   })
 

--- a/src/main/databases/secret-storage.ts
+++ b/src/main/databases/secret-storage.ts
@@ -8,9 +8,31 @@ export interface SecretStorage {
   encrypt(value: string): string
 }
 
+// Everything this process knows about its own encryption, in one value.
+//
+// `sealing` is representable only under `keychain` because that is the only
+// mode that tries to seal anything, and `warnedAboutPlaintext` only under the
+// two modes that never do — so there is no combination here that cannot
+// happen, and no latch that outlives the mode it was about.
+//
+// It is deliberately process-local and never persisted: a `'failed'` written to
+// disk would outlive the restart that fixed the keychain.
+export type EncryptionState =
+  | { readonly mode: 'keychain'; readonly sealing: 'failed' | 'working' }
+  | {
+      readonly mode: 'plaintext' | 'undecided'
+      readonly warnedAboutPlaintext: boolean
+    }
+
 export type KeychainProbeResult = 'available' | 'noKeyring' | 'unavailable'
 
 const encryptedPrefix = 'enc:v1:'
+
+const missingPermissionWarning =
+  'Squeal does not have permission to use the OS keychain — storing connection secrets as plaintext.'
+
+const unavailableEncryptionWarning =
+  'OS keychain encryption is unavailable — storing connection secrets as plaintext.'
 
 // This module is the only place in the app allowed to reach `safeStorage`, and
 // the mode is its permission to do so: outside `keychain`, nothing here touches
@@ -21,17 +43,27 @@ const encryptedPrefix = 'enc:v1:'
 // plain promise code alike, and `isEncryptionAvailable()` is called inside
 // `encrypt`, below the service boundary — a gate above it could not cover
 // either.
-let mode: SecretStorageMode = 'undecided'
+let state: EncryptionState = { mode: 'undecided', warnedAboutPlaintext: false }
 
-let warnedAboutMissingPermission = false
-let warnedAboutUnavailableEncryption = false
-
-export function getSecretStorageMode(): SecretStorageMode {
-  return mode
+export function getEncryptionState(): EncryptionState {
+  return state
 }
 
 export function setSecretStorageMode(next: SecretStorageMode): void {
-  mode = next
+  // Applying a mode is the reset. Whatever this process had learned — that the
+  // keychain was refusing to seal, that the plaintext warning had been given —
+  // was learned about the mode being replaced.
+  //
+  // `working` is the optimistic default rather than a third "not tried yet"
+  // value, and it is safe to be optimistic because nothing reports it: only
+  // `failed` is ever shown, and only a seal attempt can set it. Two of the
+  // three ways into keychain mode are evidence — a `probeEncryption()` that
+  // sealed a value, a database that already holds sealed rows — but the third
+  // is the mode read back from settings at boot, which has probed nothing.
+  state =
+    next === 'keychain'
+      ? { mode: 'keychain', sealing: 'working' }
+      : { mode: next, warnedAboutPlaintext: false }
 }
 
 export function isEncrypted(value: string): boolean {
@@ -78,6 +110,29 @@ export function probeEncryption(): KeychainProbeResult {
   }
 }
 
+// Warns on the transition into failure rather than latching, so a keychain that
+// breaks, is repaired, and breaks again says so both times. A latch said the
+// second one to nobody, and nothing reset it when the mode changed.
+// `reason` is already a string rather than the caught value, so "the keychain
+// answered that encryption is unavailable" and "the keychain threw `undefined`"
+// stay two different sentences.
+function recordSealingFailure(
+  value: string,
+  reason: string | undefined
+): string {
+  if (state.mode === 'keychain' && state.sealing !== 'failed') {
+    state = { mode: 'keychain', sealing: 'failed' }
+
+    log.warn(
+      reason === undefined
+        ? unavailableEncryptionWarning
+        : `${unavailableEncryptionWarning} The keychain reported: ${reason}`
+    )
+  }
+
+  return value
+}
+
 // Encrypts values with the OS keychain via Electron's safeStorage. Values are
 // stored as `enc:v1:<base64>`; anything without that prefix is treated as
 // plaintext and passed through, so rows written before the user granted
@@ -88,7 +143,7 @@ export const safeStorageSecretStorage: SecretStorage = {
       return value
     }
 
-    if (mode !== 'keychain') {
+    if (state.mode !== 'keychain') {
       // Only reachable with a database file copied from another machine, whose
       // rows are sealed with a key this one does not hold — so prompting would
       // buy nothing and would break the promise that the keychain stays
@@ -105,30 +160,32 @@ export const safeStorageSecretStorage: SecretStorage = {
   },
 
   encrypt(value: string): string {
-    if (mode !== 'keychain') {
-      if (!warnedAboutMissingPermission) {
-        warnedAboutMissingPermission = true
+    if (state.mode !== 'keychain') {
+      if (!state.warnedAboutPlaintext) {
+        state = { mode: state.mode, warnedAboutPlaintext: true }
 
-        log.warn(
-          'Squeal does not have permission to use the OS keychain — storing connection secrets as plaintext.'
-        )
+        log.warn(missingPermissionWarning)
       }
 
       return value
     }
 
-    if (!safeStorage.isEncryptionAvailable()) {
-      if (!warnedAboutUnavailableEncryption) {
-        warnedAboutUnavailableEncryption = true
-
-        log.warn(
-          'OS keychain encryption is unavailable — storing connection secrets as plaintext.'
-        )
+    // Sealing has to survive the keychain going wrong under it, not just
+    // answering `false`: a locked login keyring passes the availability check
+    // and then throws. Letting that escape turns an otherwise fine save into a
+    // 500, and the password never reaches the database at all.
+    try {
+      if (!safeStorage.isEncryptionAvailable()) {
+        return recordSealingFailure(value, undefined)
       }
 
-      return value
-    }
+      const sealed = safeStorage.encryptString(value).toString('base64')
 
-    return `${encryptedPrefix}${safeStorage.encryptString(value).toString('base64')}`
+      state = { mode: 'keychain', sealing: 'working' }
+
+      return `${encryptedPrefix}${sealed}`
+    } catch (error) {
+      return recordSealingFailure(value, String(error))
+    }
   }
 }

--- a/src/server/http/secret-storage.test.ts
+++ b/src/server/http/secret-storage.test.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpClientRequest } from '@effect/platform'
 import { eq } from 'drizzle-orm'
-import { Effect } from 'effect'
+import { Effect, Layer, Logger } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import { databasesTable, settingsTable } from '@/database/schema'
@@ -15,13 +15,24 @@ import {
 
 const storageName = safeStorageName(process.platform)
 
+interface RunOptions extends TestApiOptions {
+  // Provided outside the API layer on purpose: the route handler runs on a
+  // fiber the served layer forked, so a logger provided inside the request
+  // effect would never reach it.
+  logging?: Layer.Layer<never>
+}
+
 function run<A, E>(
   effect: Effect.Effect<A, E, AppDatabase | HttpClient.HttpClient>,
-  options: TestApiOptions = {}
+  options: RunOptions = {}
 ): Promise<A> {
-  const { layer } = makeTestApi(options)
+  const { logging = Layer.empty, ...apiOptions } = options
 
-  return Effect.runPromise(Effect.provide(effect, layer))
+  const { layer } = makeTestApi(apiOptions)
+
+  return Effect.runPromise(
+    Effect.provide(Effect.provide(effect, layer), logging)
+  )
 }
 
 interface SeedDatabaseOptions {
@@ -42,6 +53,21 @@ function seedDatabase(options: SeedDatabaseOptions) {
       })
     )
   })
+}
+
+// Re-encryption reports what it could not seal through the log and nowhere
+// else, so that is where the test has to look.
+function captureLogs() {
+  const messages: string[] = []
+
+  const layer = Logger.replace(
+    Logger.defaultLogger,
+    Logger.make(({ logLevel, message }) => {
+      messages.push(`${logLevel.label} ${String(message)}`)
+    })
+  )
+
+  return { layer, messages }
 }
 
 function readStoredMode() {
@@ -216,6 +242,52 @@ describe('secret storage routes', () => {
       })
       expect(storedMode).toEqual(null)
       expect(connectionInfo).toEqual(['{"host":"localhost"}'])
+    })
+
+    // The keychain answers the probe and then stops sealing — a locked login
+    // keyring, or a login item revoked between the two calls. `encrypt` cannot
+    // fail, so the rows come back as the plaintext they went in as, and saying
+    // nothing about it would leave the renderer announcing that the passwords
+    // are now encrypted.
+    it('tells the user which rows it could not encrypt when the keychain breaks', async () => {
+      const logs = captureLogs()
+
+      const { connectionInfo, response, storedMode } = await run(
+        Effect.gen(function* () {
+          const client = yield* makeAuthorizedClient
+
+          yield* seedDatabase({ connectionInfo: '{"host":"localhost"}' })
+
+          const response = yield* client.secretStorage.grant()
+
+          return {
+            connectionInfo: yield* readConnectionInfo(),
+            response,
+            storedMode: yield* readStoredMode()
+          }
+        }),
+        { logging: logs.layer, secretStorageSealing: 'failed' }
+      )
+
+      // The decision still stands: the user granted permission, and the next
+      // save will try the keychain again.
+      expect({
+        connectionInfo,
+        logs: logs.messages,
+        response,
+        storedMode
+      }).toEqual({
+        connectionInfo: ['{"host":"localhost"}'],
+        logs: [
+          'WARN 1 database connection(s) remain unencrypted because OS keychain encryption is unavailable.'
+        ],
+        response: {
+          message: secretStorageMessages.sealingFailed(1, storageName),
+          mode: 'keychain',
+          storageName
+        },
+        storedMode: 'keychain'
+      })
     })
 
     it('explains a system with no keyring', async () => {

--- a/src/server/services/query-runner.test.ts
+++ b/src/server/services/query-runner.test.ts
@@ -71,7 +71,6 @@ function makeGatedSecretStorage() {
         }),
       encrypt: (value: string) =>
         Effect.succeed(`${testEncryptionPrefix}${value}`),
-      mode: Effect.sync(() => 'keychain' as const),
       probe: Effect.sync(() => 'available' as const),
       setMode: () => Effect.void
     })

--- a/src/server/services/secret-storage-settings.ts
+++ b/src/server/services/secret-storage-settings.ts
@@ -98,9 +98,12 @@ export class SecretStorageSettings extends Effect.Service<SecretStorageSettings>
 
           const encrypted = yield* secrets.encrypt(record.connectionInfo)
 
-          // encrypt() returns its input when it cannot seal, which is how a
-          // keychain that broke after permission was granted shows up here.
-          if (encrypted === record.connectionInfo) {
+          // `encrypt` cannot fail — a keychain that broke after permission was
+          // granted hands back the plaintext it was given. Testing what came
+          // back keeps the verdict per row and decided from this row's own
+          // result, where asking the process for its encryption state would
+          // read a value a concurrent save can flip between the two steps.
+          if (!isEncrypted(encrypted)) {
             plaintextCount += 1
 
             continue
@@ -127,6 +130,8 @@ export class SecretStorageSettings extends Effect.Service<SecretStorageSettings>
             `${plaintextCount} database connection(s) remain unencrypted because OS keychain encryption is unavailable.`
           )
         }
+
+        return plaintextCount
       })
 
       const grant = Effect.fn('SecretStorageSettings.grant')(function* () {
@@ -149,9 +154,20 @@ export class SecretStorageSettings extends Effect.Service<SecretStorageSettings>
         // the rows leaves the decision recorded and the next boot finishes.
         yield* secrets.setMode('keychain')
         yield* persist('keychain')
-        yield* reencryptStoredSecrets()
 
-        return { message: null, mode: 'keychain' as const, storageName }
+        const plaintextCount = yield* reencryptStoredSecrets()
+
+        // A keychain can answer the probe and then refuse to seal, which leaves
+        // permission granted and the passwords on disk exactly as they were.
+        // The mode alone cannot tell that from a clean success, so it is said.
+        return {
+          message:
+            plaintextCount > 0
+              ? secretStorageMessages.sealingFailed(plaintextCount, storageName)
+              : null,
+          mode: 'keychain' as const,
+          storageName
+        }
       })
 
       // Runs at boot, before anything can ask for a secret.

--- a/src/server/services/secret-storage.ts
+++ b/src/server/services/secret-storage.ts
@@ -7,7 +7,6 @@ import { Effect } from 'effect'
 
 import type { SecretStorageMode } from '@/glue/api/schemas'
 import {
-  getSecretStorageMode,
   probeEncryption,
   safeStorageSecretStorage,
   setSecretStorageMode
@@ -30,7 +29,6 @@ export class SecretStorage extends Effect.Service<SecretStorage>()(
         }),
       encrypt: (value: string) =>
         Effect.sync(() => safeStorageSecretStorage.encrypt(value)),
-      mode: Effect.sync(() => getSecretStorageMode()),
       probe: Effect.sync(() => probeEncryption()),
       setMode: (next: SecretStorageMode) =>
         Effect.sync(() => setSecretStorageMode(next))

--- a/src/test/effect-test-helper.ts
+++ b/src/test/effect-test-helper.ts
@@ -13,7 +13,10 @@ import type { SchemaInfo, QueryResult } from '@/databases/adapter'
 import { SquealApi } from '@/glue/api/api'
 import { UpdateNotReadyError } from '@/glue/api/errors'
 import type { DatabaseConnection, SecretStorageMode } from '@/glue/api/schemas'
-import type { KeychainProbeResult } from '@/main/databases/secret-storage'
+import type {
+  EncryptionState,
+  KeychainProbeResult
+} from '@/main/databases/secret-storage'
 import { updateMessages } from '@/main/updates/updater'
 import { ServerConfig } from '@/server/config'
 import { ApiToken } from '@/server/http/api-token'
@@ -39,11 +42,32 @@ export const testEncryptionPrefix = 'enc:v1:test:'
 //
 // encrypt and decrypt deliberately ignore the mode: whether the gate holds is a
 // property of the real module and is covered by
-// src/main/databases/secret-storage.test.ts. What matters here is that the mode
-// round-trips through setMode, and that it lives in this closure rather than in
-// the real module's process-global.
-function makeTestSecretStorage(probeResult: KeychainProbeResult = 'available') {
-  let mode: SecretStorageMode = 'keychain'
+// src/main/databases/secret-storage.test.ts. What matters here is that the
+// encryption state round-trips through setMode, and that it lives in this
+// closure rather than in the real module's process-global.
+//
+// `sealing` is what a caller sets to get a keychain that answers every save
+// with the plaintext it was handed — the shape of one that broke after
+// permission was granted, and the only way to reach the code that copes.
+//
+// It deliberately survives `setMode`, where the real module resets sealing to
+// `working` on every mode change: a test says "this keychain is broken" once
+// and means it for the whole request, including the `setMode('keychain')` that
+// granting does on the way in.
+interface TestSecretStorageOptions {
+  probeResult?: KeychainProbeResult
+  sealing?: 'failed' | 'working'
+}
+
+function makeTestSecretStorage(options: TestSecretStorageOptions = {}) {
+  const { probeResult = 'available', sealing = 'working' } = options
+
+  const stateForMode = (mode: SecretStorageMode): EncryptionState =>
+    mode === 'keychain'
+      ? { mode, sealing }
+      : { mode, warnedAboutPlaintext: false }
+
+  let state: EncryptionState = stateForMode('keychain')
 
   const layer = Layer.succeed(
     SecretStorage,
@@ -55,12 +79,15 @@ function makeTestSecretStorage(probeResult: KeychainProbeResult = 'available') {
             : value
         ),
       encrypt: (value: string) =>
-        Effect.succeed(`${testEncryptionPrefix}${value}`),
-      mode: Effect.sync(() => mode),
+        Effect.succeed(
+          state.mode === 'keychain' && state.sealing === 'working'
+            ? `${testEncryptionPrefix}${value}`
+            : value
+        ),
       probe: Effect.sync(() => probeResult),
       setMode: (next: SecretStorageMode) =>
         Effect.sync(() => {
-          mode = next
+          state = stateForMode(next)
         })
     })
   )
@@ -207,12 +234,18 @@ export interface TestApiOptions {
   publicTraceReads?: boolean
   // What the keychain answers when the user asks for encryption.
   secretStorageProbe?: KeychainProbeResult
+  // 'failed' gives a keychain that grants permission and then refuses to
+  // seal anything, which is how one that broke afterwards behaves.
+  secretStorageSealing?: 'failed' | 'working'
   updateStatus?: UpdateStatus
 }
 
 export function makeTestApi(options: TestApiOptions = {}) {
   const adapterFactory = makeTestAdapterFactory(options.adapter)
-  const secretStorage = makeTestSecretStorage(options.secretStorageProbe)
+  const secretStorage = makeTestSecretStorage({
+    probeResult: options.secretStorageProbe,
+    sealing: options.secretStorageSealing
+  })
   const updater = makeTestUpdater(options.updateStatus)
 
   const services = Layer.mergeAll(


### PR DESCRIPTION
Closes #81.

## The problem

Three module-level variables in `src/main/databases/secret-storage.ts` tracked
what the process knew about its own encryption: the mode, and two "already
warned" booleans. Nothing reset the latches when the mode changed, so a session
that answered the consent screen twice fell silent after the first answer — and
the one fact the app learned about a broken keychain, that it had stopped
sealing, went into a boolean nobody could read.

## What changed

They become one `EncryptionState` union:

```ts
export type EncryptionState =
  | { readonly mode: 'keychain'; readonly sealing: 'failed' | 'working' }
  | {
      readonly mode: 'plaintext' | 'undecided'
      readonly warnedAboutPlaintext: boolean
    }
```

`sealing` is representable only under `keychain` because that is the only mode
that tries to seal anything, and `warnedAboutPlaintext` only under the two modes
that never do — so there is no combination that cannot happen and no latch that
outlives the mode it was about. Applying a mode replaces the whole value, which
is the reset. It stays process-local and is never persisted: a `'failed'` on
disk would outlive the restart that fixed the keychain.

The plaintext warning fires on the *transition* into failure rather than
latching, so a keychain that breaks, is repaired, and breaks again says so both
times — and it now repeats what the keychain actually said, which is the only
thing that tells a locked login keyring from a revoked login item.

## Two deliberate deviations from the issue

**(a) `sealing` has no `'untried'` member.** The issue sketched one. Only
`'failed'` is ever reported to anyone, and only a seal attempt can set it, so
`'working'` is a safe optimistic default — the distinction would have been a
state nothing could observe. The comment at `setSecretStorageMode` says so
plainly, including that the boot path enters `keychain` having probed nothing.

**(b) `encrypt` now catches a throwing `encryptString`.** Not asked for, but
reachable: a locked login keyring passes `isEncryptionAvailable()` and then
throws. That used to escape as a defect — a 500 on an otherwise fine save, with
the password never reaching the database at all. It now falls back to plaintext
the same way an unavailable keychain does.

## What (b) forced

Catching the throw made the failure silent where it used to fail closed. So
`POST /secret-storage/grant` counts the rows re-encryption left as plaintext and
returns them as a `message` alongside `mode: 'keychain'`, and both callers check
it before announcing a success:

- the "stored unencrypted" notice in a connection's Authentication section, which
  otherwise says *"Your saved passwords are now encrypted with the macOS
  Keychain"* when none of them are;
- the consent screen, which hands the message to a toast — recording the mode is
  what unmounts that screen, so anything rendered there would be gone before it
  could be read.

Re-encryption decides per row from what `encrypt` handed back (`isEncrypted`)
rather than reading the process-global state afterwards, so a concurrent
`POST`/`PUT /databases` cannot flip the verdict between the two steps.

## Known gap, unchanged and now documented

An ordinary save that hits a broken keychain still stores the password as
plaintext with only a `log.warn` — the response says nothing, so the user hears
about it on the next grant and not before. Closing that means carrying the
sealing state on `DatabaseDto`, which is a bigger change than this one.

## Testing

- 32 → 34 tests in `src/main/databases/secret-storage.test.ts`, including the
  keychain that throws, the keychain that throws `undefined`, and the recover
  → break-again sequence the old latch swallowed.
- 13 tests in `src/server/http/secret-storage.test.ts`, one of which drives a
  keychain that grants permission and then refuses to seal, and asserts the
  message, the log line, the untouched rows, and the persisted mode together.
- New renderer tests for both callers of the message.
- 10 hand-written mutants across the changed code; all 10 killed.
- Full suite: 970 passed, 1 pre-existing failure (`sqlite-adapter.test.ts`,
  a path-format assertion that also fails on `main`).
