### PR TITLE
style(format): stop formatting the generated design bundle

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,6 @@
 CHANGELOG.md
 build/
 coverage/
+design/
 dist/
 node_modules/

--- a/src/prettier-ignore.test.ts
+++ b/src/prettier-ignore.test.ts
@@ -1,0 +1,130 @@
+import { execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join, resolve } from 'path'
+import invariant from 'tiny-invariant'
+import { describe, expect, it } from 'vitest'
+
+// `doctor.config.json` says what in this repository is not source. Prettier has
+// its own list and they disagreed: `design/squeal-sql-editor.html` is a 252 KB
+// bundle whose script block the design tool generates, declared not-source
+// there and walked by `prettier --write .` anyway.
+//
+// This is not a hypothetical cost. `459efbf style: format the repo with
+// prettier` reformatted that one file by 917 lines — 81% of everything that
+// commit changed — and the bundle is only Prettier-shaped today because
+// Prettier reshaped it then. The bill arrives again the next time the design
+// tool regenerates it.
+//
+// `ignore.files` is the right list to compare against rather than the whole
+// config: `overrides` already exists for source the linter skips for other
+// reasons, and holds `src/preload.ts` — real source, reached through
+// `forge.config.ts` instead of an import. So an entry under `ignore.files` is a
+// claim that the formatter has no business there either.
+//
+// The stronger test would ask Prettier's own matcher instead of comparing the
+// two declarations textually. Importing `prettier` is not available: it is not
+// a declared dependency — `package.json` names it in the `format` script and
+// nowhere else — and Fallow fails the build on an unlisted one, static import
+// or dynamic. Shelling out to `prettier --file-info` does dodge that, at the
+// price of a 1.2 s subprocess per path resolved through a binary this
+// repository never asked for. Not worth it before #107 lands; worth
+// reconsidering after.
+//
+// The file lives here rather than beside a subject because it has no subject,
+// and `src/` is the only directory that both runs under vitest and typechecks
+// — see #161.
+describe('.prettierignore', () => {
+  const root = resolve(import.meta.dirname, '..')
+
+  const lines = readFileSync(join(root, '.prettierignore'), 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'))
+
+  const negations = lines.filter((line) => line.startsWith('!'))
+  const patterns = lines.filter((line) => !line.startsWith('!'))
+
+  // The config is JSONC — its entries carry the comments explaining why each is
+  // there, which is most of their value. Only whole-line comments are stripped,
+  // because `$schema`'s value contains `//`; a trailing comment or a trailing
+  // comma is legal JSONC that this does not handle, and arrives as a bare
+  // `SyntaxError` from `JSON.parse`.
+  const configuration = JSON.parse(
+    readFileSync(join(root, 'doctor.config.json'), 'utf-8').replace(
+      /^\s*\/\/.*$/gm,
+      ''
+    )
+  ) as { ignore?: { files?: string[] } }
+
+  const declared = configuration.ignore?.files ?? []
+
+  invariant(
+    declared.length > 0 && declared.every((entry) => typeof entry === 'string'),
+    'doctor.config.json must declare a list of ignored file patterns for this to compare.'
+  )
+
+  /**
+   * The directory a pattern is rooted at, so the two files can be compared
+   * whichever of gitignore's equivalent spellings each happens to use:
+   * `design/**`, `/design/`, and `design/` are one claim about `design`.
+   */
+  function rootOf(pattern: string): string {
+    return pattern
+      .replace(/\/\*+$/, '')
+      .replace(/^\//, '')
+      .replace(/\/$/, '')
+  }
+
+  function covers(pattern: string, target: string): boolean {
+    return target === pattern || target.startsWith(`${pattern}/`)
+  }
+
+  /**
+   * The files git tracks under a path. Both files are claims about the
+   * repository, so the repository's own list is what they should be checked
+   * against: a design-tool temp file or an editor swap file appearing in
+   * `design/` is not a change to anything declared, and `readdirSync` cannot
+   * tell the difference.
+   */
+  function trackedFiles(target: string): string[] {
+    return execFileSync('git', ['ls-files', '-z', '--', target], {
+      cwd: root,
+      encoding: 'utf-8',
+      timeout: 30_000
+    })
+      .split('\0')
+      .filter((path) => path.length > 0)
+  }
+
+  // A `!` line re-includes what an earlier line excluded, and the prefix
+  // comparison above reads it as one more exclusion — so the test below would
+  // report a bundle Prettier formats as covered. Measured: `design/` followed
+  // by `!design/` makes `prettier --file-info` answer `"ignored": false` while
+  // both assertions pass. Nothing here uses negation, so rather than model
+  // gitignore's re-inclusion rules this fails until someone needs them.
+  it('has no negated pattern for the comparison below to misread', () => {
+    expect(negations).toEqual([])
+  })
+
+  it('ignores every path the repository declares is not source', () => {
+    const uncovered = declared.filter(
+      (entry) =>
+        !patterns.some((pattern) => covers(rootOf(pattern), rootOf(entry)))
+    )
+
+    expect(uncovered, 'these each need a line in .prettierignore').toEqual([])
+  })
+
+  // An ignore entry for a path that holds nothing is decoration — `build/` and
+  // `dist/` in this same file name directories that do not exist. Asking git
+  // what is under each declared path says the entry is live without failing
+  // over a rename: `design/` covers whatever is in there, so the design tool
+  // emitting a new filename is not a defect.
+  it('ignores paths that are really in the repository', () => {
+    const empty = declared.filter(
+      (entry) => trackedFiles(rootOf(entry)).length === 0
+    )
+
+    expect(empty, 'these ignore entries name nothing git tracks').toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #106.

## The change

One line in `.prettierignore`, plus a test that keeps the two ignore lists honest.

`doctor.config.json` declares `design/**` is not source. `.prettierignore` did not, so `prettier --write .` walked `design/squeal-sql-editor.html` — a 252 KB bundle whose script block the design tool generates.

## This already cost something once

The issue frames the cost as future. It is not — it has been paid already:

```
$ git log --oneline -- design/squeal-sql-editor.html
459efbf style: format the repo with prettier
acc6362 Create the redesign plan

$ git show --stat 459efbf -- design/squeal-sql-editor.html
 design/squeal-sql-editor.html | 917 +++++++++++++++++++++++++-----------------
 1 file changed, 550 insertions(+), 367 deletions(-)
```

917 lines in one generated file — 81% of everything that commit changed. The bundle is only Prettier-shaped today *because Prettier reshaped it then*. The next regeneration turns the Format job red until someone commits Prettier's churn over machine-generated output.

## Measured, not reasoned

Ground truth from Prettier's own resolver:

```
# before
$ npx prettier --file-info design/squeal-sql-editor.html
{ "ignored": false, "inferredParser": "html" }

# after
$ npx prettier --file-info design/squeal-sql-editor.html
{ "ignored": true, "inferredParser": null }
```

And end to end: an identically mis-formatted probe file is accepted inside `design/` and flagged at the repository root.

## The test

`src/prettier-ignore.test.ts` holds the two declarations against each other, so the next entry added to `doctor.config.json` cannot quietly skip this file.

It compares them textually rather than calling Prettier's matcher, which would be stronger. `prettier` is not a declared dependency — `package.json` names it in the `format` script and nowhere else — and Fallow fails the build on an unlisted one whether the import is static or dynamic. Shelling out to `prettier --file-info` does dodge that, at the price of a ~1.2 s subprocess per path resolved through a binary this repository never asked for. The comment records the trade-off and points at #107, which makes the clean version available.

### Mutation-tested, including three cases a review found

Ten cases, each behaving as intended. Six defects caught:

| Mutation | Result |
|---|---|
| `design/` line removed | caught |
| `design/` misspelled `desgin/` | caught |
| config entry points at a path that is gone | caught |
| config gains a second entry | caught |
| config names live source (`src/**`) | caught |
| config names a directory git tracks nothing in | caught |

And four cases that must **not** fire — three of which a first draft got wrong:

| Case | First draft | Now |
|---|---|---|
| `design/` + `!design/` — Prettier answers `ignored: false` | **passed silently** | caught |
| pattern written `design/**` — Prettier: `ignored: true` | **false alarm** | passes |
| pattern written `/design/` — Prettier: `ignored: true` | **false alarm** | passes |
| an untracked temp file appears in `design/` | **false alarm** | passes |

The negation case was the dangerous one: the bundle was being formatted and the test said the invariant held. Fixed by refusing to guess — a `!` line fails its own assertion rather than being read as one more exclusion. The two spelling false alarms are fixed by normalizing both sides to the directory a pattern is rooted at, so `design/**`, `/design/`, and `design/` are one claim. The untracked-file alarm is fixed by asking `git ls-files` instead of walking the working tree: both files are claims about the repository, and a design-tool temp file is not a change to anything declared.

## Why the four dead entries stay

`.cache/`, `build/`, `coverage/`, and `dist/` name nothing that exists. Pruning them looks like tidying but is not:

```
$ git check-ignore -v build/x.html dist/x.html coverage/x.html .cache/x.html
.gitignore:27:coverage   coverage/x.html
.gitignore:1:.cache      .cache/x.html
```

`build/` and `dist/` are **not** in `.gitignore` — it carries `build/Release`, not `build/`, and no `dist` entry at all, while `dist` is `tsconfig.base.json`'s `outDir`. Prettier 3 does read `.gitignore` (verified: `out/` is gitignored, not in `.prettierignore`, and a mis-formatted `out/` probe is reported `ignored: true`), so pruning `coverage/` and `.cache/` would be safe — but pruning `build/` and `dist/` would be a real, if small, loss of coverage. Out of scope either way.

## Verification

All six CI gates run locally, clean:

```
eslint --ext .ts,.tsx .                        exit 0
tsc --noEmit -p tsconfig.backend.json          exit 0
tsc --noEmit -p tsconfig.renderer.json         exit 0
prettier --check --end-of-line auto .          All matched files use Prettier code style!
vitest run                                     954 passed, 1 pre-existing failure
fallow@3.2.0                                   No issues found
```

The one failure is `src/databases/sqlite-adapter.test.ts > testConnection > connects and executes SELECT 1`, a Windows `file:///` path-format mismatch that is red on `main` too — `git diff --stat origin/main HEAD -- src/databases/` is empty, so this branch does not touch it.

One thing I will not tidy away: in a first full run I observed **two** failures rather than one, and I could not reproduce it in four subsequent full runs (three consecutive clean, plus one more). I do not know what the second one was and cannot rule out that it was mine. Flagging it rather than reporting five-for-five.
