### PR TITLE
fix(cancel): stop cancel from fabricating a query state it does not own

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -4,6 +4,7 @@ import invariant from 'tiny-invariant'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DatabaseDto } from '@/glue/databases'
+import { QueryDto } from '@/glue/api/schemas'
 import { WorksheetDto } from '@/glue/worksheets'
 import { App, useWorksheetSession } from './App'
 import { useAppSelector } from './store'
@@ -12,9 +13,11 @@ import { renderWithProviders } from './test-utils'
 
 vi.mock('./api-client', () => ({
   apiClient: {
+    cancelQuery: vi.fn(async () => undefined),
     createQuery: vi.fn(),
     getDatabases: vi.fn(async () => []),
     getDatabaseSchema: vi.fn(async () => ({ tables: [] })),
+    getQuery: vi.fn(),
     updateWorksheet: vi.fn()
   }
 }))
@@ -203,6 +206,65 @@ describe('running a query', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('canceling a query', () => {
+  const runningQuery: QueryDto = {
+    content: 'SELECT pg_sleep(30);',
+    databaseId: 'database-1',
+    error: null,
+    finishedAt: null,
+    id: 'q-1',
+    queriedAt: 1,
+    result: null,
+    truncated: false,
+    worksheetId: 'ws-1'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(apiClient.updateWorksheet).mockResolvedValue(testWorksheet)
+    vi.mocked(apiClient.getQuery).mockResolvedValue(runningQuery)
+  })
+
+  // The whole app rather than a probe: the props `App` hands the toolbar are
+  // the wiring under test, and a probe that passes them itself would keep
+  // passing with `App` unwired.
+  function renderApp(): void {
+    renderWithProviders(<App />, {
+      databases: [testDatabase],
+      openWorksheetId: 'ws-1',
+      queries: [runningQuery],
+      ui: { gettingStartedDismissed: true },
+      worksheets: [testWorksheet]
+    })
+  }
+
+  it('cancels the running query when the button is clicked', async () => {
+    renderApp()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(vi.mocked(apiClient.cancelQuery).mock.calls).toEqual([['q-1']])
+    })
+  })
+
+  // The row stays running until the backend finalizes it, so the button is on
+  // screen the whole time the request is in flight. Saying "Canceling…" and
+  // refusing further clicks is the only feedback the user gets in that window.
+  it('shows the cancel as in flight until the backend finalizes the row', async () => {
+    renderApp()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    const button = await screen.findByRole('button', { name: 'Canceling…' })
+
+    expect({
+      disabled: button.hasAttribute('disabled'),
+      label: button.textContent
+    }).toEqual({ disabled: true, label: 'Canceling…' })
   })
 })
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -27,7 +27,6 @@ import {
 import { useCancelQuery } from './hooks/mutations'
 import { useStartQuery } from './hooks/use-start-query'
 import { useWorksheetAutosave } from './hooks/useWorksheetAutosave'
-import type { QueryDto } from '@/glue/api/schemas'
 import { useAppDispatch, useAppSelector } from './store'
 import { selectActiveWorksheetId } from './store/tabs-slice'
 import { uiActions } from './store/ui-slice'
@@ -104,20 +103,6 @@ function useActiveStatement(openWorksheetId: string | undefined) {
   }
 }
 
