### PR TITLE
chore(deps): declare the prettier this repository formats against

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "jsdom": "^27.2.0",
     "png-to-ico": "^3.0.1",
     "postcss": "^8.5.6",
+    "prettier": "3.7.1",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.1.17",
     "tsx": "^4.20.6",

--- a/scripts/declared-tools.test.ts
+++ b/scripts/declared-tools.test.ts
@@ -1,0 +1,232 @@
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  invokedTools,
+  toolsInvokedByScript,
+  unpinnedNpxTools
+} from './declared-tools'
+
+const repositoryRoot = join(import.meta.dirname, '..')
+
+describe('invokedTools', () => {
+  it('reports what the scripts run and what the workflows fetch', () => {
+    expect(
+      invokedTools({
+        scripts: { format: 'prettier --write .' },
+        workflows: ['      - name: Audit\n        run: npx license-checker\n']
+      })
+    ).toEqual(['license-checker', 'prettier'])
+  })
+
+  it('reports a tool both places name only once', () => {
+    expect(
+      invokedTools({
+        scripts: { format: 'prettier --write .' },
+        workflows: ['        run: npx prettier --check .\n']
+      })
+    ).toEqual(['prettier'])
+  })
+})
+
+describe('toolsInvokedByScript', () => {
+  it('names the command a script runs', () => {
+    expect(toolsInvokedByScript('prettier --write .')).toEqual(['prettier'])
+  })
+
+  it('names the command in every segment of a chain', () => {
+    expect(
+      toolsInvokedByScript(
+        'tsx scripts/fetch-macos-bindings.ts && electron-forge make'
+      )
+    ).toEqual(['electron-forge', 'tsx'])
+  })
+
+  it('names a command once however often a script runs it', () => {
+    expect(
+      toolsInvokedByScript(
+        'tsc --noEmit -p tsconfig.backend.json && tsc --noEmit -p tsconfig.renderer.json'
+      )
+    ).toEqual(['tsc'])
+  })
+
+  it('looks past an environment assignment', () => {
+    expect(toolsInvokedByScript('NODE_ENV=test vitest run')).toEqual(['vitest'])
+  })
+
+  it('ignores the runtimes the machine already has', () => {
+    expect(toolsInvokedByScript('bun run scripts/generate-icons.ts')).toEqual(
+      []
+    )
+  })
+
+  it('names what npx would fetch rather than npx', () => {
+    expect(toolsInvokedByScript('npx prettier --check .')).toEqual(['prettier'])
+  })
+
+  it('says nothing about an npx invocation that pins its own version', () => {
+    expect(toolsInvokedByScript('npx --yes fallow@3.2.0')).toEqual([])
+  })
+})
+
+describe('unpinnedNpxTools', () => {
+  it('finds an npx invocation inside a shell block', () => {
+    expect(
+      unpinnedNpxTools('yarn install --frozen-lockfile\nnpx prettier --check .')
+    ).toEqual(['prettier'])
+  })
+
+  it('leaves a pinned invocation alone', () => {
+    expect(unpinnedNpxTools('npx --yes fallow@3.2.0')).toEqual([])
+  })
+
+  it('leaves a scoped pinned invocation alone', () => {
+    expect(unpinnedNpxTools('npx --yes @biomejs/biome@2.0.0 check')).toEqual([])
+  })
+
+  it('reports a scoped package with no version', () => {
+    expect(unpinnedNpxTools('npx @biomejs/biome check')).toEqual([
+      '@biomejs/biome'
+    ])
+  })
+
+  // A scope may begin with a digit, so a specifier's leading `@` cannot be read
+  // as the start of a version even by shape — `@11ty/eleventy` would otherwise
+  // pass for a pinned invocation and drop off the list entirely.
+  it('reports a scoped package whose scope begins with a digit', () => {
+    expect(unpinnedNpxTools('npx @11ty/eleventy --serve')).toEqual([
+      '@11ty/eleventy'
+    ])
+  })
+
+  it('finds nothing in a block that runs no npx', () => {
+    expect(unpinnedNpxTools('yarn typecheck')).toEqual([])
+  })
+
+  // A tag is the float this guard is for, not an exemption from it. Reported
+  // under the name it was written with, because that is the thing invoked and
+  // nothing declares it — `prettier` being in devDependencies does not constrain
+  // what `@latest` fetches.
+  it('reports an invocation pinned to a tag rather than a version', () => {
+    expect(unpinnedNpxTools('npx prettier@latest --check .')).toEqual([
+      'prettier@latest'
+    ])
+  })
+
+  it('reports a prerelease version as pinned', () => {
+    expect(unpinnedNpxTools('npx fallow@4.0.0-beta.1')).toEqual([])
+  })
+
+  // The command after `--package` is a bin inside it, and a bin name is not what
+  // a dependency list declares — `tsc` would be reported as undeclared while
+  // `typescript` sat in devDependencies.
+  it('names the package an invocation asks for rather than the bin', () => {
+    expect(unpinnedNpxTools('npx --package=typescript tsc --noEmit')).toEqual([
+      'typescript'
+    ])
+  })
+
+  // Which needs nothing of its own to work, the package being the first token
+  // that is not an option — but it is the spelling this repository would most
+  // likely be written with, so it is held down.
+  it('reads the spaced spelling of the package option', () => {
+    expect(unpinnedNpxTools('npx -p typescript tsc --noEmit')).toEqual([
+      'typescript'
+    ])
+  })
+})
+
+// The version of a tool the repository runs is part of the repository, not of
+// whatever the registry served the day a job happened to run. A tool that is
+// invoked but not declared has no version of its own here: it is whatever
+// yarn.lock happens to hold for some other package's range, or — where nothing
+// depends on it at all — whatever the registry serves. The lockfile keeps that
+// deterministic between installs, so this is not a live CI failure; what it
+// means is that the version this project formats and lints against is chosen by
+// someone else, and moves when their range does or when the lockfile is
+// regenerated.
+//
+// Only two places are checked, because they are the two that run this project's
+// own Node tooling: every package.json script, and every `npx` anywhere in the
+// workflows. The shell blocks in release.yml reach for `openssl`, `xcrun` and
+// `find`, which the runner image owns and package.json has no say over.
+describe('the tools this repository invokes', () => {
+  const manifest = JSON.parse(
+    readFileSync(join(repositoryRoot, 'package.json'), 'utf-8')
+  ) as {
+    dependencies: Record<string, string>
+    devDependencies: Record<string, string>
+    scripts: Record<string, string>
+  }
+
+  const declaredPackages = [
+    ...Object.keys(manifest.dependencies),
+    ...Object.keys(manifest.devDependencies)
+  ]
+
+  // Which package provides which command, read off the installed tree rather
+  // than written down here — a hand-kept map of `tsc` to `typescript` would be
+  // one more thing to get wrong.
+  const providers = new Map<string, string>()
+
+  for (const packageName of declaredPackages) {
+    const manifestPath = join(
+      repositoryRoot,
+      'node_modules',
+      packageName,
+      'package.json'
+    )
+
+    if (!existsSync(manifestPath)) {
+      continue
+    }
+
+    const installed = JSON.parse(readFileSync(manifestPath, 'utf-8')) as {
+      bin?: Record<string, string> | string
+    }
+
+    if (typeof installed.bin === 'string') {
+      providers.set(packageName.split('/').at(-1) ?? packageName, packageName)
+
+      continue
+    }
+
+    for (const binaryName of Object.keys(installed.bin ?? {})) {
+      providers.set(binaryName, packageName)
+    }
+  }
+
+  const workflowsDirectory = join(repositoryRoot, '.github', 'workflows')
+  const invoked = invokedTools({
+    scripts: manifest.scripts,
+    workflows: readdirSync(workflowsDirectory).map((fileName) =>
+      readFileSync(join(workflowsDirectory, fileName), 'utf-8')
+    )
+  })
+
+  it.each(invoked)('%s is a declared dependency', (tool) => {
+    expect(
+      { tool, provider: providers.get(tool) },
+      `\`${tool}\` is invoked by a package.json script or a workflow, but no declared dependency provides a bin by that name. Add the package that owns it to devDependencies with an exact version — or, if it is \`name@latest\`, name the version instead of the tag.`
+    ).toEqual({ tool, provider: expect.any(String) })
+  })
+
+  // An empty list would satisfy every assertion above, and so would a list that
+  // had quietly stopped covering package.json. `electron-forge` is named by four
+  // scripts and by nothing else, so it is the one tool whose presence says the
+  // scripts were read.
+  it('reads the package.json scripts', () => {
+    expect(invoked).toContain('electron-forge')
+  })
+
+  // And the same for the other half. Every tool the workflows reach for through
+  // `npx` is also named by a script, so the union above would look identical if
+  // the workflow scan silently stopped matching — this is the one assertion that
+  // fails when it does.
+  it('reads the workflows', () => {
+    const workflow = readFileSync(join(workflowsDirectory, 'ci.yml'), 'utf-8')
+
+    expect(unpinnedNpxTools(workflow)).toEqual(['prettier'])
+  })
+})

