### PR TITLE
refactor(tracing): delete the unused traceparent parser

### DIFF
--- a/src/glue/tracing/traceparent.test.ts
+++ b/src/glue/tracing/traceparent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatTraceparent, parseTraceparent } from './traceparent'
+import { formatTraceparent, isValidSpanId, isValidTraceId } from './traceparent'
 
 const spanId = '00f067aa0ba902b7'
 const traceId = '4bf92f3577b34da6a3ce929d0e0e4736'
@@ -13,33 +13,76 @@ describe('formatTraceparent', () => {
   })
 })
 
-describe('parseTraceparent', () => {
-  it('parses a valid header', () => {
-    expect(parseTraceparent(`00-${traceId}-${spanId}-01`)).toEqual({
-      spanId,
-      traceId
-    })
-  })
-
-  it('accepts any flag byte', () => {
-    expect(parseTraceparent(`00-${traceId}-${spanId}-00`)).toEqual({
-      spanId,
-      traceId
-    })
-  })
-
+// These two decide whether an id is usable, and every id reaching the app from
+// outside goes through them: a `traceparent`, a `b3` header, the renderer's
+// span ingest, and the `/traces` route parameters — the last three through
+// `Schema.filter` in `src/glue/api/schemas.ts`. An id that fails here cannot be
+// looked up again, so storing one produces a trace the dashboard lists and
+// `GET /traces/:id` then refuses to open.
+//
+// The cases below are the ones no caller covers. `@effect/platform` matches the
+// same hex shape case-insensitively, so an uppercase id reaches these and
+// nothing else rejects it; `b3` does not validate at all, so everything reaches
+// these. Both spellings of a wrong-but-plausible pattern — an `i` flag, or
+// `a-z` in the character class — otherwise survive the entire suite.
+describe('isValidTraceId', () => {
   it.each([
-    ['undefined', undefined],
-    ['an empty string', ''],
-    ['a wrong version', `ff-${traceId}-${spanId}-01`],
-    ['a short trace id', `00-${traceId.slice(1)}-${spanId}-01`],
-    ['a short span id', `00-${traceId}-${spanId.slice(1)}-01`],
-    ['uppercase hex', `00-${traceId.toUpperCase()}-${spanId}-01`],
-    ['an all-zero trace id', `00-${'0'.repeat(32)}-${spanId}-01`],
-    ['an all-zero span id', `00-${traceId}-${'0'.repeat(16)}-01`],
-    ['missing flags', `00-${traceId}-${spanId}`],
-    ['extra segments', `00-${traceId}-${spanId}-01-99`]
-  ])('returns undefined for %s', (_label, header) => {
-    expect(parseTraceparent(header)).toEqual(undefined)
+    {
+      accepted: true,
+      description: 'a lowercase 32-character id',
+      value: traceId
+    },
+    {
+      accepted: false,
+      description: 'the same id in uppercase',
+      value: traceId.toUpperCase()
+    },
+    { accepted: false, description: 'all zeros', value: '0'.repeat(32) },
+    {
+      accepted: true,
+      description: 'leading zeros that are not all of them',
+      value: `${'0'.repeat(31)}1`
+    },
+    {
+      accepted: false,
+      description: 'non-hex characters',
+      value: 'z'.repeat(32)
+    },
+    { accepted: false, description: 'too few characters', value: '0123456789' },
+    { accepted: false, description: 'a span id', value: spanId },
+    { accepted: false, description: 'nothing at all', value: '' }
+  ])('is $accepted for $description', ({ accepted, value }) => {
+    expect(isValidTraceId(value)).toEqual(accepted)
+  })
+})
+
+describe('isValidSpanId', () => {
+  it.each([
+    {
+      accepted: true,
+      description: 'a lowercase 16-character id',
+      value: spanId
+    },
+    {
+      accepted: false,
+      description: 'the same id in uppercase',
+      value: spanId.toUpperCase()
+    },
+    { accepted: false, description: 'all zeros', value: '0'.repeat(16) },
+    {
+      accepted: true,
+      description: 'leading zeros that are not all of them',
+      value: `${'0'.repeat(15)}1`
+    },
+    {
+      accepted: false,
+      description: 'non-hex characters',
+      value: 'z'.repeat(16)
+    },
+    { accepted: false, description: 'too few characters', value: '0123' },
+    { accepted: false, description: 'a trace id', value: traceId },
+    { accepted: false, description: 'nothing at all', value: '' }
+  ])('is $accepted for $description', ({ accepted, value }) => {
+    expect(isValidSpanId(value)).toEqual(accepted)
   })
 })

--- a/src/glue/tracing/traceparent.ts
+++ b/src/glue/tracing/traceparent.ts
@@ -5,7 +5,6 @@ import { SpanContext } from './spans'
 
 const spanIdPattern = /^[0-9a-f]{16}$/
 const traceIdPattern = /^[0-9a-f]{32}$/
-const traceparentPattern = /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/
 
 export function formatTraceparent(context: SpanContext): string {
   return `00-${context.traceId}-${context.spanId}-01`
@@ -15,34 +14,20 @@ export function formatTraceparent(context: SpanContext): string {
 // from anywhere — a traceparent, a b3 header, or the renderer's span ingest —
 // and an id that fails this check cannot be looked up again, so it must never
 // be stored.
+//
+// Reading the header is not this module's job. `@effect/platform` does it in
+// its own HTTP middleware and hands the result to the request span as its
+// parent; these two are what `SquealSpan` then applies to that parent, because
+// the platform accepts ids the spec forbids — all-zero ones, and uppercase hex,
+// since its patterns carry the `i` flag — and does not check a `b3` header at
+// all. See `src/server/http/traceparent-propagation.test.ts` for the path from
+// header to parent.
 export function isValidSpanId(value: string): boolean {
   return spanIdPattern.test(value) && !isAllZeros(value)
 }
 
 export function isValidTraceId(value: string): boolean {
   return traceIdPattern.test(value) && !isAllZeros(value)
-}
-
-export function parseTraceparent(
-  header: string | undefined
-): SpanContext | undefined {
-  if (!header) {
-    return undefined
-  }
-
-  const match = traceparentPattern.exec(header)
-  const traceId = match?.[1]
-  const spanId = match?.[2]
-
-  if (!traceId || !spanId) {
-    return undefined
-  }
-
-  if (!isValidTraceId(traceId) || !isValidSpanId(spanId)) {
-    return undefined
-  }
-
-  return { spanId, traceId }
 }
 
 function isAllZeros(value: string): boolean {

--- a/src/server/http/traceparent-propagation.test.ts
+++ b/src/server/http/traceparent-propagation.test.ts
@@ -1,0 +1,239 @@
+import { HttpClient, HttpClientRequest } from '@effect/platform'
+import { Effect, Layer } from 'effect'
+import invariant from 'tiny-invariant'
+import { describe, expect, it } from 'vitest'
+
+import { SpanRecord } from '@/glue/tracing/spans'
+import { makeSquealTracer } from '@/server/tracing/effect-tracer'
+import { makeTestApi, testApiToken } from '@/test/effect-test-helper'
+
+const inboundTraceId = '4bf92f3577b34da6a3ce929d0e0e4736'
+const inboundSpanId = '00f067aa0ba902b7'
+
+interface Handled {
+  spans: SpanRecord[]
+  status: number
+}
+
+/** One request, and every span the server finished while handling it. */
+async function handleRequest(
+  headers: Record<string, string>
+): Promise<Handled> {
+  const spans: SpanRecord[] = []
+
+  // The production tracer, not a stand-in. What happens to an inbound parent
+  // is decided in `SquealSpan`'s constructor, so a collector that skipped it
+  // would not be measuring the thing under test.
+  const tracer = makeSquealTracer({
+    persist: (records) => {
+      spans.push(...records)
+
+      return Promise.resolve(records.length)
+    }
+  })
+
+  const { layer } = makeTestApi()
+
+  const status = await Effect.runPromise(
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient.pipe(
+        // Without this the client opens a span of its own around the request.
+        // That span would land in the collection below — where it is neither
+        // the server's work nor part of the server's trace — and the server
+        // would inherit it as its parent, so the test would be measuring
+        // itself. `src/app/api-client.ts` switches the same thing off in
+        // production for the same reason.
+        Effect.map(HttpClient.withTracerDisabledWhen(() => true))
+      )
+
+      const response = yield* client.execute(
+        HttpClientRequest.get('/databases').pipe(
+          HttpClientRequest.setHeaders({
+            authorization: `Bearer ${testApiToken}`,
+            ...headers
+          })
+        )
+      )
+
+      return response.status
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(layer),
+      Effect.provide(Layer.setTracer(tracer))
+    )
+  )
+
+  return { spans, status }
+}
+
+function describeSpans(handled: Handled): string {
+  return handled.spans.map((span) => span.name).join(', ')
+}
+
+function serverSpanOf(handled: Handled): SpanRecord {
+  const span = handled.spans.find((candidate) => candidate.kind === 'server')
+
+  invariant(
+    span,
+    `The server wrote no request span, so there is nothing to assert about its parent. It wrote: ${describeSpans(handled)}`
+  )
+
+  return span
+}
+
+// Who reads an inbound `traceparent` is a question this repository answered
+// twice. `@effect/platform` reads it in its own HTTP middleware —
+// `HttpTraceContext.fromHeaders`, which also falls through to the `b3` and
+// `x-b3-*` headers — and hands the result to the request span as its parent.
+// `src/glue/tracing/traceparent.ts` had a second parser that nothing called.
+//
+// Nothing here asserts that the duplicate is gone; a deleted function needs no
+// test. What was missing is coverage of the behaviour the deletion leans on, so
+// that removing the spare parser is a provable non-event rather than a `tsc`
+// pass. Every assertion below fails identically before and after the deletion —
+// which is the point.
+//
+// The division these pin down is that the platform decides which header to
+// believe, and `isValidTraceId` / `isValidSpanId` — reached from `SquealSpan`'s
+// constructor — decide whether the ids in it are usable at all. Both halves are
+// load-bearing and the second is this repository's own code, so both are
+// covered. Measured against `@effect/platform` 0.97.0.
+describe('inbound traceparent', () => {
+  it('continues the trace the caller names', async () => {
+    const handled = await handleRequest({
+      traceparent: `00-${inboundTraceId}-${inboundSpanId}-01`
+    })
+
+    const { parentSpanId, traceId } = serverSpanOf(handled)
+
+    expect({ parentSpanId, status: handled.status, traceId }).toEqual({
+      parentSpanId: inboundSpanId,
+      status: 200,
+      traceId: inboundTraceId
+    })
+  })
+
+  // The request span is one span of several. A caller that stitched only that
+  // one into the caller's trace, and left the work underneath it in a trace of
+  // its own, would satisfy the assertion above and still produce a waterfall
+  // with nothing in it.
+  //
+  // By parentage rather than by counting spans, because how many spans a
+  // request produces is a property of how the services happen to be
+  // instrumented — CLAUDE.md prescribes an unnamed `Effect.fn` for methods on
+  // untraced paths, so that count is something someone may legitimately change.
+  it('puts the work it does under that same trace', async () => {
+    const handled = await handleRequest({
+      traceparent: `00-${inboundTraceId}-${inboundSpanId}-01`
+    })
+
+    const requestSpan = serverSpanOf(handled)
+    const child = handled.spans.find(
+      (candidate) => candidate.parentSpanId === requestSpan.id
+    )
+
+    invariant(
+      child,
+      `Nothing ran under the request span, so there is no way to tell whether the work it did joined the caller's trace. The server wrote: ${describeSpans(handled)}`
+    )
+
+    expect(child.traceId).toEqual(inboundTraceId)
+  })
+
+  // A header nobody can read is not a reason to fail a request, and it is not a
+  // reason to write a span into a trace id the dashboard cannot open either.
+  // This one is rejected by the platform's arity check — a traceparent has four
+  // dash-separated fields and this has three — rather than by its hex patterns.
+  it('starts a fresh trace when the header is not a traceparent', async () => {
+    const handled = await handleRequest({ traceparent: 'not-a-traceparent' })
+
+    const { parentSpanId, traceId } = serverSpanOf(handled)
+
+    expect({ parentSpanId, status: handled.status }).toEqual({
+      parentSpanId: null,
+      status: 200
+    })
+    expect(traceId).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  // The cases the platform accepts and the validators then reject, which is why
+  // the validators are the half of this that had to survive the deletion.
+  //
+  // All-zero ids are 32 and 16 hex characters, so the platform's patterns pass
+  // them and produce an external span the W3C spec calls invalid. Uppercase hex
+  // is the same story for a different reason: those patterns carry the `i` flag,
+  // so they are more permissive than the spec — and more permissive than the
+  // parser this commit deletes, which was case-sensitive and had a test saying
+  // so. That case is preserved here rather than lost with it.
+  //
+  // Without the validators either one becomes a trace the dashboard lists and
+  // `GET /traces/:id` then refuses to open. `effect-tracer.test.ts` already
+  // covers an all-zero parent, but it builds the parent with
+  // `Tracer.externalSpan` by hand, and so cannot say whether a header produces
+  // one. Anyone deleting "the dead traceparent module" wholesale takes both
+  // validators with it and that unit test keeps passing — it never reaches this
+  // code path.
+  //
+  // Both halves of the all-zero case separately, because `Option.filter` needs
+  // both to hold: zeroing only the span id leaves the trace id valid, and
+  // nothing else in the suite fails when `isValidSpanId` stops rejecting zeros.
+  it.each([
+    { part: 'trace', traceparent: `00-${'0'.repeat(32)}-${inboundSpanId}-01` },
+    { part: 'span', traceparent: `00-${inboundTraceId}-${'0'.repeat(16)}-01` },
+    {
+      part: 'uppercase trace',
+      traceparent: `00-${inboundTraceId.toUpperCase()}-${inboundSpanId}-01`
+    }
+  ])(
+    'starts a fresh trace when the $part id is unusable',
+    async ({ traceparent }) => {
+      const handled = await handleRequest({ traceparent })
+
+      const { parentSpanId, traceId } = serverSpanOf(handled)
+
+      expect({ parentSpanId, status: handled.status }).toEqual({
+        parentSpanId: null,
+        status: 200
+      })
+      expect(traceId).toMatch(/^[0-9a-f]{32}$/)
+      expect([
+        inboundTraceId,
+        inboundTraceId.toUpperCase(),
+        '0'.repeat(32)
+      ]).not.toContain(traceId)
+    }
+  )
+})
+
+// `fromHeaders` falls through to `b3` when there is no `traceparent`, and `b3`
+// validates nothing at all — it splits on dashes and passes both fields
+// straight through. That is why `isValidTraceId` and `isValidSpanId` are a
+// separate check rather than something folded into a parser: on this path there
+// is no parser to fold them into.
+describe('inbound b3', () => {
+  it('continues the trace the caller names', async () => {
+    const handled = await handleRequest({
+      b3: `${inboundTraceId}-${inboundSpanId}-1`
+    })
+
+    const { parentSpanId, traceId } = serverSpanOf(handled)
+
+    expect({ parentSpanId, status: handled.status, traceId }).toEqual({
+      parentSpanId: inboundSpanId,
+      status: 200,
+      traceId: inboundTraceId
+    })
+  })
+
+  it('starts a fresh trace when b3 carries ids nothing could look up', async () => {
+    const handled = await handleRequest({ b3: 'nonsense-ids' })
+
+    const { parentSpanId, traceId } = serverSpanOf(handled)
+
+    expect({ parentSpanId, status: handled.status }).toEqual({
+      parentSpanId: null,
+      status: 200
+    })
+    expect(traceId).toMatch(/^[0-9a-f]{32}$/)
+  })
+})


### PR DESCRIPTION
Closes #76.

`parseTraceparent` in `src/glue/tracing/traceparent.ts` had no call site. `@effect/platform` reads the inbound header in its own HTTP middleware (`HttpTraceContext.fromHeaders`) and hands the result to the request span as its parent, so inbound propagation stopped being this repository's job when that middleware went in. The second parser was left behind by the change that made it redundant.

## What is not equivalent

The platform is close to the deleted parser, but not the same, and the difference is why two functions in that module stay:

| | deleted parser | `@effect/platform` 0.97.0 |
|---|---|---|
| hex shape | `/^[0-9a-f]{32}$/`, `/^[0-9a-f]{16}$/` | same, **with the `i` flag** |
| version `00` | required | required |
| all-zero ids | rejected as a shape match, then unusable | **accepted** |
| `b3` / `x-b3-*` | not handled | handled, **with no validation at all** |

`isValidTraceId` and `isValidSpanId`, applied in `SquealSpan`'s constructor, are what stands between those last three rows and a trace the dashboard lists but `GET /traces/:id` refuses to open.

## How the deletion was checked

- **Deadness probe** — `parseTraceparent` replaced with a `throw`, whole suite run with its own test file excluded: unchanged, the single pre-existing `sqlite-adapter` failure and nothing else.
- **Control probe** — the same probe applied to `isValidTraceId`, which is live: the suite goes from that one failure to 34. That is what makes the first result mean something.
- **Mutation, eight cases** — seven defects killed (both patterns loosened to `/i` and to `a-z`, either zero check dropped, length unchecked, an unusable parent trusted, every parent ignored) and one equivalent respelling of the zero check correctly left alone.

## What the tests add

A deleted function needs no test, so nothing here asserts the duplicate is gone. What was missing is coverage of the behaviour the deletion leans on — no server test touched an inbound `traceparent` at all.

`src/server/http/traceparent-propagation.test.ts` drives real requests through the platform's tracer middleware and the production `makeSquealTracer`: the request span continues the caller's trace, the work under it lands in that same trace, an unreadable header starts a fresh one rather than failing the request, and an id the platform accepts but nothing can look up — all zeros, or uppercase — is treated as no parent. `b3` is covered both ways. **Every assertion passes identically before and after the deletion**, which is the point of them.

`traceparent.test.ts` gains direct cases for the two survivors, which had no unit test of their own. They are reached from three other places through `Schema.filter` in `schemas.ts`, and both spellings of a wrong-but-plausible pattern previously survived the entire suite untouched. The 12 deleted cases did not cover this: `traceparentPattern` was itself case-sensitive, so its uppercase case never reached a validator.

## Review notes

- This branch was reviewed by a fresh-context agent, which found the earlier version claimed `withTracerPropagation(false)` was required (it is unreachable once the client tracer is disabled — the platform returns before that branch), claimed shape-check equivalence (the `i` flag), and reported a control-probe count that did not reproduce. All three are corrected here, and the uppercase, `b3`, and validator-unit-test coverage above came out of that review.
- **Expect a textual conflict with #147** on `traceparent.ts`. Its hunk is `@@ -1,7 +1,9 @@`; this deletion starts at line 8. There is no semantic conflict — #147 keeps both validators and only moves `isValidSpanId`'s consumer into `spans.ts`.
- Not addressed here, worth its own issue: `makeTestApi` composes `ServeLive` + `CorsLive` + `ApiLive`, but production `HttpLive` also wraps `HttpMiddleware.withTracerDisabledWhen(shouldSkipTracing)`. Patching `shouldSkipTracing` to return `true` unconditionally leaves the whole suite green, so nothing covers that the skip list is actually attached.

Gates: `tsc` backend and renderer clean, `eslint` clean, `prettier` clean, `fallow` 92.5 (its three `dead-code` items — `DatabaseDto`, `WorksheetDto`, `SslMode` — are pre-existing and unrelated), suite `963 passed | 1 failed`, the failure being the pre-existing `sqlite-adapter` one.