-function useCancelRunningQuery(query: QueryDto | undefined) {
-  const cancelQuery = useCancelQuery()
-
-  const { cancel: cancelQueryById } = cancelQuery
-
-  const handleCancelQuery = useCallback(() => {
-    if (query?.id) {
-      cancelQueryById(query.id)
-    }
-  }, [cancelQueryById, query?.id])
-
-  return { handleCancelQuery, isCancelPending: cancelQuery.isPending }
-}
-
 function useLatestQuery(openWorksheetId: string | undefined) {
   const queries = useQueriesList()
 
@@ -176,7 +161,7 @@ export function useWorksheetSession(openWorksheetId: string | undefined) {
 
   useQueryResultSync(query)
 
-  const { handleCancelQuery, isCancelPending } = useCancelRunningQuery(query)
+  const { cancel: handleCancelQuery, isCanceling } = useCancelQuery(query)
 
   const { flushSave, queueSave, saveState } =
     useWorksheetAutosave(openWorksheetId)
@@ -215,7 +200,7 @@ export function useWorksheetSession(openWorksheetId: string | undefined) {
     handleCancelQuery,
     handleRunQuery,
     handleUpdateContent,
-    isCancelPending,
+    isCanceling,
     isQueryRunning: Boolean(query && !query.finishedAt),
     query,
     saveState,
@@ -313,7 +298,7 @@ function Workspace(): ReactElement {
     handleCancelQuery,
     handleRunQuery,
     handleUpdateContent,
-    isCancelPending,
+    isCanceling,
     isQueryRunning,
     query,
     saveState,
@@ -330,7 +315,7 @@ function Workspace(): ReactElement {
 
         <WorksheetToolbar
           activeStatement={activeStatement}
-          isCancelPending={isCancelPending}
+          isCanceling={isCanceling}
           isQueryRunning={isQueryRunning}
           onCancelQuery={handleCancelQuery}
           onRunQuery={handleRunQuery}

--- a/src/app/components/WorksheetToolbar.test.tsx
+++ b/src/app/components/WorksheetToolbar.test.tsx
@@ -45,7 +45,7 @@ describe('WorksheetToolbar', () => {
     renderWithProviders(
       <WorksheetToolbar
         activeStatement={statement}
-        isCancelPending={false}
+        isCanceling={false}
         isQueryRunning={false}
         onCancelQuery={vi.fn()}
         onRunQuery={onRunQuery}
@@ -68,7 +68,7 @@ describe('WorksheetToolbar', () => {
     renderWithProviders(
       <WorksheetToolbar
         activeStatement={statement}
-        isCancelPending={false}
+        isCanceling={false}
         isQueryRunning={false}
         onCancelQuery={vi.fn()}
         onRunQuery={vi.fn()}
@@ -85,7 +85,7 @@ describe('WorksheetToolbar', () => {
     renderWithProviders(
       <WorksheetToolbar
         activeStatement={statement}
-        isCancelPending={false}
+        isCanceling={false}
         isQueryRunning={false}
         onCancelQuery={vi.fn()}
         onRunQuery={vi.fn()}
@@ -102,7 +102,7 @@ describe('WorksheetToolbar', () => {
     renderWithProviders(
       <WorksheetToolbar
         activeStatement={null}
-        isCancelPending={false}
+        isCanceling={false}
         isQueryRunning={false}
         onCancelQuery={vi.fn()}
         onRunQuery={vi.fn()}
@@ -123,7 +123,7 @@ describe('WorksheetToolbar', () => {
     renderWithProviders(
       <WorksheetToolbar
         activeStatement={statement}
-        isCancelPending={false}
+        isCanceling={false}
         isQueryRunning={false}
         onCancelQuery={vi.fn()}
         onRunQuery={vi.fn()}
@@ -143,7 +143,7 @@ describe('WorksheetToolbar', () => {
     renderWithProviders(
       <WorksheetToolbar
         activeStatement={statement}
-        isCancelPending={false}
+        isCanceling={false}
         isQueryRunning
         onCancelQuery={onCancelQuery}
         onRunQuery={vi.fn()}
@@ -162,7 +162,7 @@ describe('WorksheetToolbar', () => {
     renderWithProviders(
       <WorksheetToolbar
         activeStatement={statement}
-        isCancelPending
+        isCanceling
         isQueryRunning
         onCancelQuery={vi.fn()}
         onRunQuery={vi.fn()}
@@ -177,7 +177,7 @@ describe('WorksheetToolbar', () => {
     renderWithProviders(
       <WorksheetToolbar
         activeStatement={statement}
-        isCancelPending={false}
+        isCanceling={false}
         isQueryRunning={false}
         onCancelQuery={vi.fn()}
         onRunQuery={vi.fn()}

--- a/src/app/components/WorksheetToolbar.tsx
+++ b/src/app/components/WorksheetToolbar.tsx
@@ -8,7 +8,7 @@ import { type Statement } from '../sql-parser'
 
 interface WorksheetToolbarProps {
   activeStatement: Statement | null
-  isCancelPending: boolean
+  isCanceling: boolean
   isQueryRunning: boolean
   onCancelQuery: () => void
   onRunQuery: () => void
@@ -16,7 +16,7 @@ interface WorksheetToolbarProps {
 
 export function WorksheetToolbar({
   activeStatement,
-  isCancelPending,
+  isCanceling,
   isQueryRunning,
   onCancelQuery,
   onRunQuery
@@ -61,11 +61,11 @@ export function WorksheetToolbar({
       {isQueryRunning && (
         <Button
           className="cursor-pointer"
-          disabled={isCancelPending}
+          disabled={isCanceling}
           variant="outline"
           onClick={onCancelQuery}
         >
-          {isCancelPending ? 'Canceling…' : 'Cancel'}
+          {isCanceling ? 'Canceling…' : 'Cancel'}
         </Button>
       )}
 

--- a/src/app/hooks/mutations.test.tsx
+++ b/src/app/hooks/mutations.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, renderHook, screen } from '@testing-library/react'
 import { ReactElement } from 'react'
+import invariant from 'tiny-invariant'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { canceledQueryMessage } from '@/glue/queries'
@@ -84,6 +85,49 @@ function stayRunning(): void {
   vi.mocked(apiClient.cancelQuery).mockImplementation(async () => undefined)
 }
 
+// A backend that refuses the cancel outright, with the row left running — what
+// the user sees when the request never lands.
+function failCancel(): void {
+  vi.mocked(apiClient.getQuery).mockImplementation(async () => runningQuery)
+  vi.mocked(apiClient.cancelQuery).mockRejectedValue(
+    new Error('The connection was lost.')
+  )
+}
+
+/**
+ * A backend whose cancel answers only when the test says so, and whose row can
+ * be finalized separately. That is the only way to put a whole query lifetime
+ * between the click and the answer to it.
+ */
+function deferredCancels() {
+  const rejecters = new Map<string, (error: Error) => void>()
+
+  let row = runningQuery
+
+  vi.mocked(apiClient.getQuery).mockImplementation(async () => row)
+  vi.mocked(apiClient.cancelQuery).mockImplementation(
+    (queryId: string) =>
+      new Promise<void>((_resolve, reject) => {
+        rejecters.set(queryId, reject)
+      })
+  )
+
+  return {
+    async fail(queryId: string): Promise<void> {
+      const reject = rejecters.get(queryId)
+
+      invariant(reject, `No cancel is in flight for ${queryId}.`)
+
+      await act(async () => {
+        reject(new Error('The connection was lost.'))
+      })
+    },
+    finalize(): void {
+      row = canceledQuery
+    }
+  }
+}
+
 describe('useCancelQuery', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -111,8 +155,10 @@ describe('useCancelQuery', () => {
 
     expect(await screen.findByText('canceling')).toBeInTheDocument()
 
-    expect(screen.getByText('running')).toBeInTheDocument()
-    expect(screen.getByText('no error')).toBeInTheDocument()
+    expect({
+      error: screen.getByText('no error').textContent,
+      row: screen.getByText('running').textContent
+    }).toEqual({ error: 'no error', row: 'running' })
   })
 
   it('shows the query as canceled once the backend finalizes it', async () => {
@@ -192,10 +238,7 @@ describe('useCancelQuery', () => {
   // on "Canceling…" forever would tell the user the query is on its way out
   // when nothing has asked for it.
   it('offers cancel again when the request fails', async () => {
-    vi.mocked(apiClient.getQuery).mockImplementation(async () => runningQuery)
-    vi.mocked(apiClient.cancelQuery).mockRejectedValue(
-      new Error('The connection was lost.')
-    )
+    failCancel()
 
     renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
 
@@ -209,10 +252,7 @@ describe('useCancelQuery', () => {
   // The query keeps running either way, so the one thing the user must not be
   // left with is a click that looks like it worked.
   it('says so when the cancel request fails', async () => {
-    vi.mocked(apiClient.getQuery).mockImplementation(async () => runningQuery)
-    vi.mocked(apiClient.cancelQuery).mockRejectedValue(
-      new Error('The connection was lost.')
-    )
+    failCancel()
 
     renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
 
@@ -223,7 +263,120 @@ describe('useCancelQuery', () => {
     ).toBeInTheDocument()
 
     expect(
-      screen.getByText('The connection was lost. The query is still running.')
+      screen.getByText('The query is still running. The connection was lost.')
+    ).toBeInTheDocument()
+  })
+
+  // A cancel request can outlive the query it belongs to: the backend bounds
+  // its cancel work at five seconds and the poller can write the terminal row
+  // first. A rejection that lands after that describes a query nobody is
+  // looking at any more, and saying so would be a message about nothing.
+  it('says nothing when the cancel fails after the query has finished', async () => {
+    const cancels = deferredCancels()
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(await screen.findByText('canceling')).toBeInTheDocument()
+
+    cancels.finalize()
+
+    expect(await screen.findByText('finished')).toBeInTheDocument()
+
+    await cancels.fail('q-1')
+
+    // Absence needs a wait: the toast the other cases assert on is only found
+    // by polling, so checking immediately would pass without proving anything.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300))
+    })
+
+    expect(screen.queryByText('Could not cancel the query')).toBeNull()
+  })
+
+  // The same rejection must not re-enable a Cancel that belongs to a different
+  // query — that one's own request is still in flight.
+  it('leaves a later query alone when an earlier cancel fails', async () => {
+    const cancels = deferredCancels()
+
+    const { rerender, result } = renderHook(
+      ({ query }: { query: QueryDto }) => useCancelQuery(query),
+      { initialProps: { query: runningQuery } }
+    )
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    rerender({ query: { ...runningQuery, id: 'q-2' } })
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    await cancels.fail('q-1')
+
+    expect(result.current.isCanceling).toEqual(true)
+  })
+
+  // A finished row can go back to running: a slow insert response landing after
+  // the poller already saw the query finish rewrites it. The button must not
+  // come back saying "Canceling…" with nothing in flight.
+  it('forgets the cancel once the query it belongs to has finished', () => {
+    stayRunning()
+
+    const { rerender, result } = renderHook(
+      ({ query }: { query: QueryDto }) => useCancelQuery(query),
+      { initialProps: { query: runningQuery } }
+    )
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    rerender({ query: canceledQuery })
+    rerender({ query: runningQuery })
+
+    expect(result.current.isCanceling).toEqual(false)
+  })
+
+  // Only the canceled query's own terminal row means the cancel is over. Every
+  // worksheet has its own latest query, so looking at a finished one elsewhere
+  // must leave the cancel you started intact for when you come back to it.
+  it('keeps the cancel while a different query is finished', () => {
+    stayRunning()
+
+    const { rerender, result } = renderHook(
+      ({ query }: { query: QueryDto }) => useCancelQuery(query),
+      { initialProps: { query: runningQuery } }
+    )
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    rerender({ query: { ...canceledQuery, id: 'q-2' } })
+    rerender({ query: runningQuery })
+
+    expect(result.current.isCanceling).toEqual(true)
+  })
+
+  // A rejection that is not an `Error` has no message worth showing, so the
+  // advice has to come from us — an empty half would read as a cut-off
+  // sentence.
+  it('still says what to do when the failure carries no message', async () => {
+    vi.mocked(apiClient.getQuery).mockImplementation(async () => runningQuery)
+    vi.mocked(apiClient.cancelQuery).mockRejectedValue('no message at all')
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(
+      await screen.findByText(
+        'The query is still running. Try canceling it again.'
+      )
     ).toBeInTheDocument()
   })
 

--- a/src/app/hooks/mutations.test.tsx
+++ b/src/app/hooks/mutations.test.tsx
@@ -1,0 +1,252 @@
+import { act, fireEvent, renderHook, screen } from '@testing-library/react'
+import { ReactElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { canceledQueryMessage } from '@/glue/queries'
+import type { QueryDto } from '@/glue/api/schemas'
+
+import { renderWithProviders } from '../test-utils'
+import { useCancelQuery } from './mutations'
+import { useQueriesList, useQueryResultSync } from './queries'
+
+vi.mock('../api-client', () => ({
+  apiClient: {
+    cancelQuery: vi.fn(async () => undefined),
+    getDatabases: vi.fn(async () => []),
+    getQueries: vi.fn(async () => []),
+    getQuery: vi.fn(),
+    getWorksheets: vi.fn(async () => [])
+  }
+}))
+
+import { apiClient } from '../api-client'
+
+const runningQuery: QueryDto = {
+  content: 'SELECT pg_sleep(30);',
+  databaseId: 'database-1',
+  error: null,
+  finishedAt: null,
+  id: 'q-1',
+  queriedAt: 1,
+  result: null,
+  truncated: false,
+  worksheetId: 'ws-1'
+}
+
+const canceledQuery: QueryDto = {
+  ...runningQuery,
+  error: canceledQueryMessage,
+  finishedAt: 2
+}
+
+// The same pairing `App` makes: the poller is the only writer of the terminal
+// row, and cancel is a request that the poller is expected to observe.
+function CancelProbe(): ReactElement {
+  const queries = useQueriesList()
+  const query = queries.data[0]
+
+  useQueryResultSync(query)
+
+  const { cancel, isCanceling } = useCancelQuery(query)
+
+  return (
+    <>
+      <button
+        onClick={cancel}
+        type="button"
+      >
+        cancel
+      </button>
+
+      <output>{isCanceling ? 'canceling' : 'idle'}</output>
+      <output>{query?.finishedAt ? 'finished' : 'running'}</output>
+      <output>{query?.error ?? 'no error'}</output>
+    </>
+  )
+}
+
+// A backend that finalizes the row only once someone asks it to, which is what
+// makes the window between the click and the terminal row observable.
+function finalizeOnCancel(): void {
+  let finalized = false
+
+  vi.mocked(apiClient.getQuery).mockImplementation(async () =>
+    finalized ? canceledQuery : runningQuery
+  )
+
+  vi.mocked(apiClient.cancelQuery).mockImplementation(async () => {
+    finalized = true
+  })
+}
+
+function stayRunning(): void {
+  vi.mocked(apiClient.getQuery).mockImplementation(async () => runningQuery)
+  vi.mocked(apiClient.cancelQuery).mockImplementation(async () => undefined)
+}
+
+describe('useCancelQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('asks the backend to cancel the running query', () => {
+    stayRunning()
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(vi.mocked(apiClient.cancelQuery).mock.calls).toEqual([['q-1']])
+  })
+
+  // The row is the backend's to finalize. Writing a terminal state here would
+  // disable the poller in the very window it is needed, which is why the old
+  // implementation had to hand-roll a second one.
+  it('leaves the row running until the backend finalizes it', async () => {
+    stayRunning()
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(await screen.findByText('canceling')).toBeInTheDocument()
+
+    expect(screen.getByText('running')).toBeInTheDocument()
+    expect(screen.getByText('no error')).toBeInTheDocument()
+  })
+
+  it('shows the query as canceled once the backend finalizes it', async () => {
+    finalizeOnCancel()
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(await screen.findByText('finished')).toBeInTheDocument()
+
+    expect(screen.getByText(canceledQueryMessage)).toBeInTheDocument()
+  })
+
+  // Self-clears off the row rather than off the request, so the flag cannot
+  // outlive the query it belongs to.
+  it('stops reporting canceling once the terminal row arrives', async () => {
+    finalizeOnCancel()
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(await screen.findByText('finished')).toBeInTheDocument()
+
+    expect(screen.getByText('idle')).toBeInTheDocument()
+  })
+
+  // The button used to unmount on click, so nothing had to stop a second one.
+  // Now it stays on screen for as long as the query runs.
+  it('ignores a second click while the first cancel is in flight', async () => {
+    stayRunning()
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(await screen.findByText('canceling')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(vi.mocked(apiClient.cancelQuery).mock.calls).toEqual([['q-1']])
+  })
+
+  // The flag belongs to the query it was set for, not to whatever is running
+  // now. Running a second query while the first is still being canceled would
+  // otherwise open with its cancel button already spent.
+  it('does not report canceling for a query it was not asked about', () => {
+    stayRunning()
+
+    const { rerender, result } = renderHook(
+      ({ query }: { query: QueryDto }) => useCancelQuery(query),
+      { initialProps: { query: runningQuery } }
+    )
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    expect(result.current.isCanceling).toEqual(true)
+
+    rerender({ query: { ...runningQuery, id: 'q-2' } })
+
+    expect(result.current.isCanceling).toEqual(false)
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    expect(vi.mocked(apiClient.cancelQuery).mock.calls).toEqual([
+      ['q-1'],
+      ['q-2']
+    ])
+  })
+
+  // A cancel that never reached the backend is not a cancel. Leaving the label
+  // on "Canceling…" forever would tell the user the query is on its way out
+  // when nothing has asked for it.
+  it('offers cancel again when the request fails', async () => {
+    vi.mocked(apiClient.getQuery).mockImplementation(async () => runningQuery)
+    vi.mocked(apiClient.cancelQuery).mockRejectedValue(
+      new Error('The connection was lost.')
+    )
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(await screen.findByText('idle')).toBeInTheDocument()
+
+    expect(screen.getByText('running')).toBeInTheDocument()
+  })
+
+  // The query keeps running either way, so the one thing the user must not be
+  // left with is a click that looks like it worked.
+  it('says so when the cancel request fails', async () => {
+    vi.mocked(apiClient.getQuery).mockImplementation(async () => runningQuery)
+    vi.mocked(apiClient.cancelQuery).mockRejectedValue(
+      new Error('The connection was lost.')
+    )
+
+    renderWithProviders(<CancelProbe />, { queries: [runningQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(
+      await screen.findByText('Could not cancel the query')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByText('The connection was lost. The query is still running.')
+    ).toBeInTheDocument()
+  })
+
+  it('does nothing for a query that has already finished', () => {
+    stayRunning()
+
+    renderWithProviders(<CancelProbe />, { queries: [canceledQuery] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect({
+      calls: vi.mocked(apiClient.cancelQuery).mock.calls,
+      canceling: screen.getByText('idle').textContent
+    }).toEqual({ calls: [], canceling: 'idle' })
+  })
+
+  it('does nothing when there is no query to cancel', () => {
+    stayRunning()
+
+    renderWithProviders(<CancelProbe />, { queries: [] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(vi.mocked(apiClient.cancelQuery).mock.calls).toEqual([])
+  })
+})

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -1,10 +1,9 @@
-import { createOptimisticAction } from '@tanstack/react-db'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
 
 import { apiClient } from '../api-client'
 import { useCollections } from '../collections-context'
-import { queryPollInterval } from './queries'
 import { queryKeys } from '../query-keys'
 import {
   CreateDatabaseRequest,
@@ -12,71 +11,60 @@ import {
   type QueryDto,
   UpdateDatabaseRequest
 } from '@/glue/api/schemas'
-import { canceledQueryMessage } from '@/glue/queries'
 
-const cancelPollAttempts = 20
-
-// The cancel endpoint only signals the running adapter; the backend finalizes
-// the row afterwards. Wait for that so the optimistic canceled state is not
-// dropped before the server row catches up.
-async function waitForQueryToFinish(
-  queryId: string
-): Promise<QueryDto | undefined> {
-  for (let attempt = 0; attempt < cancelPollAttempts; attempt++) {
-    const query = await apiClient.getQuery(queryId)
-
-    if (query.finishedAt) {
-      return query
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, queryPollInterval))
-  }
-
-  return undefined
+export interface CancelQuery {
+  cancel: () => void
+  isCanceling: boolean
 }
 
-export function useCancelQuery() {
-  const { queries } = useCollections()
-  const [isPending, setIsPending] = useState(false)
-
-  const cancelAction = useMemo(
-    () =>
-      createOptimisticAction<string>({
-        onMutate: (queryId) => {
-          queries.update(queryId, (draft) => {
-            draft.error = canceledQueryMessage
-            draft.finishedAt = Date.now()
-          })
-        },
-        mutationFn: async (queryId) => {
-          await apiClient.cancelQuery(queryId)
-
-          const finalQuery = await waitForQueryToFinish(queryId)
-
-          if (finalQuery && queries.status === 'ready') {
-            queries.utils.writeUpsert(finalQuery)
-          }
-        }
-      }),
-    [queries]
+/**
+ * Asks the backend to cancel `query`, and reports whether that request is
+ * still outstanding.
+ *
+ * Nothing here writes the query row. The cancel endpoint only signals the
+ * running adapter — the backend finalizes the row afterwards, and
+ * `useQueryResultSync` is the single owner of that transition. Writing a
+ * terminal state optimistically used to disable that poller in exactly the
+ * window it is needed, which is why cancel had to hand-roll a second one.
+ *
+ * `isCanceling` is derived from the row rather than from the request, so it
+ * clears the moment the real terminal row lands and cannot outlive the query
+ * it belongs to.
+ */
+export function useCancelQuery(query: QueryDto | undefined): CancelQuery {
+  const [cancelingQueryId, setCancelingQueryId] = useState<string | undefined>(
+    undefined
   )
 
-  const cancel = useCallback(
-    (queryId: string) => {
-      setIsPending(true)
+  const runningQueryId = query?.finishedAt === null ? query.id : undefined
+  const isCanceling =
+    runningQueryId !== undefined && cancelingQueryId === runningQueryId
 
-      const transaction = cancelAction(queryId)
+  const cancel = useCallback(() => {
+    // The button now stays on screen for as long as the query runs, so this is
+    // what stops a second click from sending a second request.
+    if (runningQueryId === undefined || isCanceling) {
+      return
+    }
 
-      void transaction.isPersisted.promise
-        .catch((): void => undefined)
-        .finally(() => {
-          setIsPending(false)
-        })
-    },
-    [cancelAction]
-  )
+    setCancelingQueryId(runningQueryId)
 
-  return { cancel, isPending }
+    void apiClient.cancelQuery(runningQueryId).catch((error: unknown) => {
+      const reason =
+        error instanceof Error ? error.message : 'The request failed.'
+
+      // A cancel that never reached the backend is not a cancel: the query is
+      // still running, and leaving the button on "Canceling…" would say
+      // otherwise.
+      setCancelingQueryId(undefined)
+
+      toast.error('Could not cancel the query', {
+        description: `${reason} The query is still running.`
+      })
+    })
+  }, [isCanceling, runningQueryId])
+
+  return { cancel, isCanceling }
 }
 
 export function useCreateWorksheet() {

--- a/src/app/hooks/mutations.ts
+++ b/src/app/hooks/mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import { apiClient } from '../api-client'
@@ -32,13 +32,39 @@ export interface CancelQuery {
  * it belongs to.
  */
 export function useCancelQuery(query: QueryDto | undefined): CancelQuery {
-  const [cancelingQueryId, setCancelingQueryId] = useState<string | undefined>(
-    undefined
-  )
+  const [cancelingQueryId, setCancelingQueryId] = useState<string>()
+
+  // A rejection lands long after the click that built its handler, so it cannot
+  // read the flag out of its own closure. The ref is written with the state and
+  // only ever beside it, so there is still one answer to "which query is the
+  // button showing as canceling".
+  const shownCancelingId = useRef<string | undefined>(undefined)
+
+  const setCanceling = useCallback((queryId: string | undefined): void => {
+    shownCancelingId.current = queryId
+
+    setCancelingQueryId(queryId)
+  }, [])
 
   const runningQueryId = query?.finishedAt === null ? query.id : undefined
   const isCanceling =
     runningQueryId !== undefined && cancelingQueryId === runningQueryId
+
+  // Forgetting the id once its own row goes terminal. The flag is derived, so
+  // the button has already gone — but a row can regress from finished back to
+  // running when a slow insert response lands after the poller saw it finish,
+  // and a remembered id would relabel that button "Canceling…" with nothing in
+  // flight. Only this query's own terminal row clears it, so a cancel left
+  // behind in another worksheet is still reported when you go back to it.
+  useEffect(() => {
+    if (
+      cancelingQueryId !== undefined &&
+      query?.id === cancelingQueryId &&
+      query.finishedAt !== null
+    ) {
+      setCanceling(undefined)
+    }
+  }, [cancelingQueryId, query?.finishedAt, query?.id, setCanceling])
 
   const cancel = useCallback(() => {
     // The button now stays on screen for as long as the query runs, so this is
@@ -47,22 +73,36 @@ export function useCancelQuery(query: QueryDto | undefined): CancelQuery {
       return
     }
 
-    setCancelingQueryId(runningQueryId)
+    const canceledQueryId = runningQueryId
 
-    void apiClient.cancelQuery(runningQueryId).catch((error: unknown) => {
-      const reason =
-        error instanceof Error ? error.message : 'The request failed.'
+    setCanceling(canceledQueryId)
+
+    void apiClient.cancelQuery(canceledQueryId).catch((error: unknown) => {
+      // A rejection for a query the button has moved on from has nothing left
+      // to report: clearing the flag would re-enable a Cancel whose own request
+      // is still in flight, and the message would describe a query that is no
+      // longer running.
+      if (shownCancelingId.current !== canceledQueryId) {
+        return
+      }
 
       // A cancel that never reached the backend is not a cancel: the query is
       // still running, and leaving the button on "Canceling…" would say
       // otherwise.
-      setCancelingQueryId(undefined)
+      setCanceling(undefined)
+
+      // The fact first, then what to do about it — `reason` carries the
+      // client's own advice ("Restart Squeal and try again."), and the fallback
+      // has to supply some, because a rejection that is not an `Error` has no
+      // message worth showing.
+      const reason =
+        error instanceof Error ? error.message : 'Try canceling it again.'
 
       toast.error('Could not cancel the query', {
-        description: `${reason} The query is still running.`
+        description: `The query is still running. ${reason}`
       })
     })
-  }, [isCanceling, runningQueryId])
+  }, [isCanceling, runningQueryId, setCanceling])
 
   return { cancel, isCanceling }
 }

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -16,7 +16,7 @@ import type {
 } from '@/glue/api/schemas'
 import { canceledQueryMessage } from '@/glue/queries'
 
-export const queryPollInterval = 250
+const queryPollInterval = 250
 
 export function useDatabases() {
   const { databases } = useCollections()


### PR DESCRIPTION
Closes #52.

## What was wrong

`useCancelQuery` wrote a terminal row into the collection the moment the cancel
request resolved — `error: canceledQueryMessage`, `finishedAt: Date.now()`. That
write disabled `useQueryResultSync`'s poller in exactly the window the poller is
needed, so cancel had to hand-roll a second owner of the running→finished
transition, and the row the user saw was the renderer's guess rather than the
backend's answer. A cancel that the adapter could not honour still showed the
query as canceled.

## What this does

The cancel endpoint only signals the running adapter. The backend finalizes the
row, `useQueryResultSync` remains the single owner of that transition, and this
hook writes nothing. `isCanceling` is derived from the row rather than from the
request, so it clears the moment the real terminal row lands and cannot outlive
the query it belongs to.

The second commit is the review pass:

- **A rejection no longer speaks for a query the button has moved on from.** The
  handler is built at click time and lands whenever the request finally gives
  up — possibly after the poller wrote the terminal row, or after the user
  started a second query. It used to clear the flag and toast unconditionally,
  re-enabling a Cancel whose own request was still in flight and describing a
  query that had already stopped running. The id the button is showing is now
  written to a ref beside the state, and the handler compares against it.
- **The id is forgotten once its own query goes terminal.** A row can regress
  from finished back to running when a slow insert response lands after the
  poller saw it finish; a remembered id would relabel that button "Canceling…"
  with nothing in flight. Only that query's own terminal row clears it, so a
  cancel started in another worksheet is still reported when you go back to it.
- **The failure message leads with the fact**: "The query is still running."
  first, then the cause. A rejection that is not an `Error` now supplies its own
  advice instead of a bare sentence fragment.
- `queryPollInterval` is no longer exported — nothing outside `queries.ts` used
  it.

## Tests

15 tests in `mutations.test.tsx` plus two in `App.test.tsx`. The `App` cases
render the whole app rather than a probe, because the props `App` hands the
toolbar are the wiring under test and a probe that passes them itself would keep
passing with `App` unwired.

A 14-mutant pass over the hook and the wiring — dropping the ref write, dropping
the stale-rejection guard, dropping or loosening the terminal-row clear,
allowing a second click, allowing a finished row to be cancelled, untying the
flag from the row, dropping the reset or the toast on failure, reversing the
message order, emptying the non-`Error` fallback, and unwiring each toolbar prop
— kills all 14.

## Worth knowing before merging

- **The issue flags this as needing a product decision, and it still does.** Not
  writing an optimistic row means the results pane keeps showing `RunningQuery`
  for up to one 250ms poll after the backend finalizes, instead of flipping to
  "Query canceled." instantly. If the backend never finalizes the row, the UI
  stays on "running" indefinitely rather than lying about it. That is the
  trade-off: slower, honest feedback in place of immediate, sometimes-wrong
  feedback.
- **Only the Postgres adapter implements `cancel`.** MySQL and SQLite have no
  `adapter.cancel`, so the request returns without stopping anything and the
  button reads "Canceling…" for the rest of the statement's natural duration.
  Pre-existing; not addressed here.
- **`apiClient.cancelQuery` has no request timeout.** A hung request leaves the
  button on "Canceling…" until the row finalizes. This is a codebase-level gap —
  no renderer API call passes an `AbortSignal.timeout` — so it is out of scope
  for this change, but worth a follow-up.
