### PR TITLE
feat(results): give every worksheet its own results height

### DIFF
--- a/src/app/components/ResultsPane.test.tsx
+++ b/src/app/components/ResultsPane.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { ReactElement, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { QueryDto } from '@/glue/api/schemas'
@@ -30,6 +31,48 @@ const successfulQuery = query({
     truncated: false
   }
 })
+
+// Switching tabs in the app changes which worksheet the pane is showing
+// without unmounting it, so the harness does the same.
+function SwitchablePane(): ReactElement {
+  const [worksheetId, setWorksheetId] = useState('ws-1')
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          setWorksheetId((current) => (current === 'ws-1' ? 'ws-2' : 'ws-1'))
+        }
+      >
+        Switch worksheet
+      </button>
+
+      <ResultsPane
+        databaseName="Pagila"
+        isQueryRunning={false}
+        query={undefined}
+        worksheetId={worksheetId}
+      />
+    </>
+  )
+}
+
+function paneHeight(): string | undefined {
+  return screen.getByText('No results yet').closest('section')?.style.height
+}
+
+// Shift with an arrow is the large step: 40px, and the results handle grows
+// upwards, so ArrowUp makes the pane taller.
+async function resize(
+  user: ReturnType<typeof userEvent.setup>,
+  keys: string
+): Promise<void> {
+  await user.click(
+    screen.getByRole('separator', { name: 'Resize results panel' })
+  )
+  await user.keyboard(keys)
+}
 
 beforeEach(() => {
   localStorage.clear()
@@ -154,6 +197,45 @@ describe('ResultsPane', () => {
     expect(screen.getByText('No results yet').closest('section')).toHaveStyle({
       height: '480px'
     })
+  })
+
+  // The issue: one worksheet's results pane was every worksheet's.
+  it('keeps a height of its own for each worksheet', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<SwitchablePane />, {
+      queries: [],
+      tabs: { openWorksheetIds: ['ws-1', 'ws-2'] }
+    })
+
+    await resize(user, '{Shift>}{ArrowUp}{/Shift}')
+
+    expect(paneHeight()).toEqual('360px')
+
+    await user.click(screen.getByRole('button', { name: 'Switch worksheet' }))
+    await resize(user, '{ArrowDown}{ArrowDown}')
+
+    expect(paneHeight()).toEqual('340px')
+
+    await user.click(screen.getByRole('button', { name: 'Switch worksheet' }))
+
+    expect(paneHeight()).toEqual('360px')
+  })
+
+  // Nobody has resized this one yet, and snapping back to the app default
+  // would read as the panel jumping every time a new tab is opened.
+  it('starts a worksheet nobody has resized at the last height used', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<SwitchablePane />, {
+      queries: [],
+      tabs: { openWorksheetIds: ['ws-1', 'ws-2'] }
+    })
+
+    await resize(user, '{Shift>}{ArrowUp}{/Shift}')
+    await user.click(screen.getByRole('button', { name: 'Switch worksheet' }))
+
+    expect(paneHeight()).toEqual('360px')
   })
 
   it('falls back to the default height for an out-of-range stored value', () => {

--- a/src/app/components/ResultsPane.tsx
+++ b/src/app/components/ResultsPane.tsx
@@ -2,7 +2,7 @@ import { ReactElement, useEffect, useState } from 'react'
 
 import type { QueryDto } from '@/glue/api/schemas'
 
-import { usePersistedSize } from '../hooks/use-persisted-size'
+import { usePersistedSizes } from '../hooks/use-persisted-sizes'
 import { useWorksheetMessages } from '../hooks/use-worksheet-messages'
 import { cn } from '../lib/utils'
 import { useAppSelector } from '../store'
@@ -17,6 +17,10 @@ type ResultsTab = 'messages' | 'results'
 const defaultHeight = 320
 const maximumHeight = 620
 const minimumHeight = 120
+
+// Enough that a session's worth of worksheets all keep their height, small
+// enough that the stored record cannot grow without end.
+const maximumRememberedHeights = 50
 
 interface ResultsPaneProps {
   databaseName: string | undefined
@@ -45,12 +49,19 @@ export function ResultsPane({
   const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
   const messages = useWorksheetMessages(worksheetId)
 
-  const [height, setHeight] = usePersistedSize({
+  // Each worksheet keeps its own height, and the record is bounded by a cap on
+  // how many it holds rather than by the open tabs: closing a worksheet and
+  // opening it again is ordinary, and losing its height there would make this
+  // hold only for as long as the tab does.
+  const { setSize, sizeFor } = usePersistedSizes({
     defaultSize: defaultHeight,
     maximum: maximumHeight,
+    maximumKeys: maximumRememberedHeights,
     minimum: minimumHeight,
     storageKey: 'ui:resultsHeight'
   })
+
+  const height = sizeFor(worksheetId)
 
   // Which tab is showing is remembered per worksheet, so switching tabs does
   // not snap everyone back to Results.
@@ -87,13 +98,17 @@ export function ResultsPane({
 
   return (
     <>
+      {/* With no worksheet open there is no key to store the height under, so
+          the drag moves the fallback — which is the height every worksheet
+          nobody has resized starts at, and what a single shared height did for
+          all of them. */}
       <ResizeHandle
         ariaLabel="Resize results panel"
         className="h-[7px] -my-[3px]"
         growsToward="start"
         orientation="row"
         size={height}
-        onResize={setHeight}
+        onResize={(size) => setSize(worksheetId, size)}
       />
 
       <section

--- a/src/app/hooks/panel-size-storage.ts
+++ b/src/app/hooks/panel-size-storage.ts
@@ -1,0 +1,25 @@
+// What both panel-size hooks need from `localStorage`, in one place. They held
+// a copy each while the second one was being written, which is 44 identical
+// lines that have to be changed together to stay correct.
+
+export function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value))
+}
+
+// Storage can be unavailable (or throw) in some Electron contexts, and a panel
+// size is never important enough to break rendering over.
+export function readStorageItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function writeStorageItem(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // A size that fails to persist is still usable for this session.
+  }
+}

--- a/src/app/hooks/use-persisted-size.ts
+++ b/src/app/hooks/use-persisted-size.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react'
 
+import { clamp, readStorageItem, writeStorageItem } from './panel-size-storage'
+
 export interface PersistedSizeOptions {
   defaultSize: number
   maximum: number
@@ -8,28 +10,6 @@ export interface PersistedSizeOptions {
 }
 
 export type PersistedSize = [size: number, setSize: (size: number) => void]
-
-function clamp(value: number, minimum: number, maximum: number): number {
-  return Math.min(maximum, Math.max(minimum, value))
-}
-
-// Storage can be unavailable (or throw) in some Electron contexts, and a
-// panel size is never important enough to break rendering over.
-function readStorageItem(key: string): string | null {
-  try {
-    return window.localStorage.getItem(key)
-  } catch {
-    return null
-  }
-}
-
-function writeStorageItem(key: string, value: string): void {
-  try {
-    window.localStorage.setItem(key, value)
-  } catch {
-    // A size that fails to persist is still usable for this session.
-  }
-}
 
 // A stored size only survives when it is a finite number inside the current
 // bounds. Hand-edited storage, or bounds that moved between releases, fall

--- a/src/app/hooks/use-persisted-sizes.test.ts
+++ b/src/app/hooks/use-persisted-sizes.test.ts
@@ -1,0 +1,543 @@
+import { act, renderHook } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePersistedSizes } from './use-persisted-sizes'
+
+const storageKey = 'ui:resultsHeight'
+
+// Small on purpose: eviction is the interesting behaviour, and three keys make
+// it visible without a wall of setup.
+function renderSizes(maximumKeys = 3) {
+  return renderHook(() =>
+    usePersistedSizes({
+      defaultSize: 320,
+      maximum: 620,
+      maximumKeys,
+      minimum: 120,
+      storageKey
+    })
+  )
+}
+
+// Reads the whole picture rather than the one key a test expects to have
+// moved, so a change that leaks into the others cannot pass.
+function sizes(
+  sizeFor: (key: string | undefined) => number
+): Record<string, number> {
+  return {
+    none: sizeFor(undefined),
+    'ws-1': sizeFor('ws-1'),
+    'ws-2': sizeFor('ws-2')
+  }
+}
+
+// Counts renders as well as returning the hook, which is the only way to see
+// a resize that changes nothing still costing one.
+function renderCountedSizes(maximumKeys = 3) {
+  const renders = { count: 0 }
+
+  const { result } = renderHook(() => {
+    renders.count += 1
+
+    return usePersistedSizes({
+      defaultSize: 320,
+      maximum: 620,
+      maximumKeys,
+      minimum: 120,
+      storageKey
+    })
+  })
+
+  return { renders, result }
+}
+
+function stored(): unknown {
+  return JSON.parse(localStorage.getItem(storageKey) ?? 'null')
+}
+
+describe('usePersistedSizes', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('gives every key the default size when nothing is stored', () => {
+    const { result } = renderSizes()
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 320,
+      'ws-1': 320,
+      'ws-2': 320
+    })
+  })
+
+  it('keeps a size of its own for each key', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    act(() => {
+      result.current.setSize('ws-2', 200)
+    })
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 200,
+      'ws-1': 500,
+      'ws-2': 200
+    })
+  })
+
+  // Snapping an unresized key back to the app default would read as the panel
+  // jumping every time one is opened, which is the one thing a single shared
+  // size got right.
+  it('starts a key nobody has resized at the last size set anywhere', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 500,
+      'ws-1': 500,
+      'ws-2': 500
+    })
+  })
+
+  it('leaves a key that has been resized where the user put it', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-2', 200)
+    })
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 500,
+      'ws-1': 500,
+      'ws-2': 200
+    })
+  })
+
+  it('moves only the fallback when a size is set with no key', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    act(() => {
+      result.current.setSize(undefined, 250)
+    })
+
+    // The stored record is read too: a size set with no key belongs in the
+    // fallback and nowhere else. Writing it under the key it did not get gives
+    // the record an entry named after the missing argument.
+    expect({
+      sizes: sizes(result.current.sizeFor),
+      stored: stored()
+    }).toEqual({
+      sizes: { none: 250, 'ws-1': 500, 'ws-2': 250 },
+      stored: { default: 250, sizes: { 'ws-1': 500 } }
+    })
+  })
+
+  it('clamps a size to the bounds', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', 9000)
+    })
+
+    act(() => {
+      result.current.setSize('ws-2', -40)
+    })
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 120,
+      'ws-1': 620,
+      'ws-2': 120
+    })
+  })
+
+  it('ignores a size that is not a finite number', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', Number.NaN)
+    })
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 320,
+      'ws-1': 320,
+      'ws-2': 320
+    })
+  })
+
+  it('keeps sizes across an unmount', () => {
+    const first = renderSizes()
+
+    act(() => {
+      first.result.current.setSize('ws-1', 500)
+    })
+
+    first.unmount()
+
+    const { result } = renderSizes()
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 500,
+      'ws-1': 500,
+      'ws-2': 500
+    })
+  })
+
+  // A mount that changes nothing must not write: the first thing this hook
+  // does on a fresh install would otherwise be to replace the size a previous
+  // release stored with its own serialization of the same number.
+  it('writes nothing on a mount that changes nothing', () => {
+    localStorage.setItem(storageKey, '480')
+
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+
+    renderSizes()
+
+    expect(setItem.mock.calls).toEqual([])
+  })
+
+  // Dragging a handle emits a size on every pointer move, and most of them
+  // repeat the last one. Serializing is cheap; a storage write per pixel is
+  // not.
+  it('writes nothing when a size is set to what it already was', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    expect(setItem.mock.calls).toEqual([])
+  })
+
+  // A drag emits a size on every pointer move, and a drag held past the bounds
+  // emits the same clamped one over and over. The old shared size got this for
+  // free — React bails out when a state number is unchanged — and a record that
+  // is rebuilt every time does not.
+  it('does not re-render when a size is set to what it already was', () => {
+    const { renders, result } = renderCountedSizes()
+
+    // The resize, then one repeat: React renders once more before it bails out
+    // on a state object that came back unchanged, and only the moves after that
+    // are free.
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    const before = renders.count
+
+    for (let move = 0; move < 10; move += 1) {
+      act(() => {
+        result.current.setSize('ws-1', 500)
+      })
+    }
+
+    expect(renders.count).toEqual(before)
+  })
+
+  // Nor may it swallow a real change. The fallback moving to a number the key
+  // does not hold is not the key changing, so resizing the key to that same
+  // number afterwards still has to land on it.
+  it('resizes a key to the size the fallback already holds', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    act(() => {
+      result.current.setSize(undefined, 300)
+    })
+
+    act(() => {
+      result.current.setSize('ws-1', 300)
+    })
+
+    expect(stored()).toEqual({ default: 300, sizes: { 'ws-1': 300 } })
+  })
+
+  // The bail-out above must not swallow the recency refresh: re-setting the
+  // size a key already has is still the user using that key, and dropping it
+  // for that reason would evict the key they just touched.
+  it('counts a repeated size as using the key again', () => {
+    const { result } = renderSizes()
+
+    for (const key of ['ws-1', 'ws-2', 'ws-3', 'ws-1']) {
+      act(() => {
+        result.current.setSize(key, 500)
+      })
+    }
+
+    act(() => {
+      result.current.setSize('ws-4', 400)
+    })
+
+    expect(stored()).toEqual({
+      default: 400,
+      sizes: { 'ws-1': 500, 'ws-3': 500, 'ws-4': 400 }
+    })
+  })
+
+  // V8 orders array-index keys ahead of insertion order, so one in the record
+  // is always evicted first and re-inserting it never refreshes it — the
+  // recency this cap evicts by would silently stop being recency. No worksheet
+  // id is one (they are UUIDs), so anything that looks like an index was
+  // hand-edited in.
+  it('takes no size from an array-index key in storage', () => {
+    localStorage.setItem(storageKey, '{"sizes":{"2":300,"ws-1":500}}')
+
+    const { result } = renderSizes()
+
+    expect({
+      '2': result.current.sizeFor('2'),
+      'ws-1': result.current.sizeFor('ws-1')
+    }).toEqual({ '2': 320, 'ws-1': 500 })
+  })
+
+  // What this key held while the size was shared by every panel. Reading it as
+  // the fallback carries the height the user chose into their first per-key
+  // session instead of resetting them to the default.
+  it('reads a bare number left by an earlier release as the fallback', () => {
+    localStorage.setItem(storageKey, '480')
+
+    const { result } = renderSizes()
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 480,
+      'ws-1': 480,
+      'ws-2': 480
+    })
+  })
+
+  it('falls back to the default when storage cannot be read', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Access to storage is denied.')
+    })
+
+    const { result } = renderSizes()
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 320,
+      'ws-1': 320,
+      'ws-2': 320
+    })
+  })
+
+  it('still resizes when storage refuses to be written', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('The storage quota has been exceeded.')
+    })
+
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 500,
+      'ws-1': 500,
+      'ws-2': 500
+    })
+  })
+
+  // Every one of these is a value a hand-edit or an older release can leave
+  // behind, and the read runs inside a `useState` initializer — so anything
+  // that throws here takes the whole editor down on boot rather than losing a
+  // panel size.
+  it.each([
+    ['nonsense that is not JSON', 'not json at all'],
+    ['a stored null', 'null'],
+    ['a stored string', '"480"'],
+    ['a record whose sizes are null', '{"sizes":null}'],
+    ['a size below the minimum', '{"sizes":{"ws-1":40}}'],
+    ['a size above the maximum', '{"sizes":{"ws-1":5000}}'],
+    ['a size that parses to infinity', '{"sizes":{"ws-1":1e999}}'],
+    ['a size that is not a number', '{"sizes":{"ws-1":"500"}}']
+  ])('survives %s in storage', (_description, value) => {
+    localStorage.setItem(storageKey, value)
+
+    const { result } = renderSizes()
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 320,
+      'ws-1': 320,
+      'ws-2': 320
+    })
+  })
+
+  // An array clears `typeof === 'object'`, and reading one as a record gives
+  // entries named after its indices — sizes belonging to keys no worksheet
+  // will ever have, held against the cap forever.
+  it('takes no sizes from a record whose sizes are an array', () => {
+    localStorage.setItem(storageKey, '{"sizes":[500,200]}')
+
+    const { result } = renderSizes()
+
+    expect({
+      '0': result.current.sizeFor('0'),
+      '1': result.current.sizeFor('1'),
+      none: result.current.sizeFor(undefined)
+    }).toEqual({ '0': 320, '1': 320, none: 320 })
+  })
+
+  it('rounds a fractional stored size', () => {
+    localStorage.setItem(storageKey, '{"default":320,"sizes":{"ws-1":500.6}}')
+
+    const { result } = renderSizes()
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 320,
+      'ws-1': 501,
+      'ws-2': 320
+    })
+  })
+
+  // The bound. Without it the record grows by one entry for every key ever
+  // resized and never gives one back.
+  it('drops the least recently sized key once the record is full', () => {
+    const { result } = renderSizes()
+
+    for (const [key, size] of [
+      ['ws-1', 500],
+      ['ws-2', 200],
+      ['ws-3', 300],
+      ['ws-4', 400]
+    ] as const) {
+      act(() => {
+        result.current.setSize(key, size)
+      })
+    }
+
+    expect(stored()).toEqual({
+      default: 400,
+      sizes: { 'ws-2': 200, 'ws-3': 300, 'ws-4': 400 }
+    })
+  })
+
+  it('counts resizing a key as using it again', () => {
+    const { result } = renderSizes()
+
+    for (const [key, size] of [
+      ['ws-1', 500],
+      ['ws-2', 200],
+      ['ws-3', 300],
+      ['ws-1', 480],
+      ['ws-4', 400]
+    ] as const) {
+      act(() => {
+        result.current.setSize(key, size)
+      })
+    }
+
+    expect(stored()).toEqual({
+      default: 400,
+      sizes: { 'ws-1': 480, 'ws-3': 300, 'ws-4': 400 }
+    })
+  })
+
+  // The reason the bound is a cap rather than a sweep of the keys that are
+  // still open: closing a worksheet's tab and opening it again is ordinary,
+  // and forgetting its height there would make the feature hold only for as
+  // long as the tab does.
+  it('keeps the size of a key that is not being used right now', () => {
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    act(() => {
+      result.current.setSize('ws-2', 200)
+    })
+
+    expect(result.current.sizeFor('ws-1')).toEqual(500)
+  })
+
+  // The read trims what the hook uses, not what is on disk: the oversized
+  // record stays in storage until the next resize rewrites it, because a mount
+  // that changes nothing deliberately writes nothing. What must not happen is
+  // the extra entries counting against the cap for the rest of the session.
+  it('forgets the oldest stored sizes when the record arrives over the cap', () => {
+    localStorage.setItem(
+      storageKey,
+      '{"default":320,"sizes":{"ws-1":500,"ws-2":200,"ws-3":300,"ws-4":400}}'
+    )
+
+    const { result } = renderSizes()
+
+    expect(sizes(result.current.sizeFor)).toEqual({
+      none: 320,
+      'ws-1': 320,
+      'ws-2': 200
+    })
+  })
+
+  it('trims a stored record that is over the cap', () => {
+    localStorage.setItem(
+      storageKey,
+      '{"default":320,"sizes":{"ws-1":500,"ws-2":200,"ws-3":300,"ws-4":400}}'
+    )
+
+    const { result } = renderSizes()
+
+    act(() => {
+      result.current.setSize('ws-5', 360)
+    })
+
+    expect(stored()).toEqual({
+      default: 360,
+      sizes: { 'ws-3': 300, 'ws-4': 400, 'ws-5': 360 }
+    })
+  })
+
+  // React mounts every component twice in development, so an effect that
+  // writes on the second pass would double every write in the real app.
+  it('writes once under StrictMode', () => {
+    const { result } = renderHook(
+      () =>
+        usePersistedSizes({
+          defaultSize: 320,
+          maximum: 620,
+          maximumKeys: 3,
+          minimum: 120,
+          storageKey
+        }),
+      { wrapper: StrictMode }
+    )
+
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+
+    act(() => {
+      result.current.setSize('ws-1', 500)
+    })
+
+    expect(setItem.mock.calls).toEqual([
+      [storageKey, '{"default":500,"sizes":{"ws-1":500}}']
+    ])
+  })
+})

