### PR TITLE
fix(seed): seed MySQL without shelling out to cat

### DIFF
--- a/scripts/mysql-seed.test.ts
+++ b/scripts/mysql-seed.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  mysqlSeedArguments,
+  mysqlSeedCommand,
+  pipeFileToCommand
+} from './mysql-seed'
+
+// Writes whatever it is given on standard input to the path it is passed.
+const copyStdinTo = [
+  '-e',
+  'require("fs").writeFileSync(process.argv[1], require("fs").readFileSync(0))'
+]
+
+// A real child process reading real bytes off its own standard input. Mocking
+// the spawn would have passed against the shell pipeline this replaces, which
+// is exactly the thing that does not work.
+describe('pipeFileToCommand', () => {
+  let directory = ''
+  let pathVariable = process.env.PATH
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), 'squeal-seed-'))
+    pathVariable = process.env.PATH
+  })
+
+  afterEach(() => {
+    process.env.PATH = pathVariable
+
+    rmSync(directory, { force: true, recursive: true })
+  })
+
+  // The seed corpus really does contain `1. sakila-schema.sql`, and the space
+  // in that name is why the old command had to quote the path it interpolated
+  // into a shell string. Handing the bytes over directly means no quoting to
+  // get wrong.
+  it('sends a file whose name contains a space on standard input', async () => {
+    const source = join(directory, '1. sakila-schema.sql')
+    const destination = join(directory, 'received.sql')
+    const contents = [
+      'DELIMITER ;;',
+      "CREATE PROCEDURE grüss() BEGIN SELECT 'a | b';; END;;",
+      'DELIMITER ;',
+      ''
+    ].join('\n')
+
+    writeFileSync(source, contents, 'utf-8')
+
+    await pipeFileToCommand(
+      process.execPath,
+      [...copyStdinTo, destination],
+      source
+    )
+
+    expect(readFileSync(destination, 'utf-8')).toEqual(contents)
+  })
+
+  // 3.4 MB of it arrives whole. `cat` streamed; this does not, and a pipe that
+  // silently truncated at its buffer size would still look like a working seed
+  // until a table came up short.
+  it('sends a file larger than a pipe buffer', async () => {
+    const source = join(directory, 'large.sql')
+    const destination = join(directory, 'received.sql')
+    const contents = 'INSERT INTO film VALUES (1);\n'.repeat(200_000)
+
+    writeFileSync(source, contents, 'utf-8')
+
+    await pipeFileToCommand(
+      process.execPath,
+      [...copyStdinTo, destination],
+      source
+    )
+
+    expect(readFileSync(destination, 'utf-8').length).toEqual(contents.length)
+  })
+
+  // The whole bug: `cat "<file>" | <command>` is a shell command, and
+  // `execSync` runs it through `process.env.ComSpec` — cmd.exe — which has no
+  // `cat`. An empty PATH is what that shell sees on a Windows machine that did
+  // not put Git's `usr\bin` on it, which is the default. This is the one
+  // assertion here that fails if the pipeline ever comes back.
+  it('needs nothing on the PATH but the command itself', async () => {
+    const source = join(directory, 'seed.sql')
+    const destination = join(directory, 'received.sql')
+
+    writeFileSync(source, 'SELECT 1;\n', 'utf-8')
+
+    process.env.PATH = ''
+
+    await pipeFileToCommand(
+      process.execPath,
+      [...copyStdinTo, destination],
+      source
+    )
+
+    expect(readFileSync(destination, 'utf-8')).toEqual('SELECT 1;\n')
+  })
+
+  // `runSeedFiles` runs the files in order, and `seed()` stops on the first
+  // rejection, so a statement the server refuses must not be reported as a
+  // completed step.
+  it('fails when the command does', async () => {
+    const source = join(directory, 'broken.sql')
+
+    writeFileSync(source, 'SELECT 1;\n', 'utf-8')
+
+    await expect(
+      pipeFileToCommand(process.execPath, ['-e', 'process.exit(3)'], source)
+    ).rejects.toThrow()
+  })
+})
+
+describe('the MySQL seed command', () => {
+  // The container name and the root password are Compose's, not the seed
+  // script's — the script only borrows them. Renaming the service or changing
+  // the password otherwise breaks `yarn seed` with a message about a container
+  // that does not exist.
+  it('addresses the container docker-compose.yml declares', () => {
+    const compose = readFileSync(
+      join(import.meta.dirname, '..', 'docker-compose.yml'),
+      'utf-8'
+    )
+    const mysqlService = compose.slice(compose.indexOf('\n  mysql:'))
+    const containerName = /container_name: (\S+)/.exec(mysqlService)?.[1]
+    const rootPassword = /MYSQL_ROOT_PASSWORD: (\S+)/.exec(mysqlService)?.[1]
+
+    expect([mysqlSeedCommand, ...mysqlSeedArguments]).toEqual([
+      'docker',
+      'exec',
+      '-i',
+      containerName,
+      'mysql',
+      '-uroot',
+      `-p${rootPassword}`
+    ])
+  })
+})