--- a/scripts/declared-tools.ts
+++ b/scripts/declared-tools.ts
@@ -1,0 +1,129 @@
+/**
+ * Which command-line tools a shell command reaches for, so a guard test can
+ * check that every one of them is a package this repository declares a version
+ * for.
+ */
+
+/**
+ * Commands the machine running the build already has. A package.json that does
+ * not declare them is not the defect. `npx` is on the list because what it
+ * fetches is the interesting part, not `npx` itself.
+ */
+const runtimeCommands = ['bun', 'node', 'npm', 'npx', 'yarn']
+
+/** `&&`, `||`, a pipe, a semicolon or a newline all start a new command. */
+const segmentSeparator = /&&|\|\||[|;\n]/
+
+/** An assignment prefix, as in `NODE_ENV=test vitest run`. */
+const assignmentPrefix = /^[A-Za-z_][A-Za-z0-9_]*=/
+
+/**
+ * What an `npx` invocation would fetch, which is not always the first argument
+ * that is not an option: `--package=name` names the package, and the command
+ * after it is a bin inside that package — a bin name is not what a dependency
+ * list declares. The spaced spellings, `-p name` and `--package name`, need no
+ * handling of their own, since the package is then the first non-option token
+ * anyway.
+ */
+function npxSpecifier(argumentTokens: readonly string[]): string | undefined {
+  const inline = argumentTokens.find((token) => token.startsWith('--package='))
+
+  if (inline !== undefined) {
+    return inline.slice('--package='.length)
+  }
+
+  return argumentTokens.find((token) => !token.startsWith('-'))
+}
+
+/**
+ * The tool an `npx` invocation would fetch, given the arguments after `npx`,
+ * or `undefined` when the invocation says for itself which version it runs.
+ */
+function npxTool(argumentTokens: readonly string[]): string | undefined {
+  const specifier = npxSpecifier(argumentTokens)
+
+  if (specifier === undefined) {
+    return undefined
+  }
+
+  // `name@3.2.0` carries its own version, which is what declaring it would have
+  // achieved. A leading `@` is a scope, not a version, so only a later one
+  // counts — and `name@latest` is not a version but the float this guard exists
+  // to catch, so it stays on the list under the name it was written with, which
+  // no declared package provides.
+  const separator = specifier.lastIndexOf('@')
+  const version = separator > 0 ? specifier.slice(separator + 1) : undefined
+
+  if (version !== undefined && /^[~^><=]*\d/.test(version)) {
+    return undefined
+  }
+
+  return specifier
+}
+
+function tokenize(segment: string): string[] {
+  return segment
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0)
+}
+
+interface Invocations {
+  /** The `scripts` block of a package.json, command lines and all. */
+  readonly scripts: Record<string, string>
+  /** The contents of each workflow file. */
+  readonly workflows: readonly string[]
+}
+
+/**
+ * Every tool the repository invokes, from both of the places it invokes one.
+ */
+export function invokedTools(invocations: Invocations): string[] {
+  const tools = [
+    ...Object.values(invocations.scripts).flatMap(toolsInvokedByScript),
+    ...invocations.workflows.flatMap(unpinnedNpxTools)
+  ]
+
+  return [...new Set(tools)].sort()
+}
+
+/** Every tool a package.json script runs, in each segment of a chain. */
+export function toolsInvokedByScript(script: string): string[] {
+  const tools = script.split(segmentSeparator).flatMap((segment) => {
+    const tokens = tokenize(segment)
+    const commandIndex = tokens.findIndex(
+      (token) => !assignmentPrefix.test(token)
+    )
+
+    if (commandIndex === -1) {
+      return []
+    }
+
+    const command = tokens[commandIndex]
+
+    if (!runtimeCommands.includes(command)) {
+      return [command]
+    }
+
+    if (command !== 'npx') {
+      return []
+    }
+
+    const tool = npxTool(tokens.slice(commandIndex + 1))
+
+    return tool === undefined ? [] : [tool]
+  })
+
+  return [...new Set(tools)].sort()
+}
+
+/** Every unpinned `npx` invocation anywhere in a block of shell. */
+export function unpinnedNpxTools(shell: string): string[] {
+  const tools = [...shell.matchAll(/\bnpx\b([^\n&|;]*)/g)].flatMap((match) => {
+    const tool = npxTool(tokenize(match[1]))
+
+    return tool === undefined ? [] : [tool]
+  })
+
+  return [...new Set(tools)].sort()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7324,7 +7324,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^3.4.2:
+prettier@3.7.1, prettier@^3.4.2:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.7.1.tgz#8dfbf54c98e85a113962d3d8414ae82ff3722991"
   integrity sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==


### PR DESCRIPTION
Closes #107.

## The mechanism is not quite what the issue says — and the defect is worse

The issue reads the `npx prettier --check .` in CI as a registry fetch.
It is not: `npx` searches `node_modules/.bin` before it touches the
registry, and prettier is there — as a **runtime dependency of
`@electron/packager`**, which asks for `^3.4.2`.

So the version this project formats and lints against was picked by an
unrelated package. The lockfile keeps that deterministic between
installs, so CI was **not** failing and was never one registry release
away from failing — the commit message and the guard's header comment
both say so now rather than inheriting the issue's framing.

What is actually wrong is ownership:

- the range belongs to `@electron/packager`, so a packager bump moves it
- `release.yml:51` installs with a bare `yarn install`, no `--frozen-lockfile`
- a lockfile regeneration floats it to the newest 3.x — **today `^3.4.2`
  resolves to 3.9.6**, two minors past what the tree is formatted for

## The fix

`"prettier": "3.7.1"` — exact, and exactly the version already installed,
so **nothing in the tree reformats**. Exact rather than `^3.7.1` because a
caret is the same float one level up, and because it matches how this
repo pins everything whose output must not move on its own (`electron`,
`@codemirror/commands`, `@electron-forge/maker-zip`, `@tanstack/react-db`).

`yarn.lock` is hand-edited, which is the part worth checking rather than
trusting, because yarn 1 merges specifiers into one key. I verified it
against real installs in a throwaway project instead of guessing:

| Starting lockfile | Root declaration | What `yarn install` writes |
| --- | --- | --- |
| *(empty)* | `3.7.1` | **two** entries — `prettier@3.7.1` at 3.7.1 and `prettier@^3.4.2` at **3.9.6** |
| already `prettier@^3.4.2 -> 3.7.1` | `3.7.1` | one merged key `prettier@3.7.1, prettier@^3.4.2:` at 3.7.1 |
| already `prettier@^3.4.2 -> 3.7.1` | `^3.7.1` | one merged key `prettier@^3.4.2, prettier@^3.7.1:` at 3.7.1 |

The second row is this repository's situation, and that merged key is what
the branch contains, byte for byte. `yarn install --frozen-lockfile`
accepts it and installs 3.7.1; with the pre-fix key it fails with "Your
lockfile needs to be updated", so the lockfile edit is load-bearing. In
the exact-pin case the root hoist and `node_modules/.bin/prettier` are
both 3.7.1 — checked directly, since that is the whole point.

## The guard

Declaring one version fixes one tool and stops nothing, so
`scripts/declared-tools.ts` works out which tools the repository invokes —
from every package.json script and every `npx` in the workflows — and a
test asserts each is provided by a declared package, reading the
bin-to-package map off the installed tree rather than restating it (a
hand-kept `tsc` → `typescript` map would be one more thing to get wrong).

An invocation that carries its own version is exempt, but only a real one:

- `npx prettier@latest` is **not** exempt. A tag is the float the guard
  exists to catch, so it is reported under the name it was written with,
  which no declared package provides.
- a scope may begin with a digit, so `@11ty/eleventy` is not read as a
  pinned version and silently dropped.
- `--package=name` names the package, not the bin that follows it —
  otherwise `npx --package=typescript tsc` would report `tsc` as
  undeclared while `typescript` sat in devDependencies.

Two assertions exist only to fail when the guard stops looking:
`electron-forge` is named by four scripts and nothing else, and the
workflow scan of `ci.yml` must still find `prettier`. That second one
matters because every tool the workflows fetch is also named by a script,
so the union alone would look identical if the workflow regex quietly
stopped matching.

27 tests. Mutation-tested: 11 mutants over the reworked module, all
killed — including one that survived the first pass (`separator > 0` →
`>= 0`, the digit-scope case above), which is why that test exists.

## Honest gaps

- **`yarn install` was never run here.** `node_modules` in this worktree
  is a junction to another checkout's, so installing would mutate a
  shared tree. The lockfile line is verified by reproduction in a
  throwaway project, as above; CI's `--frozen-lockfile` is the real check.
- **`scripts/` is in neither tsconfig's `include`**, so these 361 lines
  get no type coverage in CI. I ran `tsc --noEmit --strict` on the module
  by hand and it passes. Adding a `tsconfig.scripts.json` is the right
  fix, but the issue explicitly defers that gap, and #158 touches the same
  directory — doing it here would conflict. Left as the issue left it.
- **The test runs in the jsdom project**, paying jsdom setup for a pure
  fs/JSON test. Moving `scripts/**/*.test.ts` into `backendTestPatterns`
  is one line, and **#158 already does exactly that** — so it is left out
  here to avoid a conflict on `vitest.config.ts`.
- **Known holes in the scanner**, none of which occur in the repo:
  `sh -c "prettier ..."` reports `sh`; a bare `run: prettier --check .`
  with no `npx` is missed entirely (it would fail in Actions anyway,
  since `node_modules/.bin` is not on PATH outside `yarn run`); `pnpm dlx`
  and `bunx` are not recognised.
- **Not done:** adding a `format:check` script so `ci.yml` could run
  `yarn format:check` instead of shelling out to `npx` at all. That is the
  structural fix and it would remove the registry-fallback path entirely,
  but it is past what this issue asks for — and it would leave the
  workflow half of the guard with no input to scan. Worth its own issue.

Full suite: 978 passing, with one pre-existing failure on `main`
(`src/databases/sqlite-adapter.test.ts` — a Windows `file:///` path
mismatch), untouched by this branch.
