### PR TITLE
fix(worksheets): tell the user which worksheet failed to save

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -11,6 +11,26 @@ import { useAppSelector } from './store'
 import { selectActiveWorksheetId, tabsActions } from './store/tabs-slice'
 import { renderWithProviders } from './test-utils'
 
+// `App` loads the editor lazily, and the real one pulls in CodeMirror and the
+// SQL language support behind it — a chunk large enough that waiting on it here
+// would make the test a race against the bundler. The stub keeps the one thing
+// `App` reaches the editor through: the `onChange` that carries an edit back
+// out.
+vi.mock('./components/WorksheetEditor', () => ({
+  WorksheetEditor: ({
+    onChange
+  }: {
+    onChange?: (value: string) => void
+  }): ReactElement => (
+    <button
+      type="button"
+      onClick={() => onChange?.('SELECT 2;')}
+    >
+      type into the editor
+    </button>
+  )
+}))
+
 vi.mock('./api-client', () => ({
   apiClient: {
     cancelQuery: vi.fn(async () => undefined),
@@ -284,6 +304,60 @@ describe('canceling a query', () => {
       disabled: button.hasAttribute('disabled'),
       label: button.textContent
     }).toEqual({ disabled: true, label: 'Canceling…' })
+  })
+})
+
+describe('a save that fails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // The whole app rather than a probe: the prop `App` hands the status bar is
+  // the wiring under test, and a probe that passes it itself would keep passing
+  // with `App` unwired. The toast is gone within seconds, so this notice is the
+  // only standing sign that the worksheet on screen has unsaved edits.
+  it('shows the failure in the status bar', async () => {
+    vi.mocked(apiClient.updateWorksheet).mockRejectedValue(
+      new Error('The connection was lost.')
+    )
+
+    renderWithProviders(<App />, {
+      databases: [testDatabase],
+      openWorksheetId: 'ws-1',
+      queries: [],
+      ui: { gettingStartedDismissed: true },
+      worksheets: [testWorksheet]
+    })
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'type into the editor' })
+    )
+
+    expect(await screen.findByText('Save failed')).toBeInTheDocument()
+  })
+
+  it('says nothing in the status bar while saves succeed', async () => {
+    vi.mocked(apiClient.updateWorksheet).mockResolvedValue(testWorksheet)
+
+    renderWithProviders(<App />, {
+      databases: [testDatabase],
+      openWorksheetId: 'ws-1',
+      queries: [],
+      ui: { gettingStartedDismissed: true },
+      worksheets: [testWorksheet]
+    })
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'type into the editor' })
+    )
+
+    await waitFor(() => {
+      expect(apiClient.updateWorksheet).toHaveBeenCalledWith('ws-1', {
+        content: 'SELECT 2;'
+      })
+    })
+
+    expect(screen.queryByText('Save failed')).toBeNull()
   })
 })
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -192,7 +192,7 @@ export function useWorksheetSession(openWorksheetId: string | undefined) {
 
   const { cancel: handleCancelQuery, isCanceling } = useCancelQuery(query)
 
-  const { flushSave, queueSave, saveState } =
+  const { flushSave, hasSaveFailed, queueSave } =
     useWorksheetAutosave(openWorksheetId)
 
   const handleUpdateContent = useCallback(
@@ -230,10 +230,10 @@ export function useWorksheetSession(openWorksheetId: string | undefined) {
     handleCancelQuery,
     handleRunQuery,
     handleUpdateContent,
+    hasSaveFailed,
     isCanceling,
     isQueryRunning: isQueryInFlight(query),
     query,
-    saveState,
     setCursorOffset,
     statements
   }
@@ -321,10 +321,10 @@ function Workspace(): ReactElement {
     handleCancelQuery,
     handleRunQuery,
     handleUpdateContent,
+    hasSaveFailed,
     isCanceling,
     isQueryRunning,
     query,
-    saveState,
     setCursorOffset,
     statements
   } = useWorksheetSession(openWorksheetId)
@@ -372,8 +372,8 @@ function Workspace(): ReactElement {
         <StatusBar
           cursorPosition={cursorPosition}
           database={currentDatabase}
+          hasSaveFailed={hasSaveFailed}
           query={query}
-          saveState={saveState}
         />
       </div>
     </div>

--- a/src/app/components/StatusBar.test.tsx
+++ b/src/app/components/StatusBar.test.tsx
@@ -82,10 +82,24 @@ function renderStatusBar(
     <StatusBar
       cursorPosition={undefined}
       database={database}
+      hasSaveFailed={false}
       query={current}
-      saveState="idle"
     />,
     { databases: database ? [database] : [] }
+  )
+}
+
+// The save notice needs neither a query nor a connection, and giving it one
+// would put the row-count summary in the same status bar it asserts the absence
+// of a message in.
+function renderSaveState(hasSaveFailed: boolean): void {
+  renderWithProviders(
+    <StatusBar
+      cursorPosition={undefined}
+      database={undefined}
+      hasSaveFailed={hasSaveFailed}
+      query={undefined}
+    />
   )
 }
 
@@ -181,5 +195,19 @@ describe('StatusBar', () => {
       grouped: summary?.includes(count(1234567)),
       ungrouped: summary?.includes('1234567')
     }).toEqual({ grouped: true, ungrouped: false })
+  })
+
+  // The only standing sign that the worksheet on screen has edits the backend
+  // never took. The toast that raised it is gone within seconds.
+  it('says so while the open worksheet has a failed save', () => {
+    renderSaveState(true)
+
+    expect(screen.getByText('Save failed')).toBeInTheDocument()
+  })
+
+  it('says nothing while the open worksheet is saving cleanly', () => {
+    renderSaveState(false)
+
+    expect(screen.queryByText('Save failed')).toBeNull()
   })
 })