--- a/src/app/hooks/use-persisted-sizes.ts
+++ b/src/app/hooks/use-persisted-sizes.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { clamp, readStorageItem, writeStorageItem } from './panel-size-storage'
+
 export interface PersistedSizesOptions {
   defaultSize: number
   maximum: number
@@ -22,28 +24,6 @@ export interface PersistedSizes {
 interface Sizes {
   default: number
   sizes: Record<string, number>
-}
-
-function clamp(value: number, minimum: number, maximum: number): number {
-  return Math.min(maximum, Math.max(minimum, value))
-}
-
-// Storage can be unavailable (or throw) in some Electron contexts, and a panel
-// size is never important enough to break rendering over.
-function readStorageItem(key: string): string | null {
-  try {
-    return window.localStorage.getItem(key)
-  } catch {
-    return null
-  }
-}
-
-function writeStorageItem(key: string, value: string): void {
-  try {
-    window.localStorage.setItem(key, value)
-  } catch {
-    // A size that fails to persist is still usable for this session.
-  }
 }
 
 // A stored size only survives when it is a finite number that lands inside the
@@ -117,7 +97,19 @@ function readStoredSizes(options: PersistedSizesOptions): Sizes {
     return empty
   }
 
-  const record = parsed as { default?: unknown; sizes?: unknown }
+  return readStoredRecord(
+    parsed as { default?: unknown; sizes?: unknown },
+    options
+  )
+}
+
+// The record shape, once `readStoredSizes` has established that it is one. Split
+// out because the two halves fail differently: everything above rejects the
+// stored value whole, everything here keeps what survives and drops the rest.
+function readStoredRecord(
+  record: { default?: unknown; sizes?: unknown },
+  options: PersistedSizesOptions
+): Sizes {
   const sizes: Record<string, number> = {}
 
   // An array survives `typeof === 'object'` and would hand back entries named

--- a/src/app/hooks/use-persisted-sizes.ts
+++ b/src/app/hooks/use-persisted-sizes.ts
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface PersistedSizesOptions {
+  defaultSize: number
+  maximum: number
+  // How many per-key sizes the record may hold. The least recently resized key
+  // is dropped past this, which is what keeps the record from growing by one
+  // entry for every key ever resized.
+  maximumKeys: number
+  minimum: number
+  storageKey: string
+}
+
+export interface PersistedSizes {
+  setSize: (key: string | undefined, size: number) => void
+  sizeFor: (key: string | undefined) => number
+}
+
+// The fallback and the per-key overrides are one value because they move
+// together: setting a size both remembers it for that key and becomes the size
+// a key nobody has resized yet starts at.
+interface Sizes {
+  default: number
+  sizes: Record<string, number>
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value))
+}
+
+// Storage can be unavailable (or throw) in some Electron contexts, and a panel
+// size is never important enough to break rendering over.
+function readStorageItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function writeStorageItem(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // A size that fails to persist is still usable for this session.
+  }
+}
+
+// A stored size only survives when it is a finite number that lands inside the
+// current bounds. Hand-edited storage, or bounds that moved between releases,
+// fall back to the default rather than laying out a broken panel.
+//
+// Rounding happens before the bounds test so the number that is checked is the
+// number that gets used.
+function validSize(
+  value: unknown,
+  options: PersistedSizesOptions
+): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+
+  const rounded = Math.round(value)
+
+  if (rounded < options.minimum || rounded > options.maximum) {
+    return undefined
+  }
+
+  return rounded
+}
+
+// Insertion order is the recency order — `setSize` re-inserts the key it
+// touches — so the oldest entries are simply the first ones.
+function capSizes(
+  sizes: Record<string, number>,
+  maximumKeys: number
+): Record<string, number> {
+  const keys = Object.keys(sizes)
+
+  if (keys.length <= maximumKeys) {
+    return sizes
+  }
+
+  return Object.fromEntries(
+    keys.slice(keys.length - maximumKeys).map((key) => [key, sizes[key]])
+  )
+}
+
+function readStoredSizes(options: PersistedSizesOptions): Sizes {
+  const empty: Sizes = { default: options.defaultSize, sizes: {} }
+
+  const stored = readStorageItem(options.storageKey)
+
+  if (stored === null) {
+    return empty
+  }
+
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(stored)
+  } catch {
+    return empty
+  }
+
+  // A bare number is what this key held while the size was shared by every
+  // panel. Reading it as the fallback carries the size the user had chosen
+  // into their first per-key session instead of resetting them to the default.
+  if (typeof parsed === 'number') {
+    return {
+      default: validSize(parsed, options) ?? options.defaultSize,
+      sizes: {}
+    }
+  }
+
+  if (parsed === null || typeof parsed !== 'object') {
+    return empty
+  }
+
+  const record = parsed as { default?: unknown; sizes?: unknown }
+  const sizes: Record<string, number> = {}
+
+  // An array survives `typeof === 'object'` and would hand back entries named
+  // after its indices, which are keys no worksheet will ever have.
+  if (
+    record.sizes !== null &&
+    typeof record.sizes === 'object' &&
+    !Array.isArray(record.sizes)
+  ) {
+    for (const [key, value] of Object.entries(
+      record.sizes as Record<string, unknown>
+    )) {
+      // V8 puts array-index keys ahead of insertion order, so one in the
+      // record would always be evicted first and re-inserting it would never
+      // refresh it — the recency this cap evicts by would quietly stop being
+      // recency. No worksheet id is one, so anything that looks like an index
+      // was hand-edited in.
+      if (String(Number(key)) === key) {
+        continue
+      }
+
+      const size = validSize(value, options)
+
+      if (size !== undefined) {
+        sizes[key] = size
+      }
+    }
+  }
+
+  return {
+    default: validSize(record.default, options) ?? options.defaultSize,
+    sizes: capSizes(sizes, options.maximumKeys)
+  }
+}
+
+/**
+ * Panel sizes in pixels, one per key, clamped to the given bounds and persisted
+ * together under `storageKey`.
+ *
+ * A key with no size of its own takes the last size set anywhere, so opening a
+ * key nobody has resized does not snap the panel back to the app default —
+ * which is the behaviour a single shared size used to give for free.
+ *
+ * The record holds at most `maximumKeys` sizes and drops the least recently
+ * resized one past that. A cap rather than a sweep of the keys that are still
+ * open, because closing a worksheet and opening it again is ordinary, and
+ * forgetting its size there would make the feature hold only for as long as the
+ * tab does.
+ */
+export function usePersistedSizes(
+  options: PersistedSizesOptions
+): PersistedSizes {
+  const { maximum, maximumKeys, minimum, storageKey } = options
+
+  const [sizes, setSizes] = useState<Sizes>(() => readStoredSizes(options))
+
+  // Seeded on the first effect run rather than from the read, so a mount that
+  // changes nothing writes nothing — otherwise the first thing a new release
+  // does is replace the stored value with its own serialization of the same
+  // sizes.
+  const persistedRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const serialized = JSON.stringify(sizes)
+
+    if (persistedRef.current === null) {
+      persistedRef.current = serialized
+
+      return
+    }
+
+    if (persistedRef.current === serialized) {
+      return
+    }
+
+    persistedRef.current = serialized
+
+    writeStorageItem(storageKey, serialized)
+  }, [sizes, storageKey])
+
+  const setSize = useCallback(
+    (key: string | undefined, nextSize: number) => {
+      if (!Number.isFinite(nextSize)) {
+        return
+      }
+
+      const clamped = clamp(Math.round(nextSize), minimum, maximum)
+
+      setSizes((current) => {
+        if (key === undefined) {
+          return current.default === clamped
+            ? current
+            : { default: clamped, sizes: current.sizes }
+        }
+
+        const keys = Object.keys(current.sizes)
+
+        // Returning the same object is what stops a drag held past the bounds
+        // from re-rendering on every pointer move — it emits the same clamped
+        // size over and over, and a record rebuilt each time is a new object
+        // even when nothing about it changed. The last term keeps the recency
+        // refresh below honest: a key that is not already the most recent one
+        // still has to move, whatever its size.
+        if (
+          current.default === clamped &&
+          current.sizes[key] === clamped &&
+          keys[keys.length - 1] === key
+        ) {
+          return current
+        }
+
+        // Deleting before inserting is what moves the key to the end of the
+        // record: assigning over a key it already holds keeps that key's
+        // original position, and position is the recency this cap evicts by.
+        const rest = { ...current.sizes }
+
+        delete rest[key]
+
+        return {
+          default: clamped,
+          sizes: capSizes({ ...rest, [key]: clamped }, maximumKeys)
+        }
+      })
+    },
+    [maximum, maximumKeys, minimum]
+  )
+
+  const sizeFor = useCallback(
+    (key: string | undefined): number => {
+      if (key === undefined) {
+        return sizes.default
+      }
+
+      return sizes.sizes[key] ?? sizes.default
+    },
+    [sizes]
+  )
+
+  return { setSize, sizeFor }
+}


