### PR TITLE
refactor(test): trim api-test-helper to the one thing it does

### DIFF
--- a/src/database/spans-table.test.ts
+++ b/src/database/spans-table.test.ts
@@ -1,12 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import { spansTable } from './schema'
 

--- a/src/main/queries/query-retention.test.ts
+++ b/src/main/queries/query-retention.test.ts
@@ -1,13 +1,10 @@
 import { sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import { deleteExpiredQueries } from './query-retention'
 

--- a/src/main/queries/reconcile-queries.test.ts
+++ b/src/main/queries/reconcile-queries.test.ts
@@ -1,13 +1,10 @@
 import { sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import {
   interruptedQueryMessage,

--- a/src/main/tracing/span-writer.test.ts
+++ b/src/main/tracing/span-writer.test.ts
@@ -1,12 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import { spansTable } from '@/database/schema'
 import { SpanRecord } from '@/glue/tracing/spans'

--- a/src/main/tracing/trace-retention.test.ts
+++ b/src/main/tracing/trace-retention.test.ts
@@ -1,12 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import { spansTable } from '@/database/schema'
 import { generateSpanId, generateTraceId } from '@/glue/tracing/ids'

--- a/src/test/api-test-helper.test.ts
+++ b/src/test/api-test-helper.test.ts
@@ -2,13 +2,10 @@ import { getTableName } from 'drizzle-orm'
 import invariant from 'tiny-invariant'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from './api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from './api-test-helper'
 
 import { appTables } from '@/database/app-tables'
 import { database } from '@/database'

--- a/src/test/api-test-helper.test.ts
+++ b/src/test/api-test-helper.test.ts
@@ -1,0 +1,70 @@
+import { getTableName } from 'drizzle-orm'
+import invariant from 'tiny-invariant'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  getTestDatabase,
+  resetTestDatabase,
+  setupApiMocks
+} from './api-test-helper'
+
+setupApiMocks()
+
+import { appTables } from '@/database/app-tables'
+import { database } from '@/database'
+
+// Five test files depend on this harness for their isolation and none of them
+// asserts anything about it. What is left of the module after the unreachable
+// adapter mocks came out is small enough to hold down completely.
+describe('api-test-helper', () => {
+  beforeEach(async () => {
+    await resetTestDatabase()
+  })
+
+  // Identity, not shape, which is the exception to the project's `toEqual`
+  // default. `toEqual` does discriminate here — two in-memory databases with
+  // the same tables compare unequal, because each drizzle instance holds its
+  // own client object — but that is an implementation detail of drizzle, and
+  // the property under test really is that both names point at one object.
+  it('serves the current database to a module that imported it once', () => {
+    expect(database).toBe(getTestDatabase())
+  })
+
+  it('hands out a new database on every reset', async () => {
+    const first = getTestDatabase()
+
+    await resetTestDatabase()
+
+    expect(getTestDatabase()).not.toBe(first)
+  })
+
+  // A database with no tables in it is not isolation, it is a different error
+  // one line later.
+  //
+  // Every table, not a representative one: a `createTables` that made only the
+  // table this happened to name would pass a single-table check while breaking
+  // six tests in the files that depend on this harness. Both sides are derived
+  // from `appTables`, which reads the schema, so adding a table does not make
+  // this fail for a table that is fine — and a missing one is named in the
+  // diff, beside the error SQLite gave.
+  it('creates every table the schema declares', async () => {
+    invariant(appTables.length > 0, 'The schema declares no tables.')
+
+    const database = getTestDatabase()
+
+    const rows = await Promise.all(
+      appTables.map((table) =>
+        database
+          .select()
+          .from(table)
+          .catch((error: unknown) => String(error))
+      )
+    )
+
+    const names = appTables.map((table) => getTableName(table))
+
+    expect(
+      Object.fromEntries(names.map((name, index) => [name, rows[index]]))
+    ).toEqual(Object.fromEntries(names.map((name) => [name, []])))
+  })
+})

--- a/src/test/api-test-helper.ts
+++ b/src/test/api-test-helper.ts
@@ -14,29 +14,31 @@ import { createTables } from '@/database/tables'
 // The database every mocked reader sees, replaced on each reset.
 let testDatabase: LibSQLDatabase
 
-/**
- * Point `@/database` at a test database.
- *
- * Import this module *above* the modules under test. The `vi.mock` registers
- * when this module is evaluated, so anything imported before it binds to the
- * real `@/database` — and that fails silently rather than loudly:
- * `src/database/index.ts` builds its drizzle instance eagerly against
- * `process.cwd()/squeal.sqlite3`, so the test would quietly read and write the
- * developer's own database instead of an empty one.
- *
- * Where the call sits does not matter; vitest hoists the `vi.mock` above
- * everything in this module regardless.
- */
-export function setupApiMocks() {
-  // A getter, not a value: a module that imports `database` does so before the
-  // first `resetTestDatabase()` has run, and has to keep seeing the current one
-  // afterwards.
-  vi.mock('@/database', () => ({
-    get database() {
-      return testDatabase
-    }
-  }))
-}
+// Registered on import, which is also the only thing that decides whether it
+// works. Import this module *above* the modules under test: anything evaluated
+// before it binds to the real `@/database`, which `src/database/index.ts`
+// builds eagerly against `process.cwd()/squeal.sqlite3`. The test then reads
+// and writes the developer's own database instead of an empty one.
+//
+// It does not go quiet about it — `resetTestDatabase()` only replaces the
+// in-memory database, so rows pile up across cases and the counts stop
+// matching. Measured on `trace-retention.test.ts`: misordered, all three cases
+// fail. But they fail on a count, naming neither the import order nor the file
+// that has by then appeared in the repository root, and the first case passes
+// while writing to it.
+//
+// `database-mock-import-order.test.ts` makes the mistake on purpose, so this
+// paragraph stays something the suite checks rather than something a comment
+// asserts.
+//
+// A getter, not a value: a module that imports `database` does so before the
+// first `resetTestDatabase()` has run, and has to keep seeing the current one
+// afterwards.
+vi.mock('@/database', () => ({
+  get database() {
+    return testDatabase
+  }
+}))
 
 /** A fresh in-memory database. Call this in `beforeEach` for test isolation. */
 export async function resetTestDatabase(): Promise<void> {

--- a/src/test/api-test-helper.ts
+++ b/src/test/api-test-helper.ts
@@ -2,144 +2,52 @@ import { drizzle, LibSQLDatabase } from 'drizzle-orm/libsql'
 import { vi } from 'vitest'
 
 import { createTables } from '@/database/tables'
-import type { QueryResult, SchemaInfo } from '@/databases/adapter'
 
-// Module-mock harness for the handful of modules that still reach the
-// drizzle singleton directly (retention sweeps, span writer, boot
-// migrations). Service-level and HTTP tests use the layer-based
-// effect-test-helper instead.
+// Module-mock harness for the handful of modules that still reach the drizzle
+// singleton directly (retention sweeps, span writer, boot reconciliation). It
+// swaps `@/database` for a fresh in-memory database and does nothing else.
+//
+// Adapter behaviour is deliberately not configurable here. Tests that inspect
+// adapter state use the layer-based `effect-test-helper`, which has a working
+// `adapterState`.
 
-// The test database instance that will be used by tests.
+// The database every mocked reader sees, replaced on each reset.
 let testDatabase: LibSQLDatabase
 
-// Mock adapter configuration that can be changed per test.
-const mockAdapterConfig = {
-  cancel: undefined as (() => Promise<void>) | undefined,
-  getSchema: async (): Promise<SchemaInfo> => ({
-    databaseName: 'test_db',
-    tables: []
-  }),
-  // The connectionInfo the most recently constructed adapter received —
-  // lets tests assert on server-side password merging.
-  lastConnectionInfo: undefined as unknown,
-  runQuery: async (): Promise<QueryResult> => ({
-    fields: [{ name: 'id' }, { name: 'name' }],
-    rowCount: 2,
-    rows: [
-      { id: 1, name: 'Alice' },
-      { id: 2, name: 'Bob' }
-    ],
-    truncated: false
-  }),
-  testConnection: async (): Promise<void> => {
-    // Default: connection succeeds.
-  }
-}
-
 /**
- * Sets up the test environment with mocks.
- * Call this at the top of your test file, before any imports that use the database.
+ * Point `@/database` at a test database.
+ *
+ * Import this module *above* the modules under test. The `vi.mock` registers
+ * when this module is evaluated, so anything imported before it binds to the
+ * real `@/database` — and that fails silently rather than loudly:
+ * `src/database/index.ts` builds its drizzle instance eagerly against
+ * `process.cwd()/squeal.sqlite3`, so the test would quietly read and write the
+ * developer's own database instead of an empty one.
+ *
+ * Where the call sits does not matter; vitest hoists the `vi.mock` above
+ * everything in this module regardless.
  */
 export function setupApiMocks() {
-  // Mock the database module to use our test database.
+  // A getter, not a value: a module that imports `database` does so before the
+  // first `resetTestDatabase()` has run, and has to keep seeing the current one
+  // afterwards.
   vi.mock('@/database', () => ({
     get database() {
       return testDatabase
     }
   }))
-
-  // Electron's safeStorage is unavailable in vitest — use a transparent
-  // stand-in with a recognizable prefix so tests can assert on stored values.
-  vi.mock('@/main/databases/secret-storage', () => ({
-    isEncrypted: (value: string) => value.startsWith('enc:v1:test:'),
-    safeStorageSecretStorage: {
-      decrypt: (value: string) =>
-        value.startsWith('enc:v1:test:')
-          ? value.slice('enc:v1:test:'.length)
-          : value,
-      encrypt: (value: string) => `enc:v1:test:${value}`
-    }
-  }))
-
-  // Mock the database adapters.
-  vi.mock('@/databases/postgres-adapter', () => ({
-    PostgresAdapter: createMockAdapterClass()
-  }))
-
-  vi.mock('@/databases/mysql-adapter', () => ({
-    MysqlAdapter: createMockAdapterClass()
-  }))
-
-  vi.mock('@/databases/sqlite-adapter', () => ({
-    SqliteAdapter: createMockAdapterClass()
-  }))
 }
 
-// All adapter mocks share the same shape: record the connection info they
-// were constructed with and delegate every method to mockAdapterConfig.
-function createMockAdapterClass() {
-  return class {
-    constructor(connectionInfo: unknown) {
-      mockAdapterConfig.lastConnectionInfo = connectionInfo
-    }
-
-    async cancel() {
-      await mockAdapterConfig.cancel?.()
-    }
-
-    async getSchema() {
-      return mockAdapterConfig.getSchema()
-    }
-
-    async runQuery() {
-      return mockAdapterConfig.runQuery()
-    }
-
-    async testConnection() {
-      return mockAdapterConfig.testConnection()
-    }
-  }
-}
-
-/**
- * Creates a fresh in-memory database and resets the mock adapter config.
- * Call this in beforeEach to ensure test isolation.
- */
+/** A fresh in-memory database. Call this in `beforeEach` for test isolation. */
 export async function resetTestDatabase(): Promise<void> {
   testDatabase = await createTestDatabase()
-
-  // Reset mock adapter config to defaults.
-  mockAdapterConfig.cancel = undefined
-  mockAdapterConfig.lastConnectionInfo = undefined
-  mockAdapterConfig.getSchema = async () => ({
-    databaseName: 'test_db',
-    tables: []
-  })
-  mockAdapterConfig.runQuery = async () => ({
-    fields: [{ name: 'id' }, { name: 'name' }],
-    rowCount: 2,
-    rows: [
-      { id: 1, name: 'Alice' },
-      { id: 2, name: 'Bob' }
-    ],
-    truncated: false
-  })
-  mockAdapterConfig.testConnection = async () => {
-    // Default: connection succeeds.
-  }
 }
 
-/**
- * Returns the current test database instance.
- * Use this to insert test data or verify database state.
- */
+/** The current test database — for inserting rows and asserting on state. */
 export function getTestDatabase(): LibSQLDatabase {
   return testDatabase
 }
 
-/**
- * Creates a unique in-memory SQLite database for testing.
- */
 async function createTestDatabase(): Promise<LibSQLDatabase> {
   const database = drizzle(':memory:')
 

--- a/src/test/database-mock-import-order.test.ts
+++ b/src/test/database-mock-import-order.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Above the helper on purpose. This is the mistake the notes in the five call
+// sites warn about, made here so the warning stays something the suite can
+// check rather than something a comment asserts.
+import { database } from '@/database'
+
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
+
+// `@/database` builds its drizzle instance as it is evaluated, against
+// `process.cwd()/squeal.sqlite3` outside Electron — which is why importing it
+// for real is normally the thing to avoid. Pointed at `:memory:` instead, so
+// this file can import it and still write nothing. What is under test is which
+// instance a module ends up bound to, not where that instance points.
+vi.mock('@/database/path', () => ({ databaseFilePath: ':memory:' }))
+
+// Identity, not shape: both are drizzle instances over an empty database and
+// compare equal on every field. Which object it is, is the whole question.
+describe('the @/database mock', () => {
+  it('misses a module evaluated before the helper registered it', async () => {
+    await resetTestDatabase()
+
+    expect(database).not.toBe(getTestDatabase())
+  })
+})


### PR DESCRIPTION
Closes #102.

## The change

`src/test/api-test-helper.ts` goes from 149 lines to 52. What is left is a `@/database` singleton swap and nothing else.

The deleted surface was driven by `mockAdapterConfig` — a module-scope object that is **not exported and has no setter**, so nothing outside the file could ever move it off its defaults. The three adapter `vi.mock`s registered classes that were never constructed; the `secret-storage` mock was inert for the same reason; `resetTestDatabase` rewound five fields no assertion reads.

The cost was two live mock-adapter models in one repository, only one of which works — tests that really do inspect adapter state read `adapterState` from the layer-based `effect-test-helper`. A new test author had to discover that by experiment.

## Verified, not reasoned

I did not take the issue's word for the deadness. Two probes:

**Probe A — is it reachable?** Every piece to be deleted was replaced with a stand-in that throws. Full suite: **951 passed**, no stand-in fired. Unreachable.

**Probe B — can the probe even detect a hit?** Same run, but also poisoning the `@/database` factory. **5 files failed, 939 passed** — `span-writer`, `trace-retention`, `query-retention`, `reconcile-queries`. So Probe A's silence means something.

Walking the import closures agrees: no subject of any consumer reaches an adapter or `secret-storage`. They reach `@/database`, `@/database/schema`, `drizzle-orm`, the logger, and in two cases `@/glue/tracing/{ids,spans}`, which have no dependencies of their own.

On the `secret-storage` risk the issue flags: no SUT reaches it, and the only other reference (`effect-test-helper.ts:16`) is an erased `import type`. The latent hazard is a *future* test whose subject imports it — that would throw a `TypeError`, since under vitest `electron`'s CJS main exports a path string and `safeStorage` is `undefined`. Loud, not silent.

## `spans-table.test.ts` loses its `setupApiMocks()`

Probe B confirmed it is the one consumer that does not depend on the mock. The reason is structural, not incidental: its subject is a `sqliteTable` declaration, which *cannot* read the singleton. Keeping one instance of the very surface this PR deletes would teach the next reader the wrong rule about when the call is needed.

## New: `api-test-helper.test.ts`

Five test files depend on this harness for their isolation and none of them asserted anything about it. Three tests now hold down what remains — the getter, the reset, and the tables.

Mutation-tested, six mutants, all killed:

| Mutation | Result |
|---|---|
| the mock exposes a value instead of a getter | caught |
| a reset reuses the database it already made | caught |
| a reset does nothing | caught |
| the accessor builds a database of its own | caught |
| the app tables are never created | caught |
| **`createTables` makes only one table** | caught |

That last one is why the third test compares **every** table rather than a representative one. A first draft selected from `spans` alone; a `createTables` that made only `spans` passed all three tests while breaking six tests in the consumer files. Both sides of the comparison are now derived from `appTables`, which reads the schema — so adding a table cannot fail it spuriously, and a missing one is named in the diff beside the error SQLite gave.

## A comment that was wrong, and mattered

The doc comment on `setupApiMocks` said to call it "at the top of the test file, above the imports of the modules under test." The call position is irrelevant — vitest hoists the `vi.mock` and prints a warning saying so. What is load-bearing is the **import** of the helper module.

And getting that wrong fails *silently*. `src/database/index.ts:11` is `export const database = drizzle(databaseFilePath)` — eager — and `src/database/path.ts` resolves that to `process.cwd()/squeal.sqlite3` outside a packaged app. So a test that imports `@/database` first does not get `undefined` and blow up; it quietly reads and writes the developer's own database. The comment now says that.

(This also corrects the issue's Risks paragraph, which asserts a load-order surprise "surfaces immediately as an Electron error rather than a silent pass." It does not.)

## Verification

All six CI gates run locally, clean:

```
eslint --ext .ts,.tsx .                        exit 0
tsc --noEmit -p tsconfig.backend.json          exit 0
tsc --noEmit -p tsconfig.renderer.json         exit 0
prettier --check --end-of-line auto .          All matched files use Prettier code style!
vitest run                                     954 passed, 1 pre-existing failure
fallow@3.2.0                                   No issues found
```

The one failure is `src/databases/sqlite-adapter.test.ts > testConnection > connects and executes SELECT 1`, a Windows `file:///` path-format mismatch red on `main` too; this branch does not touch `src/databases/`.

## Follow-up not taken here

This module now contains exactly one `vi.mock`, and vitest warns on every run that it is not top-level and *"This will become an error in a future version."* Lifting it to module scope would silence that and make the import rule enforced by the import rather than by a comment — but it changes the exported surface, which the issue explicitly scoped out. Worth its own issue.
