### PR TITLE
chore(build): keep the native-package list in one place

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -12,14 +12,12 @@ import { execFileSync } from 'child_process'
 import { cpSync, existsSync, mkdirSync, readFileSync } from 'fs'
 import { join, resolve } from 'path'
 
-// Root external packages (Vite externals that need runtime resolution).
-// Every module externalized in vite.main.config.ts has to be reachable from
-// this list, either directly or as a transitive dependency. mysql2 and
-// pg-cursor are not dependencies of @libsql/client or pg, so they need naming:
-// src/databases/create-adapter.ts imports all three adapters at module level,
-// which means a single missing package breaks every database type, not just its
-// own.
-const rootExternalPackages = ['@libsql/client', 'mysql2', 'pg', 'pg-cursor']
+// A relative path rather than the `@` alias: Forge loads this config through
+// its own TypeScript loader, which knows nothing of the Vite alias.
+import {
+  asarUnpackGlob,
+  rootExternalPackages
+} from './src/build/native-packages'
 
 interface PackageDependency {
   name: string
@@ -213,9 +211,7 @@ const config: ForgeConfig = {
   packagerConfig: {
     appBundleId: 'co.artmann.squeal',
     asar: {
-      // Kept in step with rootExternalPackages: these resolve at runtime, so
-      // they must stay outside the archive. libsql carries the native binding.
-      unpack: '**/node_modules/{@libsql,libsql,mysql2,pg,pg-cursor}/**/*'
+      unpack: asarUnpackGlob
     },
     // macOS ships one universal build, stitched from an x64 slice and an arm64
     // slice that are both packaged from this machine's node_modules — so both
@@ -245,7 +241,10 @@ const config: ForgeConfig = {
       osxNotarize: {
         appleId: process.env.APPLE_ID ?? '',
         appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD ?? '',
-        teamId: process.env.APPLE_TEAM_ID
+        // Never empty in practice — it is what `signsWithAppleIdentity`
+        // tests for — but the check is a `Boolean(...)` TypeScript cannot
+        // narrow through, and notarization requires a string.
+        teamId: process.env.APPLE_TEAM_ID ?? ''
       },
       osxSign: {
         identity: 'Developer ID Application',

--- a/src/build/native-packages.test.ts
+++ b/src/build/native-packages.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+
+import forgeConfig from '../../forge.config'
+import viteMainConfig from '../../vite.main.config'
+import {
+  asarUnpackGlob,
+  nativePackages,
+  rollupExternals,
+  rootExternalPackages
+} from './native-packages'
+
+// The scope directory of `@scope/name`, and the package name itself otherwise —
+// what a package occupies inside `node_modules`.
+function nodeModulesDirectory(packageName: string): string {
+  const [scope] = packageName.split('/')
+
+  return scope.startsWith('@') ? scope : packageName
+}
+
+describe('native packages', () => {
+  // Adding a package to `roots` without unpacking its directory ships an app
+  // that resolves the module to a path inside the asar archive, where the
+  // native binding cannot be loaded.
+  it('unpacks the directory of every package that resolves at runtime', () => {
+    const missing = nativePackages.flatMap((nativePackage) =>
+      nativePackage.roots
+        .map(nodeModulesDirectory)
+        .filter((directory) => !nativePackage.directories.includes(directory))
+    )
+
+    expect(missing).toEqual([])
+  })
+
+  // The mirror: a package Vite is allowed to bundle does not resolve at
+  // runtime, so naming it as a root promises something the build does not do.
+  it('keeps every package that resolves at runtime out of the bundle', () => {
+    const bundled = rootExternalPackages.filter(
+      (packageName) =>
+        !rollupExternals.some((external) =>
+          typeof external === 'string'
+            ? external === packageName
+            : external.test(packageName)
+        )
+    )
+
+    expect(bundled).toEqual([])
+  })
+
+  // Subpath imports are how these packages are actually used —
+  // `mysql2/promise`, `@libsql/client/node` — and an external that only covers
+  // the bare name lets the subpath be bundled.
+  it('keeps subpath imports of those packages out of the bundle too', () => {
+    const bundled = rootExternalPackages.filter(
+      (packageName) =>
+        !rollupExternals.some(
+          (external) =>
+            typeof external !== 'string' && external.test(`${packageName}/deep`)
+        )
+    )
+
+    expect(bundled).toEqual([])
+  })
+
+  it('names every unpacked directory once', () => {
+    const directories = nativePackages.flatMap(
+      (nativePackage) => nativePackage.directories
+    )
+
+    expect([...new Set(directories)]).toEqual(directories)
+  })
+
+  // The list Forge walks to decide what stays reachable from the app root. Every
+  // other assertion here is a cross-check between two derived views, so this one
+  // and the glob below are the only places a package can be dropped outright and
+  // still leave the module self-consistent.
+  it('names every package this app imports by name', () => {
+    expect(rootExternalPackages).toEqual([
+      '@libsql/client',
+      'libsql',
+      'mysql2',
+      'pg',
+      'pg-cursor'
+    ])
+  })
+
+  // The accelerators are external without being roots or unpacked, so nothing
+  // above cross-checks them. Asserting the whole set of bare names also pins
+  // that no package is named twice — once as a string and once by pattern.
+  it('leaves the optional ws accelerators to the runtime as well', () => {
+    const names = rollupExternals.filter(
+      (external) => typeof external === 'string'
+    )
+
+    expect(names).toEqual(['bufferutil', 'utf-8-validate'])
+  })
+
+  // The glob electron-packager is handed. It is the one derived value with no
+  // second reader to catch a mistake, so its shape is asserted directly.
+  it('unpacks every directory and nothing else', () => {
+    expect(asarUnpackGlob).toEqual(
+      '**/node_modules/{@libsql,libsql,mysql2,pg,pg-cursor}/**/*'
+    )
+  })
+
+  // Everything above holds the module to itself, which a config that had
+  // stopped reading it would satisfy just as well — and an emptied externals
+  // list still builds, still passes CI, and still throws `MODULE_NOT_FOUND` at
+  // the first connection. These two are the only assertions that fail when the
+  // wire is cut.
+  it('is what Vite externalizes from the main bundle', () => {
+    expect(viteMainConfig.build?.rollupOptions?.external).toEqual(
+      rollupExternals
+    )
+  })
+
+  it('is what Forge leaves outside the asar archive', () => {
+    expect(forgeConfig.packagerConfig?.asar).toEqual({ unpack: asarUnpackGlob })
+  })
+})

--- a/src/build/native-packages.ts
+++ b/src/build/native-packages.ts
@@ -1,0 +1,88 @@
+/**
+ * The one place the list of packages the build leaves to Node is written down.
+ *
+ * Each is here for its own reason — the `@libsql` scope carries the platform
+ * binding for the SQLite driver, and the `pg` and `mysql2` families reach for
+ * optional modules of their own by name — but the consequence is the same:
+ * bundling them produces a main process that cannot find them. Three
+ * build-time declarations need to know that, and each needs it in a different
+ * shape: the Vite externals, the packages Forge keeps reachable from the app
+ * root, and the asar unpack glob.
+ *
+ * All three are derived here rather than restated, because the failure mode of
+ * restating them is a green build that ships `MODULE_NOT_FOUND`:
+ * `src/databases/create-adapter.ts` imports all three adapters at module
+ * level, so one missing package breaks every connection type, not just its
+ * own.
+ */
+interface NativePackage {
+  /**
+   * What the package occupies inside `node_modules` — the scope directory for a
+   * scoped package, since its platform binding is a sibling in that scope.
+   */
+  readonly directories: readonly string[]
+  /** Module ids Vite must leave for the runtime to resolve. */
+  readonly externals: readonly RegExp[]
+  /**
+   * The packages that have to be reachable from the packaged app's root, which
+   * Forge copies there itself. A transitive dependency comes along with the
+   * package that requires it, so naming one is not strictly required — but a
+   * package this app imports by name is named here anyway, rather than left to
+   * survive on someone else's dependency list.
+   */
+  readonly roots: readonly string[]
+}
+
+export const nativePackages: readonly NativePackage[] = [
+  {
+    // `libsql` is the driver, and its platform binding is an optional
+    // dependency in the `@libsql` scope beside the client.
+    directories: ['@libsql', 'libsql'],
+    externals: [/^@libsql(\/.*)?$/, /^libsql(\/.*)?$/],
+    // Both are imported by name: the client by `src/databases/libsql-*`, and
+    // `libsql` itself by `src/databases/sqlite-adapter.ts`.
+    roots: ['@libsql/client', 'libsql']
+  },
+  {
+    directories: ['mysql2'],
+    externals: [/^mysql2(\/.*)?$/],
+    roots: ['mysql2']
+  },
+  {
+    directories: ['pg'],
+    externals: [/^pg(\/.*)?$/],
+    roots: ['pg']
+  },
+  {
+    // Not a dependency of `pg`, so it has to be named on its own.
+    directories: ['pg-cursor'],
+    externals: [/^pg-cursor(\/.*)?$/],
+    roots: ['pg-cursor']
+  }
+]
+
+/**
+ * Optional native accelerators of `ws`, pulled in via
+ * `@effect/platform-node`. Not installed — `ws` catches the failed require at
+ * runtime — but Vite must not try to resolve them. Nothing resolves them at
+ * runtime either, so they are external without being roots or unpacked.
+ */
+const optionalAccelerators: readonly string[] = [
+  'bufferutil',
+  'utf-8-validate'
+]
+
+export const rollupExternals: (RegExp | string)[] = [
+  ...nativePackages.flatMap((nativePackage) => nativePackage.externals),
+  ...optionalAccelerators
+]
+
+export const rootExternalPackages: readonly string[] = nativePackages.flatMap(
+  (nativePackage) => nativePackage.roots
+)
+
+const unpackedDirectories = nativePackages.flatMap(
+  (nativePackage) => nativePackage.directories
+)
+
+export const asarUnpackGlob = `**/node_modules/{${unpackedDirectories.join(',')}}/**/*`

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,39 +1,14 @@
 import path from 'path'
 import { defineConfig } from 'vite'
 
+import { rollupExternals } from './src/build/native-packages'
+
 // https://vitejs.dev/config
 export default defineConfig({
   build: {
     rollupOptions: {
-      external: [
-        '@libsql/client',
-        '@libsql/win32-x64-msvc',
-        /^@libsql(\/.*)?$/,
-        /^libsql(\/.*)?$/,
-        /^mysql2(\/.*)?$/,
-        /^pg(\/.*)?$/,
-        /^pg-cursor(\/.*)?$/,
-
-        // Optional native accelerators of `ws` (pulled in via
-        // @effect/platform-node). Not installed — ws catches the failed
-        // require at runtime, but Vite must not try to resolve them.
-        'bufferutil',
-        'utf-8-validate'
-      ]
+      external: rollupExternals
     }
-  },
-  optimizeDeps: {
-    // don't try to pre-bundle these native packages
-    exclude: [
-      '@libsql/client',
-      '@libsql/win32-x64-msvc',
-      '@libsql',
-      'libsql',
-      'mysql2',
-      'mysql2/promise',
-      'pg',
-      'pg-cursor'
-    ]
   },
   resolve: {
     alias: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ import { configDefaults, defineConfig } from 'vitest/config'
 // the jsdom environment the React tests need.
 const backendTestPatterns = [
   'scripts/**/*.test.ts',
+  'src/build/**/*.test.ts',
   'src/glue/**/*.test.ts',
   'src/server/**/*.test.ts'
 ]


### PR DESCRIPTION
Closes #101.

## The problem

Four places wrote down the same fact — which packages the build has to leave for Node to resolve instead of bundling — and nothing kept them in step:

| Declaration | Shape |
| --- | --- |
| `vite.main.config.ts` → `rollupOptions.external` | module-id patterns |
| `vite.main.config.ts` → `optimizeDeps.exclude` | bare names |
| `forge.config.ts` → `rootExternalPackages` | package names |
| `forge.config.ts` → `packagerConfig.asar.unpack` | a `node_modules` glob |

One of them did nothing at all: `optimizeDeps.exclude` only applies to the dev server's dependency pre-bundling, which never runs for the main process. Its eight entries were an inert copy that still had to be maintained by hand.

The others matter. `src/databases/create-adapter.ts` imports all three adapters at module level, so a package missed in any one of them breaks *every* connection type with `MODULE_NOT_FOUND` — in a packaged build, after CI is green.

## The change

`src/build/native-packages.ts` states each package once, and the three live declarations derive from it. `optimizeDeps.exclude` is deleted.

`libsql` joins the root list. It was reachable only as a dependency of `@libsql/client`, but `src/databases/sqlite-adapter.ts` imports it by name — the built main bundle contains a bare `require("libsql")` — so it is now named rather than left to survive on someone else's dependency list.

## Tests

`src/build/native-packages.test.ts`, 9 tests, in the `backend` vitest project (a build-time module has no use for jsdom):

- Four cross-checks between the derived views: every root is unpacked, every root is external, subpath imports of those packages are external too, and no directory is named twice.
- Three pins on the values with no second reader: the root list, the whole set of bare-name externals, and the glob itself.
- **Two that assert the configs still read the module.** These are the ones that matter for this issue. The other seven hold the module to itself, which a config that had stopped reading it satisfies just as well: setting `external: []` in `vite.main.config.ts` left every other test passing and the build green.

Verified by mutation — eight mutants, all killed, including both wiring cuts.

## Verifying nothing moved

Building `create-adapter.ts` the way `@electron-forge/plugin-vite` builds the main process — minified cjs library mode, node resolve conditions, the builtins external — under the old externals list and the new one gives byte-identical output (`6d1a06f3…`, 24,123 bytes).

An `--ssr` build would have proved nothing: it externalizes every bare `node_modules` import on its own, whatever the externals list says.

## Side effect

Importing `forge.config.ts` from a test is the first time it has been typechecked — it is in no tsconfig `include`. That surfaced an `osxNotarize.teamId` of type `string | undefined`; it now falls back to `''` the same way its two siblings already did. Unreachable in practice, since `signsWithAppleIdentity` is `Boolean(process.env.APPLE_TEAM_ID)`, but not something TypeScript can narrow through.

## What this still does not catch

Nothing asserts against a *packaged* app. The gap that would close it is a post-`yarn package` check that `out/**/resources/app.asar.unpacked/node_modules/@libsql` exists and is non-empty — worth filing separately, since it needs a packaging step in CI.

`forge.config.ts` also still hardcodes `'**/@libsql/*/index.node'` for `osxUniversal.x64ArchFiles`. It is a different fact (which files are single-arch Mach-O), so it is deliberately not derived here.

## Checks

- `yarn lint`, `yarn typecheck`, `prettier --check`: clean.
- `yarn test`: 960 passing. The one failure, `src/databases/sqlite-adapter.test.ts > testConnection > connects and executes SELECT 1`, is pre-existing on `main` and untouched by this branch.