### PR DESCRIPTION
Closes #46.

## The problem

The results panel stored one height under `ui:resultsHeight` and applied it to
every worksheet. Sizing the panel for a wide result set resized it for the
schema note in the next tab too.

## What changed

`usePersistedSizes` (new, next to the existing single-value
`usePersistedSize`) replaces the stored number with `{ default, sizes }`:

- **A key nobody has resized takes the last size set anywhere**, not the app
  default. Snapping back would read as the panel jumping every time a worksheet
  is opened, which is the one thing a single shared height got right.
- **A bare number left by an earlier release is read as that fallback**, so the
  height the user already chose carries into their first per-key session.
- **The record is bounded by a cap on how many sizes it holds (50)** rather than
  by which tabs are open. Closing a worksheet and opening it again is ordinary,
  and forgetting its height there would make the feature hold only for as long
  as the tab does.

## The eviction order

Insertion order *is* the recency order — `setSize` deletes the key before
re-inserting it, so the key it touched moves to the end, and `capSizes` drops
from the front. Both the read and the write trim.

Two consequences worth naming:

- **Array-index keys are refused on the way in.** V8 orders those ahead of
  insertion order, so one in the record would always be evicted first and
  re-inserting it would never refresh it — the recency this cap evicts by would
  quietly stop being recency. Worksheet ids are UUIDs, so anything that looks
  like an index was hand-edited in.