--- a/src/app/components/StatusBar.tsx
+++ b/src/app/components/StatusBar.tsx
@@ -5,7 +5,6 @@ import { isQueryFinished } from '@/glue/queries'
 import type { QueryDto } from '@/glue/api/schemas'
 import type { DatabaseDto } from '@/glue/databases'
 
-import type { SaveState } from '../hooks/useWorksheetAutosave'
 import { useServerVersion } from '../hooks/queries'
 import { useAppDispatch } from '../store'
 import { uiActions } from '../store/ui-slice'
@@ -18,8 +17,8 @@ interface StatusBarProps {
   cursorPosition: CursorPosition | undefined
   /** The worksheet's connection, or undefined when it has none this app knows. */
   database: DatabaseDto | undefined
+  hasSaveFailed: boolean
   query: QueryDto | undefined
-  saveState: SaveState
 }
 
 const healthColors: Record<ConnectionHealth, string> = {
@@ -69,8 +68,8 @@ function formatRunSummary(query: QueryDto | undefined): string | undefined {
 export function StatusBar({
   cursorPosition,
   database,
-  query,
-  saveState
+  hasSaveFailed,
+  query
 }: StatusBarProps): ReactElement {
   const dispatch = useAppDispatch()
   const serverVersion = useServerVersion(database)
@@ -102,7 +101,7 @@ export function StatusBar({
       )}
 
       <div className="ml-auto flex items-center gap-4">
-        {saveState === 'error' && <span className="text-err">Save failed</span>}
+        {hasSaveFailed && <span className="text-err">Save failed</span>}
 
         <span className="text-text3">
           {cursorPosition

--- a/src/app/hooks/useWorksheetAutosave.test.tsx
+++ b/src/app/hooks/useWorksheetAutosave.test.tsx
@@ -1,5 +1,6 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen } from '@testing-library/react'
 import { ReactElement, useState } from 'react'
+import invariant from 'tiny-invariant'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { WorksheetDto } from '@/glue/worksheets'
@@ -53,6 +54,16 @@ function AutosaveProbe(): ReactElement {
         edit
       </button>
 
+      {/* Different content from `edit`: an update that changes nothing is not
+          a save, so two clicks of the same button cannot put two saves in
+          flight. */}
+      <button
+        onClick={() => queueSave(`edited ${worksheetId} again`)}
+        type="button"
+      >
+        edit again
+      </button>
+
       <button
         onClick={flushSave}
         type="button"
@@ -86,7 +97,7 @@ function click(name: string): void {
   fireEvent.click(screen.getByRole('button', { name }))
 }
 
-async function renderProbe() {
+async function renderProbe(): Promise<ReturnType<typeof renderWithProviders>> {
   const rendered = renderWithProviders(<AutosaveProbe />, {
     worksheets: [first, second]
   })
@@ -107,11 +118,18 @@ interface Settler {
   worksheetId: string
 }
 
+interface DeferredSaves {
+  fail: (worksheetId: string, position?: number) => Promise<void>
+  succeed: (worksheetId: string, position?: number) => Promise<void>
+}
+
 /**
  * Saves that settle only when the test says so, which is the only way to place
- * a switch between a save being sent and its answer coming back.
+ * a switch — or a whole second save — between a save being sent and its answer
+ * coming back. `position` picks among the saves still in flight for that
+ * worksheet, oldest first, so a test can answer them out of order.
  */
-function deferredSaves() {
+function deferredSaves(): DeferredSaves {
   const settlers: Settler[] = []
 
   vi.mocked(apiClient.updateWorksheet).mockImplementation(
@@ -121,14 +139,15 @@ function deferredSaves() {
       })
   )
 
-  function take(worksheetId: string): Settler {
-    const settler = settlers.find(
+  function take(worksheetId: string, position: number): Settler {
+    const settler = settlers.filter(
       (entry) => !entry.settled && entry.worksheetId === worksheetId
-    )
+    )[position]
 
-    if (settler === undefined) {
-      throw new Error(`No save is in flight for ${worksheetId}.`)
-    }
+    invariant(
+      settler,
+      `No save is in flight for ${worksheetId} at position ${position}.`
+    )
 
     settler.settled = true
 
@@ -136,15 +155,15 @@ function deferredSaves() {
   }
 
   return {
-    async fail(worksheetId: string) {
-      const settler = take(worksheetId)
+    async fail(worksheetId: string, position = 0) {
+      const settler = take(worksheetId, position)
 
       await act(async () => {
         settler.reject(new Error('The connection was lost.'))
       })
     },
-    async succeed(worksheetId: string) {
-      const settler = take(worksheetId)
+    async succeed(worksheetId: string, position = 0) {
+      const settler = take(worksheetId, position)
 
       await act(async () => {
         settler.resolve({ ...first, id: worksheetId })
@@ -163,17 +182,17 @@ describe('useWorksheetAutosave', () => {
   })
 
   it('saves the edited content once the debounce elapses', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
+    await renderProbe()
+
+    vi.useFakeTimers()
 
     try {
-      await renderProbe()
-
       click('edit')
 
       expect(apiClient.updateWorksheet).not.toHaveBeenCalled()
 
       await act(async () => {
-        vi.advanceTimersByTime(300)
+        await vi.advanceTimersByTimeAsync(300)
       })
 
       expect(vi.mocked(apiClient.updateWorksheet).mock.calls).toEqual([
@@ -187,17 +206,17 @@ describe('useWorksheetAutosave', () => {
   // The debounce is the reason a keystroke does not cost a request, so the hook
   // must still coalesce rather than save once per edit.
   it('coalesces rapid edits into one save', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
+    await renderProbe()
+
+    vi.useFakeTimers()
 
     try {
-      await renderProbe()
-
       click('edit')
       click('edit')
       click('edit')
 
       await act(async () => {
-        vi.advanceTimersByTime(300)
+        await vi.advanceTimersByTimeAsync(300)
       })
 
       expect(vi.mocked(apiClient.updateWorksheet).mock.calls).toEqual([
@@ -213,27 +232,27 @@ describe('useWorksheetAutosave', () => {
   // window has to restart from the last keystroke, or a steady typist is saved
   // on a fixed 300ms drumbeat instead of when they pause.
   it('restarts the debounce window on every edit', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
+    await renderProbe()
+
+    vi.useFakeTimers()
 
     try {
-      await renderProbe()
-
       click('edit')
 
       await act(async () => {
-        vi.advanceTimersByTime(200)
+        await vi.advanceTimersByTimeAsync(200)
       })
 
       click('edit')
 
       await act(async () => {
-        vi.advanceTimersByTime(200)
+        await vi.advanceTimersByTimeAsync(200)
       })
 
       expect(apiClient.updateWorksheet).not.toHaveBeenCalled()
 
       await act(async () => {
-        vi.advanceTimersByTime(100)
+        await vi.advanceTimersByTimeAsync(100)
       })
 
       expect(vi.mocked(apiClient.updateWorksheet).mock.calls).toEqual([
@@ -249,14 +268,26 @@ describe('useWorksheetAutosave', () => {
   it('saves immediately when the caller flushes', async () => {
     await renderProbe()
 
-    click('edit')
-    click('flush')
+    // Frozen time is the assertion: a save that shows up here can only have
+    // come from the flush, because the debounce never elapses. Polling with
+    // `waitFor` would let the 300ms window close on its own and pass against a
+    // `flushSave` that did nothing at all.
+    vi.useFakeTimers()
 
-    await waitFor(() => {
+    try {
+      click('edit')
+      click('flush')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
       expect(vi.mocked(apiClient.updateWorksheet).mock.calls).toEqual([
         ['ws-1', { content: 'edited ws-1' }]
       ])
-    })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   // Nothing is open before the first worksheet is picked, and "no worksheet"
@@ -280,7 +311,7 @@ describe('useWorksheetAutosave', () => {
     expect(screen.getByText('save failed')).toBeInTheDocument()
   })
 
-  it('tells the user when a save fails', async () => {
+  it('raises a toast when a save fails', async () => {
     const saves = deferredSaves()
 
     await renderProbe()
@@ -334,9 +365,76 @@ describe('useWorksheetAutosave', () => {
     }).toEqual({ failure: 'no failure', worksheet: 'ws-2' })
   })
 
-  // The mirror case: a save that succeeds late clears the failure it belongs to
-  // and no other.
-  it('keeps the failure when an older worksheet saves successfully', async () => {
+  // The notice is about the save you just made. By the time you come back the
+  // content it carried is gone — a failed persist rolls the collection back to
+  // the server's copy, and nothing else keeps it — so a worksheet that still
+  // said "Save failed" would be pointing at text that matches what is stored.
+  it('forgets the failure once you come back to the worksheet', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('flush')
+
+    await saves.fail('ws-1')
+
+    expect(screen.getByText('save failed')).toBeInTheDocument()
+
+    click('switch')
+    click('switch')
+
+    expect({
+      failure: screen.getByText('no failure').textContent,
+      worksheet: screen.getByText('ws-1').textContent
+    }).toEqual({ failure: 'no failure', worksheet: 'ws-1' })
+  })
+
+  // Two saves for one worksheet really do run at the same time: the second is
+  // sent while the first is still open. If the first then fails, the content it
+  // carried has already been stored by the second, and saying "Save failed"
+  // would be a warning about nothing.
+  it('does not re-raise a failure a newer save has already cleared', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('flush')
+
+    click('edit again')
+    click('flush')
+
+    await saves.succeed('ws-1', 1)
+    await saves.fail('ws-1', 0)
+
+    expect(screen.getByText('no failure')).toBeInTheDocument()
+  })
+
+  // The mirror of the case above, and the reason the answer to a save is
+  // ignored by age rather than by outcome: an older save landing successfully
+  // says nothing about the newer one that failed after it.
+  it('keeps the failure when an older save for the same worksheet lands', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('flush')
+
+    click('edit again')
+    click('flush')
+
+    await saves.fail('ws-1', 1)
+    await saves.succeed('ws-1', 0)
+
+    expect(screen.getByText('save failed')).toBeInTheDocument()
+  })
+
+  // The status bar describes the worksheet on screen, so it says nothing about
+  // one you have left. The toast is not tied to a worksheet, and a save that
+  // did not happen is worth knowing about wherever you are.
+  it('still raises a toast for a save that failed after you moved on', async () => {
     const saves = deferredSaves()
 
     await renderProbe()
@@ -344,14 +442,55 @@ describe('useWorksheetAutosave', () => {
     click('edit')
     click('switch')
 
+    await saves.fail('ws-1')
+
+    expect(
+      await screen.findByText('Failed to save worksheet')
+    ).toBeInTheDocument()
+  })
+
+  // Deleting a worksheet takes its row out of the collection and moves the app
+  // to another one, both inside the debounce window. Updating a key that is
+  // gone throws, and it throws out of the effect cleanup that flushes on the
+  // way out — which unmounts the whole workspace.
+  it('drops a pending save for a worksheet that has been deleted', async () => {
+    const rendered = await renderProbe()
+
+    click('edit')
+
+    act(() => {
+      rendered.collections.worksheets.utils.writeDelete(first.id)
+    })
+
+    click('switch')
+
+    expect({
+      calls: vi.mocked(apiClient.updateWorksheet).mock.calls,
+      worksheet: screen.getByText('ws-2').textContent
+    }).toEqual({ calls: [], worksheet: 'ws-2' })
+  })
+
+  // The mirror case: a save that succeeds clears the failure it belongs to and
+  // no other. Age alone cannot decide this one — the successful save is the
+  // newer of the two, and it still has nothing to say about the worksheet you
+  // are looking at.
+  it('keeps the failure when a different worksheet saves successfully', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
     click('edit')
     click('flush')
 
-    await saves.fail('ws-2')
+    click('switch')
+    click('edit')
+    click('switch')
+
+    await saves.fail('ws-1')
 
     expect(screen.getByText('save failed')).toBeInTheDocument()
 
-    await saves.succeed('ws-1')
+    await saves.succeed('ws-2')
 
     expect(screen.getByText('save failed')).toBeInTheDocument()
   })

--- a/src/app/hooks/useWorksheetAutosave.test.tsx
+++ b/src/app/hooks/useWorksheetAutosave.test.tsx
@@ -1,0 +1,378 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { ReactElement, useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { WorksheetDto } from '@/glue/worksheets'
+
+import { renderWithProviders } from '../test-utils'
+import { useWorksheetAutosave } from './useWorksheetAutosave'
+
+vi.mock('../api-client', () => ({
+  apiClient: {
+    getDatabases: vi.fn(async () => []),
+    getQueries: vi.fn(async () => []),
+    getWorksheets: vi.fn(async () => []),
+    updateWorksheet: vi.fn()
+  }
+}))
+
+import { apiClient } from '../api-client'
+
+const first: WorksheetDto = {
+  content: 'select 1',
+  createdAt: 1,
+  databaseId: null,
+  id: 'ws-1',
+  lastOpenedAt: null,
+  name: 'First',
+  sortOrder: null
+}
+
+const second: WorksheetDto = {
+  ...first,
+  id: 'ws-2',
+  name: 'Second'
+}
+
+// The switch happens inside the probe rather than through `rerender`, because
+// switching worksheets in the app is a state change under the same providers —
+// and the hook's flush-on-change cleanup is what the late-resolution cases turn
+// on.
+function AutosaveProbe(): ReactElement {
+  const [worksheetId, setWorksheetId] = useState(first.id)
+
+  const { flushSave, hasSaveFailed, queueSave } =
+    useWorksheetAutosave(worksheetId)
+
+  return (
+    <>
+      <button
+        onClick={() => queueSave(`edited ${worksheetId}`)}
+        type="button"
+      >
+        edit
+      </button>
+
+      <button
+        onClick={flushSave}
+        type="button"
+      >
+        flush
+      </button>
+
+      <button
+        onClick={() =>
+          setWorksheetId(worksheetId === first.id ? second.id : first.id)
+        }
+        type="button"
+      >
+        switch
+      </button>
+
+      <output>{worksheetId}</output>
+      <output>{hasSaveFailed ? 'save failed' : 'no failure'}</output>
+    </>
+  )
+}
+
+// The state before a worksheet is picked, which the probe above cannot reach.
+function ClosedProbe(): ReactElement {
+  const { hasSaveFailed } = useWorksheetAutosave(undefined)
+
+  return <output>{hasSaveFailed ? 'save failed' : 'no failure'}</output>
+}
+
+function click(name: string): void {
+  fireEvent.click(screen.getByRole('button', { name }))
+}
+
+async function renderProbe() {
+  const rendered = renderWithProviders(<AutosaveProbe />, {
+    worksheets: [first, second]
+  })
+
+  // `AppShell` preloads the collections in the real app; without it the
+  // collection has no rows and `update` throws instead of saving.
+  await act(async () => {
+    await rendered.collections.worksheets.preload()
+  })
+
+  return rendered
+}
+
+interface Settler {
+  reject: (error: Error) => void
+  resolve: (worksheet: WorksheetDto) => void
+  settled: boolean
+  worksheetId: string
+}
+
+/**
+ * Saves that settle only when the test says so, which is the only way to place
+ * a switch between a save being sent and its answer coming back.
+ */
+function deferredSaves() {
+  const settlers: Settler[] = []
+
+  vi.mocked(apiClient.updateWorksheet).mockImplementation(
+    (worksheetId: string) =>
+      new Promise<WorksheetDto>((resolve, reject) => {
+        settlers.push({ reject, resolve, settled: false, worksheetId })
+      })
+  )
+
+  function take(worksheetId: string): Settler {
+    const settler = settlers.find(
+      (entry) => !entry.settled && entry.worksheetId === worksheetId
+    )
+
+    if (settler === undefined) {
+      throw new Error(`No save is in flight for ${worksheetId}.`)
+    }
+
+    settler.settled = true
+
+    return settler
+  }
+
+  return {
+    async fail(worksheetId: string) {
+      const settler = take(worksheetId)
+
+      await act(async () => {
+        settler.reject(new Error('The connection was lost.'))
+      })
+    },
+    async succeed(worksheetId: string) {
+      const settler = take(worksheetId)
+
+      await act(async () => {
+        settler.resolve({ ...first, id: worksheetId })
+      })
+    }
+  }
+}
+
+describe('useWorksheetAutosave', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(apiClient.updateWorksheet).mockImplementation(
+      async (worksheetId: string) => ({ ...first, id: worksheetId })
+    )
+  })
+
+  it('saves the edited content once the debounce elapses', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      await renderProbe()
+
+      click('edit')
+
+      expect(apiClient.updateWorksheet).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(300)
+      })
+
+      expect(vi.mocked(apiClient.updateWorksheet).mock.calls).toEqual([
+        ['ws-1', { content: 'edited ws-1' }]
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The debounce is the reason a keystroke does not cost a request, so the hook
+  // must still coalesce rather than save once per edit.
+  it('coalesces rapid edits into one save', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      await renderProbe()
+
+      click('edit')
+      click('edit')
+      click('edit')
+
+      await act(async () => {
+        vi.advanceTimersByTime(300)
+      })
+
+      expect(vi.mocked(apiClient.updateWorksheet).mock.calls).toEqual([
+        ['ws-1', { content: 'edited ws-1' }]
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Coalescing alone does not prove the window moves: three edits in the same
+  // tick would collapse anyway once the first flush took the pending save. The
+  // window has to restart from the last keystroke, or a steady typist is saved
+  // on a fixed 300ms drumbeat instead of when they pause.
+  it('restarts the debounce window on every edit', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      await renderProbe()
+
+      click('edit')
+
+      await act(async () => {
+        vi.advanceTimersByTime(200)
+      })
+
+      click('edit')
+
+      await act(async () => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(apiClient.updateWorksheet).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(vi.mocked(apiClient.updateWorksheet).mock.calls).toEqual([
+        ['ws-1', { content: 'edited ws-1' }]
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Running a query needs the saved copy to be current, so the caller can close
+  // the debounce window instead of waiting it out.
+  it('saves immediately when the caller flushes', async () => {
+    await renderProbe()
+
+    click('edit')
+    click('flush')
+
+    await waitFor(() => {
+      expect(vi.mocked(apiClient.updateWorksheet).mock.calls).toEqual([
+        ['ws-1', { content: 'edited ws-1' }]
+      ])
+    })
+  })
+
+  // Nothing is open before the first worksheet is picked, and "no worksheet"
+  // must not read as "the worksheet that failed".
+  it('reports no failure when no worksheet is open', () => {
+    renderWithProviders(<ClosedProbe />)
+
+    expect(screen.getByText('no failure')).toBeInTheDocument()
+  })
+
+  it('reports a save that failed', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('flush')
+
+    await saves.fail('ws-1')
+
+    expect(screen.getByText('save failed')).toBeInTheDocument()
+  })
+
+  it('tells the user when a save fails', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('flush')
+
+    await saves.fail('ws-1')
+
+    expect(
+      await screen.findByText('Failed to save worksheet')
+    ).toBeInTheDocument()
+  })
+
+  // The old state carried no worksheet, so a failure in one worksheet kept
+  // accusing whichever one you opened next.
+  it('does not carry a failure over to the next worksheet', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('flush')
+
+    await saves.fail('ws-1')
+
+    click('switch')
+
+    expect({
+      failure: screen.getByText('no failure').textContent,
+      worksheet: screen.getByText('ws-2').textContent
+    }).toEqual({ failure: 'no failure', worksheet: 'ws-2' })
+  })
+
+  // Switching flushes the previous worksheet's pending save, so its rejection
+  // always lands after the switch. That is the failure the new worksheet must
+  // not be blamed for.
+  it('does not blame the new worksheet for the old one’s failed save', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('switch')
+
+    await saves.fail('ws-1')
+
+    expect({
+      failure: screen.getByText('no failure').textContent,
+      worksheet: screen.getByText('ws-2').textContent
+    }).toEqual({ failure: 'no failure', worksheet: 'ws-2' })
+  })
+
+  // The mirror case: a save that succeeds late clears the failure it belongs to
+  // and no other.
+  it('keeps the failure when an older worksheet saves successfully', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('switch')
+
+    click('edit')
+    click('flush')
+
+    await saves.fail('ws-2')
+
+    expect(screen.getByText('save failed')).toBeInTheDocument()
+
+    await saves.succeed('ws-1')
+
+    expect(screen.getByText('save failed')).toBeInTheDocument()
+  })
+
+  it('clears the failure once the worksheet saves again', async () => {
+    const saves = deferredSaves()
+
+    await renderProbe()
+
+    click('edit')
+    click('flush')
+
+    await saves.fail('ws-1')
+
+    expect(screen.getByText('save failed')).toBeInTheDocument()
+
+    click('edit')
+    click('flush')
+
+    await saves.succeed('ws-1')
+
+    expect(screen.getByText('no failure')).toBeInTheDocument()
+  })
+})

--- a/src/app/hooks/useWorksheetAutosave.ts
+++ b/src/app/hooks/useWorksheetAutosave.ts
@@ -6,8 +6,6 @@ import { useCollections } from '../collections-context'
 
 const saveDebounceMs = 300
 
-export type SaveState = 'error' | 'idle' | 'saved' | 'saving'
-
 export function useWorksheetAutosave(openWorksheetId: string | undefined) {
   const { worksheets: worksheetsCollection } = useCollections()
 
@@ -15,7 +13,14 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
   const pendingSave = useRef<{ content: string; id: string } | undefined>(
     undefined
   )
-  const [saveState, setSaveState] = useState<SaveState>('idle')
+  // The worksheet is carried with the failure rather than beside it. Saves
+  // resolve in completion order and switching worksheets flushes the outgoing
+  // one, so a failure normally lands after the worksheet it belongs to has
+  // stopped being the open one — and a bare flag reported it against whichever
+  // worksheet was open when it arrived.
+  const [failedSave, setFailedSave] = useState<{ worksheetId: string } | null>(
+    null
+  )
 
   const flushSave = useCallback(() => {
     if (saveTimer.current) {
@@ -37,10 +42,15 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
 
     void transaction.isPersisted.promise
       .then(() => {
-        setSaveState('saved')
+        // Only this worksheet's own failure is cleared: a save that finally
+        // lands for the worksheet you left says nothing about the one you are
+        // looking at now.
+        setFailedSave((current) =>
+          current?.worksheetId === pending.id ? null : current
+        )
       })
       .catch(() => {
-        setSaveState('error')
+        setFailedSave({ worksheetId: pending.id })
         toast.error('Failed to save worksheet')
       })
   }, [worksheetsCollection])
@@ -63,8 +73,6 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
         clearTimeout(saveTimer.current)
       }
 
-      setSaveState('saving')
-
       saveTimer.current = setTimeout(flushSave, saveDebounceMs)
     },
     [flushSave, openWorksheetId]
@@ -72,5 +80,15 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
 
   // `flushSave` is exposed so callers that need the saved copy to be current —
   // running a query — can close the debounce window instead of waiting it out.
-  return { flushSave, queueSave, saveState }
+  return {
+    flushSave,
+    // Derived rather than reset when the worksheet changes, so coming back to a
+    // worksheet whose last save failed still says so — those edits really are
+    // unsaved. Compared against the record rather than through `?.`, which
+    // would answer `undefined === undefined` with "failed" before any worksheet
+    // is open.
+    hasSaveFailed:
+      failedSave !== null && failedSave.worksheetId === openWorksheetId,
+    queueSave
+  }
 }

--- a/src/app/hooks/useWorksheetAutosave.ts
+++ b/src/app/hooks/useWorksheetAutosave.ts
@@ -14,13 +14,25 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
     undefined
   )
   // The worksheet is carried with the failure rather than beside it. Saves
-  // resolve in completion order and switching worksheets flushes the outgoing
+  // settle in completion order and switching worksheets flushes the outgoing
   // one, so a failure normally lands after the worksheet it belongs to has
   // stopped being the open one — and a bare flag reported it against whichever
   // worksheet was open when it arrived.
-  const [failedSave, setFailedSave] = useState<{ worksheetId: string } | null>(
-    null
-  )
+  const [failedSave, setFailedSave] = useState<
+    { worksheetId: string } | undefined
+  >(undefined)
+
+  // The answer to a save is handled long after the flush that sent it, so
+  // neither the open worksheet nor the saves that have settled since can be
+  // read out of that closure.
+  const openWorksheetIdRef = useRef(openWorksheetId)
+
+  useEffect(() => {
+    openWorksheetIdRef.current = openWorksheetId
+  }, [openWorksheetId])
+
+  const sentSaves = useRef(0)
+  const lastSettledSave = useRef(-1)
 
   const flushSave = useCallback(() => {
     if (saveTimer.current) {
@@ -36,21 +48,58 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
 
     pendingSave.current = undefined
 
+    // Deleting a worksheet takes its row out of the collection and moves the
+    // app to another one, and both can happen inside the debounce window.
+    // `update` on a key that is gone throws, and from the cleanup below that
+    // takes the whole workspace down with it — for an edit the user deleted on
+    // purpose.
+    if (!worksheetsCollection.has(pending.id)) {
+      return
+    }
+
+    const sequence = sentSaves.current
+    sentSaves.current += 1
+
     const transaction = worksheetsCollection.update(pending.id, (draft) => {
       draft.content = pending.content
     })
 
+    // Two saves for one worksheet can be open at once, and the older one has
+    // nothing left to say once the newer has answered: its content is a prefix
+    // of what was just stored.
+    const isStale = (): boolean => sequence < lastSettledSave.current
+
     void transaction.isPersisted.promise
       .then(() => {
+        if (isStale()) {
+          return
+        }
+
+        lastSettledSave.current = sequence
+
         // Only this worksheet's own failure is cleared: a save that finally
         // lands for the worksheet you left says nothing about the one you are
         // looking at now.
         setFailedSave((current) =>
-          current?.worksheetId === pending.id ? null : current
+          current?.worksheetId === pending.id ? undefined : current
         )
       })
       .catch(() => {
-        setFailedSave({ worksheetId: pending.id })
+        if (isStale()) {
+          return
+        }
+
+        lastSettledSave.current = sequence
+
+        // The toast reports the save wherever the user is now, because a save
+        // that did not happen is worth knowing about either way. The status bar
+        // notice is not: it describes the worksheet on screen, and the failed
+        // content is no longer in it — a failed persist rolls the collection
+        // back to the server's copy.
+        if (pending.id === openWorksheetIdRef.current) {
+          setFailedSave({ worksheetId: pending.id })
+        }
+
         toast.error('Failed to save worksheet')
       })
   }, [worksheetsCollection])
@@ -62,6 +111,14 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
       flushSave()
     }
   }, [flushSave, openWorksheetId])
+
+  // The notice belongs to the worksheet that was on screen when the save
+  // failed, and leaving takes the failed content with it. Coming back to a
+  // worksheet still labelled "Save failed" would point at text that matches
+  // what is stored.
+  useEffect(() => {
+    setFailedSave(undefined)
+  }, [openWorksheetId])
 
   const queueSave = useCallback(
     (newContent: string) => {
@@ -82,13 +139,7 @@ export function useWorksheetAutosave(openWorksheetId: string | undefined) {
   // running a query — can close the debounce window instead of waiting it out.
   return {
     flushSave,
-    // Derived rather than reset when the worksheet changes, so coming back to a
-    // worksheet whose last save failed still says so — those edits really are
-    // unsaved. Compared against the record rather than through `?.`, which
-    // would answer `undefined === undefined` with "failed" before any worksheet
-    // is open.
-    hasSaveFailed:
-      failedSave !== null && failedSave.worksheetId === openWorksheetId,
+    hasSaveFailed: failedSave !== undefined,
     queueSave
   }
 }


### PR DESCRIPTION
Closes #65.

## The bug

`SaveState` was a single flag with no worksheet attached to it. Saves settle in
completion order and switching worksheets flushes the outgoing one, so a
failure normally lands *after* the worksheet it belongs to has stopped being
the open one — and the status bar reported it against whichever worksheet you
had moved to. Every failure was misattributed in the common case.

The failure is now recorded with the worksheet it belongs to, and only the same
worksheet's own successful save clears it.

## Beyond the issue

Three further ways the notice lied, found in review:

- **Two saves for one worksheet are genuinely concurrent.** The debounce sends
  the second while the first is still open. If the older one then fails, its
  content has already been stored by the newer one, so "Save failed" was a
  warning about nothing. Saves now carry a sequence and an answer older than the
  last one settled is ignored — in both directions, since a stale *success* must
  not clear a live failure either.
- **The notice outlived the thing it described.** A failed persist rolls the
  collection back to the server's copy and the edit is not kept anywhere else,
  so a worksheet you returned to said "Save failed" while showing text that
  matched what was stored. The failure is now recorded only for the worksheet on
  screen and cleared when you leave it — which is what the issue proposed. The
  toast is deliberately *not* gated that way: a save that did not happen is
  worth knowing about wherever you are.
- **Deleting a worksheet crashed the workspace.** Deleting clears the row and
  moves the app to another worksheet, both inside the 300ms debounce window, and
  `collection.update` on a key that is gone throws — out of the effect cleanup
  that flushes on the way out, which unmounted the whole subtree. A pending save
  for a row that no longer exists is now dropped.

## Deliberate deviation worth confirming

`SaveState` had three members nothing could ever read — `'saving'`, `'saved'`
and `'idle'` were never rendered anywhere — so the type is gone and the hook
returns a boolean. Reintroducing a "Saving…" indicator later is a two-line
`useState`, not a lost capability. `grep -rn "SaveState\|saveState" src/`
returns nothing.

## Test changes that are not new behaviour

The debounce tests ran on `vi.useFakeTimers({ shouldAdvanceTime: true })`, which
feeds real elapsed time into the fake clock, leaving the "has not saved yet"
assertions racing the machine. The flush test polled with `waitFor` for a
second — long enough for the 300ms window to close on its own, so it passed
against a `flushSave` that did nothing at all. Both now freeze the clock and
step it deliberately.

## Verification

- 16 tests in `useWorksheetAutosave.test.tsx`, 2 in the new
  `StatusBar.test.tsx`, 2 in `App.test.tsx` covering the wiring.
- 19 hand-written mutants of the hook, the status bar and `App.tsx`'s wiring:
  all killed.
- typecheck (both projects), eslint, prettier, full suite — only the
  pre-existing `sqlite-adapter.test.ts > connects and executes SELECT 1`
  failure, which is present on `main`.

## Known limitation

There is still no way to retry a failed save. The edit is gone by the time you
are told about it, so the notice reports history rather than something you can
act on. Keeping the pending content and resending it on the next flush would
close that, and is worth its own issue.

`App.test.tsx` now stubs `./components/WorksheetEditor` file-wide, so it no
longer exercises the `lazy`/`Suspense` boundary. Nothing else did either — the
real editor pulls in CodeMirror and the SQL language support, a chunk large
enough that waiting on it made the test a race against the bundler.