--- a/scripts/mysql-seed.test.ts
+++ b/scripts/mysql-seed.test.ts
@@ -1,6 +1,8 @@
+import { createHash } from 'crypto'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import invariant from 'tiny-invariant'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
@@ -8,6 +10,10 @@ import {
   mysqlSeedCommand,
   pipeFileToCommand
 } from './mysql-seed'
+
+function sha1(contents: string): string {
+  return createHash('sha1').update(contents).digest('hex')
+}
 
 // Writes whatever it is given on standard input to the path it is passed.
 const copyStdinTo = [
@@ -74,7 +80,7 @@ describe('pipeFileToCommand', () => {
       source
     )
 
-    expect(readFileSync(destination, 'utf-8').length).toEqual(contents.length)
+    expect(sha1(readFileSync(destination, 'utf-8'))).toEqual(sha1(contents))
   })
 
   // The whole bug: `cat "<file>" | <command>` is a shell command, and
@@ -102,30 +108,125 @@ describe('pipeFileToCommand', () => {
   // `runSeedFiles` runs the files in order, and `seed()` stops on the first
   // rejection, so a statement the server refuses must not be reported as a
   // completed step.
-  it('fails when the command does', async () => {
+  //
+  // The cases below are the four ways this actually fails, and each has a
+  // different thing to tell the developer, so each is checked against the
+  // message it produces rather than against "it threw". Raw, the first two read
+  // `Command failed: docker exec -i squeal-mysql mysql -uroot -pmysql` and
+  // `spawnSync docker EOF` — neither names the file, and the second names
+  // nothing at all.
+  it('says which file failed and what the exit status was', async () => {
     const source = join(directory, 'broken.sql')
 
     writeFileSync(source, 'SELECT 1;\n', 'utf-8')
 
     await expect(
       pipeFileToCommand(process.execPath, ['-e', 'process.exit(3)'], source)
-    ).rejects.toThrow()
+    ).rejects.toThrow(
+      `Could not send broken.sql to \`${process.execPath}\`: it exited with status 3.`
+    )
+  })
+
+  // The case the small file above cannot reach. Past the pipe buffer it is the
+  // parent's write that fails, so Node reports `EOF` and drops the status — and
+  // this is the failure a developer meets first, because it is what a container
+  // that is not up yet produces on a 3.4 MB file. The command here exits zero:
+  // a load can be incomplete without the command reporting anything wrong.
+  it('says the load is incomplete when the command stops reading', async () => {
+    const source = join(directory, 'large.sql')
+
+    writeFileSync(source, 'SELECT 1;\n'.repeat(20_000), 'utf-8')
+
+    await expect(
+      pipeFileToCommand(process.execPath, ['-e', 'process.exit(0)'], source)
+    ).rejects.toThrow(
+      `Could not send large.sql to \`${process.execPath}\`: it stopped reading before the whole file was sent, so the load is incomplete. That usually means it rejected a statement, or the server is not accepting connections yet.`
+    )
+  })
+
+  // What a machine without Docker gets. libuv's own path search tries the
+  // literal name plus `.com` and `.exe`, never `.cmd`, so this is also what a
+  // `docker` exposed only as a shim would produce.
+  it('says the command was not found when it is not installed', async () => {
+    const source = join(directory, 'seed.sql')
+
+    writeFileSync(source, 'SELECT 1;\n', 'utf-8')
+
+    await expect(
+      pipeFileToCommand('squeal-no-such-command', [], source)
+    ).rejects.toThrow(
+      'Could not send seed.sql to `squeal-no-such-command`: the command was not found — check that it is installed and on your PATH.'
+    )
+  })
+
+  it('says so when the command never finishes', async () => {
+    const source = join(directory, 'seed.sql')
+
+    writeFileSync(source, 'SELECT 1;\n', 'utf-8')
+
+    await expect(
+      pipeFileToCommand(
+        process.execPath,
+        ['-e', 'setTimeout(() => {}, 30000)'],
+        source,
+        300
+      )
+    ).rejects.toThrow(
+      `Could not send seed.sql to \`${process.execPath}\`: it did not finish within 300ms.`
+    )
+  })
+
+  // The original error is the only place the exit status and the raw output
+  // survive, and nothing above would notice if it stopped being attached.
+  it('keeps the original failure as the cause', async () => {
+    const source = join(directory, 'broken.sql')
+
+    writeFileSync(source, 'SELECT 1;\n', 'utf-8')
+
+    const failure = await pipeFileToCommand(
+      process.execPath,
+      ['-e', 'process.exit(3)'],
+      source
+    ).catch((error: unknown) => error as Error)
+
+    expect((failure.cause as { status: number }).status).toEqual(3)
   })
 })
 
+// The container name and the root password are Compose's, not the seed script's
+// — the script only borrows them, and nothing checks that the two agree. Rename
+// the service and `yarn seed` fails with a message about a container that does
+// not exist. This is drift detection, not one source of truth; MySQL still has
+// no environment override the way Postgres and SQLite do.
 describe('the MySQL seed command', () => {
-  // The container name and the root password are Compose's, not the seed
-  // script's — the script only borrows them. Renaming the service or changing
-  // the password otherwise breaks `yarn seed` with a message about a container
-  // that does not exist.
+  // The carriage returns go because the repository is checked out with CRLF
+  // on Windows and the block below is matched line by line.
+  const compose = readFileSync(
+    join(import.meta.dirname, '..', 'docker-compose.yml'),
+    'utf-8'
+  ).replace(/\r/g, '')
+
+  // Only the `mysql:` block, so a `container_name` belonging to Postgres cannot
+  // stand in for a missing one here. The service ends where the next key at the
+  // same indentation begins.
+  const mysqlService = /\n {2}mysql:\n(?: +\S.*\n|\n)*/.exec(compose)?.[0]
+
+  // Without this the assertion below compares against `-pundefined`, which
+  // fails — but says the seed command is wrong rather than that the service was
+  // renamed out from under it.
+  it('finds the mysql service to compare against', () => {
+    expect(mysqlService).toEqual(expect.stringContaining('image: mysql'))
+  })
+
   it('addresses the container docker-compose.yml declares', () => {
-    const compose = readFileSync(
-      join(import.meta.dirname, '..', 'docker-compose.yml'),
-      'utf-8'
-    )
-    const mysqlService = compose.slice(compose.indexOf('\n  mysql:'))
-    const containerName = /container_name: (\S+)/.exec(mysqlService)?.[1]
-    const rootPassword = /MYSQL_ROOT_PASSWORD: (\S+)/.exec(mysqlService)?.[1]
+    invariant(mysqlService, 'docker-compose.yml declares no mysql service.')
+
+    const containerName = /container_name: "?([^"\n]+?)"?\n/.exec(
+      mysqlService
+    )?.[1]
+    const rootPassword = /MYSQL_ROOT_PASSWORD: "?([^"\n]+?)"?\n/.exec(
+      mysqlService
+    )?.[1]
 
     expect([mysqlSeedCommand, ...mysqlSeedArguments]).toEqual([
       'docker',

--- a/scripts/mysql-seed.ts
+++ b/scripts/mysql-seed.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from 'child_process'
+import { readFile } from 'fs/promises'
+
+/** The container `docker-compose.yml` declares, and the credentials it sets. */
+export const mysqlSeedCommand = 'docker'
+export const mysqlSeedArguments = [
+  'exec',
+  '-i',
+  'squeal-mysql',
+  'mysql',
+  '-uroot',
+  '-pmysql'
+]
+
+/**
+ * Run a command with the contents of a file on its standard input.
+ *
+ * The obvious spelling of this is `cat "<file>" | <command>`, but that is a
+ * shell command, and `execSync` runs it through `process.env.ComSpec` — cmd.exe
+ * — on Windows, which has no `cat`. Node can hand the bytes over itself. That
+ * also spares the path any quoting, which matters here: one of the MySQL seed
+ * files is called `1. sakila-schema.sql`.
+ *
+ * The whole file is read into memory rather than streamed, which `cat` did not
+ * do. The largest of them is 3.4 MB.
+ */
+export async function pipeFileToCommand(
+  command: string,
+  commandArguments: string[],
+  filePath: string
+): Promise<void> {
+  const contents = await readFile(filePath)
+
+  execFileSync(command, commandArguments, {
+    // `input` requires a piped stdin — anything else is a TypeError. The other
+    // two stay inherited so the server's own output reaches the terminal.
+    input: contents,
+    stdio: ['pipe', 'inherit', 'inherit']
+  })
+}

--- a/scripts/mysql-seed.ts
+++ b/scripts/mysql-seed.ts
@@ -1,16 +1,65 @@
 import { execFileSync } from 'child_process'
 import { readFile } from 'fs/promises'
+import { basename } from 'path'
 
-/** The container `docker-compose.yml` declares, and the credentials it sets. */
-export const mysqlSeedCommand = 'docker'
+/**
+ * The container `docker-compose.yml` declares, and the root credentials it
+ * sets. Both are repeated from Compose rather than read out of it, so a test
+ * asserts the two still agree.
+ */
+export const mysqlContainer = 'squeal-mysql'
+const mysqlRootPassword = 'mysql'
+
+/** `-i` is what keeps the container's standard input open to receive the file. */
 export const mysqlSeedArguments = [
   'exec',
   '-i',
-  'squeal-mysql',
+  mysqlContainer,
   'mysql',
   '-uroot',
-  '-pmysql'
+  `-p${mysqlRootPassword}`
 ]
+export const mysqlSeedCommand = 'docker'
+
+/**
+ * Long enough that no honest load hits it, short enough that a `docker exec`
+ * against a container still initialising its data directory eventually says so
+ * instead of hanging until the developer gives up.
+ */
+const defaultTimeoutMilliseconds = 600_000
+
+/**
+ * What went wrong, in the words the developer needs. Every one of these is
+ * reached by a real `yarn seed` on a machine where the containers are not up,
+ * and none of them is legible in the error Node throws: a small file that the
+ * command rejects reads `Command failed: docker exec -i squeal-mysql mysql
+ * -uroot -pmysql`, and a large one reads `spawnSync docker EOF`.
+ */
+function describeFailure(error: unknown, timeoutMilliseconds: number): string {
+  const { code, status } = error as { code?: string; status?: number | null }
+
+  if (code === 'ENOENT') {
+    return 'the command was not found — check that it is installed and on your PATH.'
+  }
+
+  if (code === 'ETIMEDOUT') {
+    return `it did not finish within ${timeoutMilliseconds}ms.`
+  }
+
+  // The whole file goes to the child in one write, so a child that stops
+  // reading fails the parent's write instead of the child. Node reports that as
+  // `EOF` and drops the exit status, and it happens whether the command failed
+  // or succeeded — so an incomplete load can arrive with status 0.
+  if (code === 'EOF') {
+    return 'it stopped reading before the whole file was sent, so the load is incomplete. That usually means it rejected a statement, or the server is not accepting connections yet.'
+  }
+
+  if (typeof status === 'number' && status !== 0) {
+    return `it exited with status ${status}.`
+  }
+
+  return `it failed with ${error instanceof Error ? error.message : String(error)}.`
+}
 
 /**
  * Run a command with the contents of a file on its standard input.
@@ -27,14 +76,25 @@ export const mysqlSeedArguments = [
 export async function pipeFileToCommand(
   command: string,
   commandArguments: string[],
-  filePath: string
+  filePath: string,
+  timeoutMilliseconds: number = defaultTimeoutMilliseconds
 ): Promise<void> {
   const contents = await readFile(filePath)
 
-  execFileSync(command, commandArguments, {
-    // `input` requires a piped stdin — anything else is a TypeError. The other
-    // two stay inherited so the server's own output reaches the terminal.
-    input: contents,
-    stdio: ['pipe', 'inherit', 'inherit']
-  })
+  try {
+    execFileSync(command, commandArguments, {
+      input: contents,
+      // `stdio[0]` has to be `pipe` for `input` to reach the child at all —
+      // with `inherit` Node discards it silently and the child reads the
+      // terminal, which seeds nothing and can hang forever. The other two stay
+      // inherited so the server's own output reaches the developer.
+      stdio: ['pipe', 'inherit', 'inherit'],
+      timeout: timeoutMilliseconds
+    })
+  } catch (error) {
+    throw new Error(
+      `Could not send ${basename(filePath)} to \`${command}\`: ${describeFailure(error, timeoutMilliseconds)}`,
+      { cause: error }
+    )
+  }
 }

--- a/scripts/mysql-seed.ts
+++ b/scripts/mysql-seed.ts
@@ -33,7 +33,7 @@ const defaultTimeoutMilliseconds = 600_000
  * reached by a real `yarn seed` on a machine where the containers are not up,
  * and none of them is legible in the error Node throws: a small file that the
  * command rejects reads `Command failed: docker exec -i squeal-mysql mysql
- * -uroot -pmysql`, and a large one reads `spawnSync docker EOF`.
+ * -uroot -pmysql`, and a large one reads `spawnSync docker EPIPE`.
  */
 function describeFailure(error: unknown, timeoutMilliseconds: number): string {
   const { code, status } = error as { code?: string; status?: number | null }
@@ -48,9 +48,13 @@ function describeFailure(error: unknown, timeoutMilliseconds: number): string {
 
   // The whole file goes to the child in one write, so a child that stops
   // reading fails the parent's write instead of the child. Node reports that as
-  // `EOF` and drops the exit status, and it happens whether the command failed
-  // or succeeded — so an incomplete load can arrive with status 0.
-  if (code === 'EOF') {
+  // `EPIPE` and drops the exit status, and it happens whether the command
+  // failed or succeeded — so an incomplete load arrives with `status: 0`, which
+  // is why this is asked before the status below and not after it.
+  //
+  // `EOF` sits beside it for Windows, where libuv translates the broken pipe to
+  // `UV_EOF` rather than `UV_EPIPE`.
+  if (code === 'EPIPE' || code === 'EOF') {
     return 'it stopped reading before the whole file was sent, so the load is incomplete. That usually means it rejected a statement, or the server is not accepting connections yet.'
   }
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,11 +1,15 @@
 import { createClient } from '@libsql/client'
-import { execSync } from 'child_process'
 import { existsSync, statSync, unlinkSync } from 'fs'
 import { readdir, readFile } from 'fs/promises'
 import { dirname, join, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { Client } from 'pg'
 
+import {
+  mysqlSeedArguments,
+  mysqlSeedCommand,
+  pipeFileToCommand
+} from './mysql-seed'
 import { postgresUrl, sqlitePath } from './seed-config'
 
 async function runSeedFiles(
@@ -63,10 +67,7 @@ async function seedMysql() {
     join(__dirname, '..', 'seed-mysql'),
     'MySQL',
     async (filePath) => {
-      execSync(
-        `cat "${filePath}" | docker exec -i squeal-mysql mysql -uroot -pmysql`,
-        { stdio: 'inherit' }
-      )
+      await pipeFileToCommand(mysqlSeedCommand, mysqlSeedArguments, filePath)
     }
   )
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'url'
 import { Client } from 'pg'
 
 import {
+  mysqlContainer,
   mysqlSeedArguments,
   mysqlSeedCommand,
   pipeFileToCommand
@@ -61,7 +62,7 @@ async function seedPostgres() {
 }
 
 async function seedMysql() {
-  console.log('Connected to MySQL')
+  console.log(`Seeding MySQL through the ${mysqlContainer} container`)
 
   await runSeedFiles(
     join(__dirname, '..', 'seed-mysql'),
@@ -160,7 +161,14 @@ async function seed() {
 
     console.log('All databases seeded successfully!')
   } catch (error) {
-    console.error('Error seeding database:', error)
+    // The message, not the error: every failure this script can produce now
+    // says which file and which command in one line, and dumping the object
+    // buries that under a stack trace — plus, for a failed write to the child,
+    // a circular `error` property.
+    console.error(error instanceof Error ? error.message : error)
+    console.error(
+      'Postgres and MySQL run in the containers docker-compose.yml declares. Start them with `docker compose up -d`, give MySQL a moment to finish initialising, then run `yarn seed` again.'
+    )
 
     process.exit(1)
   }


### PR DESCRIPTION
Closes #73.

`yarn seed` could not seed MySQL on Windows. The two MySQL files went in
through `execSync(\`cat "${filePath}" | ...\`)`, and `execSync` runs its
argument through `process.env.ComSpec` — cmd.exe — which has no `cat`.

Node can hand the bytes over itself, so it now does:

```ts
execFileSync(command, commandArguments, {
  input: await readFile(filePath),
  stdio: ['pipe', 'inherit', 'inherit'],
  timeout: 600_000
})
```

That also spares the path any quoting, which matters here: one of the
seed files is called `1. sakila-schema.sql`.

## What the second commit adds

The first commit fixed the mechanism but left Node's own error reaching
the developer, and a fresh-context review was right that it names
nothing useful. I confirmed both shapes against the real seed files:

| Situation | What it used to print |
| --- | --- |
| Small file the server rejects | `Command failed: docker exec -i squeal-mysql mysql -uroot -pmysql` |
| 3.4 MB file, container not up | `spawnSync docker EOF` |

The second one is the failure a developer meets first, and it names
nothing at all. The cause is that the whole file goes to the child in one
write, so a child that stops reading fails the *parent's* write — Node
reports that as `EOF` and drops the exit status. It does so whether the
command failed or succeeded, so **an incomplete load can arrive with
status 0**; that is why the `EOF` branch exists separately rather than
falling through to the status check.

With Docker down, the real messages now read:

```
Could not send 1. sakila-schema.sql to `docker`: it exited with status 1.
Could not send 2. sakila-data.sql to `docker`: it stopped reading before the
whole file was sent, so the load is incomplete. That usually means it rejected
a statement, or the server is not accepting connections yet.
```

followed by `Postgres and MySQL run in the containers docker-compose.yml
declares. Start them with \`docker compose up -d\`, give MySQL a moment to
finish initialising, then run \`yarn seed\` again.`

Also: a `timeout` on the child, so `docker exec` against a container
still initialising its data directory eventually says so instead of
hanging; and `console.error(error.message)` rather than the error object,
which buries that line under a stack trace and, for a failed write, a
circular `error` property.

## Tests

Ten tests in `scripts/mysql-seed.test.ts`, driving a real child process
that reads real bytes off its own stdin — mocking the spawn would have
passed against the shell pipeline this replaces, which is exactly the
thing that does not work. `scripts/**` is added to the vitest `backend`
(node) project, where it belongs; it was in the jsdom one.

- a file with a space in its name, carrying `DELIMITER ;;` and non-ASCII
- 5.8 MB, compared by SHA-1 — a pipe that truncated at its buffer size
  would look like a working seed until a table came up short
- `PATH=''`, which is the one assertion that fails if the pipeline ever
  comes back
- each of the four failure messages, asserted as text rather than as
  "it threw"
- the original error still attached as `cause`
- the seed command still matches the `container_name` and
  `MYSQL_ROOT_PASSWORD` in the `mysql:` block of docker-compose.yml

Mutation-tested: 21 mutants, 21 killed, no survivors.

## Honest gaps

- **No live seed was run.** Docker Desktop is not running on this
  machine, so the issue's own validation plan — `SELECT COUNT(*)` on
  `sakila.film` and `sakila.rental` — is unverified. Every failure path
  was exercised for real; the success path was exercised against a Node
  child rather than mysqld.
- **The reported `'cat' is not recognized` does not reproduce here** as
  such: this machine has Git's `usr\bin` on PATH, so cmd.exe finds a
  `cat`. The test forces `PATH=''`, which is what a Windows machine
  without it sees, and that is the state the issue describes.
- **MySQL still has no environment override** for host/port/credentials
  the way Postgres and SQLite do. That is #72's subject and would
  conflict with it, so it is left alone — note that #72 also edits
  `scripts/seed.ts`.
- **A MySQL failure still `process.exit(1)`s before SQLite is seeded.**
  The issue defers that to its own commit.
- **`scripts/` is in neither tsconfig's include**, so these files get no
  type coverage in CI. Same gap #107 mentions; not fixed here.
- **One mutant is not usefully caught.** Flipping `stdio[0]` to
  `'inherit'` makes each affected test wait out the full 600 s child
  timeout rather than failing, so the suite would eventually go red but
  not in a time anyone would sit through. I killed the run rather than
  wait it out. The comment at that line is the guard instead.

The full suite is 961 passing, with one pre-existing failure on `main`
(`src/databases/sqlite-adapter.test.ts` — a Windows `file:///` path
mismatch), untouched by this branch.