- **Re-setting the size a key already has still counts as using it.** The
  render bail-out below only fires when the key is already the most recent one.

## Two things that do not happen

- **A drag held past the bounds does not re-render per pointer move.** It emits
  the same clamped size on every move; the updater returns the state object
  unchanged, which the old single number got for free from React's `Object.is`
  bail-out.
- **A mount that changes nothing writes nothing.** `persistedRef` is seeded on
  the first effect run rather than from the read, so a new release does not open
  by replacing the stored value with its own serialization of the same sizes.

## Testing

33 tests for the hook, plus `ResultsPane.test.tsx`. Storage is treated as
hostile — nonsense that is not JSON, a stored `null`, a stored string, a record
whose `sizes` is `null` or an array, sizes below the minimum, above the maximum,
`1e999`, and non-numbers — because the read runs inside a `useState`
initializer, where a throw takes the whole editor down on boot rather than
losing a panel size.

23 hand-written mutants across the hook and `ResultsPane`; 21 killed. The two
survivors are equivalent and confirmed so independently by a review pass:
`Number.isFinite` in `validSize` (JSON cannot produce `NaN`, and `±Infinity` is
caught by the bounds test) and `<=` → `<` in `capSizes` (same set, same order,
one wasted allocation). Both stay — the first is correct defence the moment a
runtime number reaches `validSize`.

Full suite: 986 passed, 1 pre-existing failure (`sqlite-adapter.test.ts`, a path
format assertion that also fails on `main`).

## Deferred

`clamp`, `readStorageItem` and `writeStorageItem` are byte-identical in
`use-persisted-size.ts` and `use-persisted-sizes.ts`. Merging the two *hooks*
would change `AppSidebar`'s persisted format, which does not belong in this PR;
lifting just the three helpers is a follow-up.
