### PR TITLE
fix(shadcn): point components.json at the stylesheet that exists

### DIFF
--- a/components.json
+++ b/components.json
@@ -5,16 +5,16 @@
   "tsx": true,
   "tailwind": {
     "config": "",
-    "css": "src/index.css",
+    "css": "src/app/index.css",
     "baseColor": "neutral",
     "cssVariables": true,
     "prefix": ""
   },
   "aliases": {
     "components": "@/app/components",
-    "utils": "@/app//lib/utils",
+    "utils": "@/app/lib/utils",
     "ui": "@/app/components/ui",
-    "lib": "@/app//lib",
+    "lib": "@/app/lib",
     "hooks": "@/app/hooks"
   },
   "iconLibrary": "lucide"

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
 
-import { cn } from '@/app//lib/utils'
+import { cn } from '@/app/lib/utils'
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-accent focus-visible:ring-accent/50 focus-visible:ring-[3px] aria-invalid:ring-err/20 aria-invalid:border-err",

--- a/src/app/components/ui/context-menu.tsx
+++ b/src/app/components/ui/context-menu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu'
 import { ChevronRightIcon } from 'lucide-react'
 
-import { cn } from '@/app//lib/utils'
+import { cn } from '@/app/lib/utils'
 
 function ContextMenu({
   ...props

--- a/src/app/components/ui/form.tsx
+++ b/src/app/components/ui/form.tsx
@@ -13,7 +13,7 @@ import {
   type FieldValues
 } from 'react-hook-form'
 
-import { cn } from '@/app//lib/utils'
+import { cn } from '@/app/lib/utils'
 import { Label } from '@/app/components/ui/label'
 
 const Form = FormProvider

--- a/src/app/components/ui/input.tsx
+++ b/src/app/components/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { cn } from '@/app//lib/utils'
+import { cn } from '@/app/lib/utils'
 
 function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (

--- a/src/app/components/ui/label.tsx
+++ b/src/app/components/ui/label.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as LabelPrimitive from '@radix-ui/react-label'
 
-import { cn } from '@/app//lib/utils'
+import { cn } from '@/app/lib/utils'
 
 function Label({
   className,

--- a/src/app/components/ui/table.tsx
+++ b/src/app/components/ui/table.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { cn } from '@/app//lib/utils'
+import { cn } from '@/app/lib/utils'
 
 function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (

--- a/src/components-json.test.ts
+++ b/src/components-json.test.ts
@@ -1,0 +1,122 @@
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import { join, relative, resolve } from 'path'
+import invariant from 'tiny-invariant'
+import { describe, expect, it } from 'vitest'
+
+// Nothing at build or run time reads `components.json`. It is consumed only by
+// the `shadcn` CLI, which is not a dependency of this repository and appears in
+// no script and no CI job — which is why a path to a file that has never
+// existed survived from the first commit, and why the doubled slash in two of
+// its aliases reached six generated components before anyone noticed. These
+// assertions are the only reader it has.
+describe('components.json', () => {
+  const root = resolve(import.meta.dirname, '..')
+  const configuration = JSON.parse(
+    readFileSync(join(root, 'components.json'), 'utf-8')
+  ) as {
+    aliases?: Record<string, string>
+    tailwind?: { config: string; css: string }
+  }
+
+  const { aliases, tailwind } = configuration
+
+  invariant(aliases, 'components.json declares no aliases.')
+  invariant(tailwind, 'components.json declares no tailwind block.')
+
+  // The encoding is what keeps this `string[]`; without it the version-agnostic
+  // overload widens to `Buffer[]`.
+  const sourceFiles = readdirSync(join(root, 'src'), {
+    encoding: 'utf-8',
+    recursive: true
+  })
+    .filter((entry) => /\.tsx?$/.test(entry))
+    .map((entry) => join(root, 'src', entry))
+
+  // `@/` is `src/` in every tsconfig and every Vite config here.
+  function aliasTarget(alias: string): string {
+    return join(root, 'src', alias.replace('@/', ''))
+  }
+
+  // An empty `tailwind.config` puts the CLI in Tailwind v4 mode, where there is
+  // no `tailwind.config.js` to hold anything: every theme token and `@layer`
+  // addition a registry item ships is written to the file named here. Naming one
+  // that does not exist aborts an add halfway through — verified against shadcn
+  // 4.18 with the pre-fix config, where `add sidebar` wrote all eight component
+  // files and installed their dependencies, then read this path without
+  // guarding it and died with `ENOENT ... src/index.css`. The components were
+  // left on disk with their custom properties defined nowhere.
+  it('names a stylesheet that exists', () => {
+    const { css } = tailwind
+
+    expect({ css, exists: existsSync(join(root, css)) }).toEqual({
+      css,
+      exists: true
+    })
+  })
+
+  // Existing is not enough. It has to be the stylesheet Tailwind actually
+  // processes, and the one that reaches Tailwind is the one the renderer
+  // imports — so that is what it is compared against rather than a path
+  // repeated here.
+  //
+  // Worth knowing before the next add: with the path correct, the same
+  // `add sidebar` succeeds and writes shadcn's own `:root` and `.dark` token
+  // names into this file, which has a vocabulary of its own (`--panel`,
+  // `--text`, `--border`) and its own ThemeProvider. A quiet stylesheet edit
+  // rather than a loud failure, and worth reading before committing.
+  it('names the stylesheet the renderer imports', () => {
+    const renderer = readFileSync(join(root, 'src', 'renderer.tsx'), 'utf-8')
+    const imported = /import '(\.[^']*\.css)'/.exec(renderer)?.[1]
+
+    invariant(
+      imported,
+      'src/renderer.tsx has no relative .css import. If the stylesheet moved to an aliased import, update this test to match both spellings.'
+    )
+
+    expect(resolve(root, tailwind.css)).toEqual(resolve(root, 'src', imported))
+  })
+
+  // A doubled separator resolves: TypeScript normalizes one away when it
+  // substitutes a `paths` entry, and Vite's alias is a string replacement the OS
+  // then collapses. So this is cosmetic on its own — but `import/no-unresolved`
+  // is off, nothing else will ever mention it, and every `shadcn add` mints
+  // another copy.
+  it('spells every alias with single separators', () => {
+    const doubled = Object.entries(aliases).filter(([, alias]) =>
+      alias.includes('//')
+    )
+
+    expect(doubled).toEqual([])
+  })
+
+  // The same defect as the stylesheet path, on the other five entries. An alias
+  // pointing nowhere is milder — the CLI creates directories it does not find —
+  // but it is the same class of thing, and this file has no other reader.
+  it('resolves every alias it declares', () => {
+    const missing = Object.entries(aliases).filter(
+      ([, alias]) =>
+        !['', '.ts', '.tsx'].some((extension) =>
+          existsSync(`${aliasTarget(alias)}${extension}`)
+        )
+    )
+
+    expect(missing).toEqual([])
+  })
+
+  // Any doubled separator in an aliased import, not just the one spelling this
+  // config happened to produce: `components`, `ui` and `hooks` are substituted
+  // the same way, and the generator copies whatever the alias says. The pattern
+  // does not match its own source, since the `@/` here is written `@\/`.
+  it('has not been copied into any import', () => {
+    invariant(
+      sourceFiles.includes(join(root, 'src', 'renderer.tsx')),
+      'The walk of src/ did not find renderer.tsx, so it read nothing and the assertion below proves nothing.'
+    )
+
+    const offenders = sourceFiles
+      .filter((file) => /'@\/[^']*\/\//.test(readFileSync(file, 'utf-8')))
+      .map((file) => relative(root, file))
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #105.

## What was wrong

`components.json` named `src/index.css` as the Tailwind stylesheet. That file has never existed — the renderer imports `src/app/index.css`. Two aliases also carried a doubled separator, `@/app//lib/utils` and `@/app//lib`.

With `tailwind.config` empty the CLI runs in Tailwind v4 mode, where there is no `tailwind.config.js` to hold anything: every theme token and `@layer` addition a registry item ships is written to the stylesheet named here.

## What that actually did — measured, not reasoned

The issue guessed at a failure mode and said so ("medium-high confidence"). I reconstructed the old config and ran the real CLI, `npx shadcn@4.18.0 add sidebar --yes`:

```
✔ Created 8 files: src/app/components/ui/{button,separator,sheet,tooltip,input,skeleton,sidebar}.tsx,
                   src/app/hooks/use-mobile.ts
- Updating src\index.css
Something went wrong. ENOENT: no such file or directory, open '<root>\src\index.css'
exit 1
```

So it is worse and louder than the issue supposed. It **fails** — non-zero exit. No `src/index.css` is created, and no second stylesheet appears; `src/app/index.css` is byte-identical afterwards. But the add is **partially applied**: eight component files and their npm dependencies are already on disk when the run dies, with the custom properties every one of them references defined nowhere. Recovering means knowing which files to revert.

The mechanism is in `shadcn/dist/chunk-2CD4IZV7.js` — `updateCssVars` and `updateCss` both do an unguarded `await fs.readFile(config.resolvedPaths.tailwindCss, 'utf8')` with no `existsSync` and no `catch`, and the add pipeline calls them *after* `updateFiles`.

## Worth knowing before the next add

With the path corrected, the same `add sidebar` exits 0 — and writes `@custom-variant dark (&:is(.dark *))` plus shadcn's own `:root`/`.dark` token names into `src/app/index.css`, which has a vocabulary of its own (`--panel`, `--text`, `--border`) and its own `ThemeProvider`. The fix converts a loud failure into a quiet stylesheet edit. That is the right trade, but the edit wants reading before it is committed. Noted in the test file so the next person meets it there.

## The doubled slash

The generator had already minted six copies: `button`, `context-menu`, `form`, `input`, `label` and `table` import from `@/app//lib/utils`, while `popover`, `select`, `separator` and `tooltip` use the single slash — `ui/` was split down the middle. They all resolve (TypeScript normalizes the duplicate when it substitutes a `paths` entry; Vite's alias is a string replacement the OS then collapses), and `import/no-unresolved` is off, so nothing was ever going to mention it. All six are now spelled one way. Fixing the alias without them would have left the directory inconsistent in the other direction, so they are in scope.

Checked and unaffected: no `@//`, no `src//`, and no doubled separator in any tsconfig path, Vite alias or Tailwind glob.

## The test

`src/components-json.test.ts` — five assertions, and the only reader this file has ever had. Nothing at build or run time reads `components.json`; only the `shadcn` CLI does, and it is not a dependency and appears in no script or CI job. That is exactly why a path to a nonexistent file survived from the first commit.

1. the stylesheet it names exists
2. it is the stylesheet `renderer.tsx` imports — existing is not enough, and the comparison is against the renderer rather than a path repeated in the test
3. every alias resolves
4. no alias carries a doubled separator
5. no source file has been given one, in **any** spelling — `/'@\/[^']*\/\//`, not the one historical `@/app//`, since `components`, `ui` and `hooks` are substituted the same way

## TDD

Red-green per assertion, then a mutation pass to show the tests have teeth. 7/7 killed:

| Mutant | Result |
|---|---|
| the nonexistent path comes back | KILLED |
| the config names an existing stylesheet the renderer does not import | KILLED |
| the doubled slash comes back in an alias | KILLED |
| an alias points at a directory that does not exist | KILLED |
| the historical `@/app//lib/utils` comes back in an import | KILLED |
| `@/app/components//ui/label` — a spelling the narrow needle missed | KILLED |
| the renderer stops importing the stylesheet the config names | KILLED |

The sixth is the one that matters: an earlier draft used `.includes("'@/app//")` and that mutant survived it.

## Gates

eslint 0, prettier clean, `tsc -p tsconfig.renderer.json` clean, 778 renderer tests passing.

One pre-existing failure on `main` is untouched and unrelated: `src/databases/sqlite-adapter.test.ts > testConnection > connects and executes SELECT 1`, a Windows `file:///` path-format mismatch.

## Not done

- **`scripts/` and the root config files are in no typecheck project.** Flagged in #158 and #159 too; wants its own issue rather than a third partial fix, since those branches touch that directory.
- **The stylesheet the CLI would now edit is not asserted against shadcn's token vocabulary.** Documented above and in the test file, not enforced — enforcing it means pinning `src/app/index.css` content, which is a real stylesheet under active edit.
