### PR TITLE
fix(databases): say when a connection's stored secret cannot be read

### DIFF
--- a/.agents/friction-log/20260819113459-three-timing-sensitive/friction.md
+++ b/.agents/friction-log/20260819113459-three-timing-sensitive/friction.md
@@ -1,0 +1,53 @@
+---
+title:
+  'Three timing-sensitive tests flake in the full suite but pass in isolation'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+`yarn test` on an unchanged tree passes every time, so a failure means the diff
+in front of you broke something.
+
+## Current Behavior
+
+The full run fails intermittently in tests that assert on wall-clock behaviour.
+Three have been seen, each in a different file, each passing 3/3 when its own
+file is run alone:
+
+- `src/server/tracing/effect-tracer.test.ts` > "writes spans that end within the
+  linger window as one batch" — `expected [ 2, 2 ] to deeply equal [ 4 ]`. The
+  batch splits when the worker stalls mid-window.
+- `src/app/components/traces/TraceDashboard.test.tsx` > "shows an error state
+  and recovers on retry".
+- `src/app/components/DatabaseForm.test.tsx` > "drops a verdict that arrives
+  after the connection changed".
+
+They are load-sensitive rather than order-sensitive, so re-running with a
+different `--sequence.seed` does not reproduce them and a plain retry always
+passes.
+
+## Possible Solution
+
+Assert on the observable outcome rather than on how work was divided across a
+real time window — for the tracer test, drive the linger window with fake timers
+so a stalled worker cannot split the batch. Failing that, `retry: 2` on the
+three tests would at least stop them reading as regressions.
+
+## Minimal Reproducible Example
+
+    for i in 1 2 3 4 5 6 7; do yarn test --run | grep -E '^ +Tests '; done
+
+Two of seven runs failed on one machine, in two different files, while six
+baseline runs on the same tree passed.
+
+## Context
+
+A failure in one of these looks exactly like a regression from whatever you just
+changed, and none of the three is anywhere near the code under change. Ruling it
+out means stashing the work, running the whole suite several times on the
+baseline, unstashing, and running it several times again — about ten minutes
+before you can trust your own diff.
+
+Suite duration on the same machine varies from 19s to 40s run to run with no
+change in the tree, which is what makes these fail.

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -178,6 +178,27 @@ describe('running a query', () => {
     })
   })
 
+  // The run used to be accepted and the reason only surfaced once the background
+  // fiber tried to open a connection it has no password for.
+  it('refuses to run against a connection whose details cannot be read', async () => {
+    renderWithProviders(<RunProbe />, {
+      databases: [{ ...testDatabase, connectionInfo: null }],
+      openWorksheetId: 'ws-1',
+      queries: [],
+      worksheets: [testWorksheet]
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'run' }))
+
+    expect(
+      await screen.findByText(
+        'Squeal can\'t read the saved details for "Pagila". Open the connection and re-enter them.'
+      )
+    ).toBeInTheDocument()
+
+    expect(apiClient.createQuery).not.toHaveBeenCalled()
+  })
+
   it('saves the pending edit when a query runs', async () => {
     // Fake timers hold the autosave debounce open, so a save showing up here can
     // only have come from the run itself. `waitFor` would defeat that by

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState
 } from 'react'
+import { toast } from 'sonner'
 import invariant from 'tiny-invariant'
 
 import { AppSidebar } from './components/AppSidebar'
@@ -27,6 +28,8 @@ import {
 import { useCancelQuery } from './hooks/mutations'
 import { useStartQuery } from './hooks/use-start-query'
 import { useWorksheetAutosave } from './hooks/useWorksheetAutosave'
+import { isConnectionUnreadable, type DatabaseDto } from '@/glue/databases'
+import { secretStorageMessages } from '@/glue/secret-storage'
 import { useAppDispatch, useAppSelector } from './store'
 import { selectActiveWorksheetId } from './store/tabs-slice'
 import { uiActions } from './store/ui-slice'
@@ -117,6 +120,7 @@ function useLatestQuery(openWorksheetId: string | undefined) {
 
 function useRunQuery(
   activeStatement: Statement | null,
+  database: DatabaseDto | undefined,
   databaseId: string | null | undefined,
   worksheetId: string | undefined,
   flushSave: () => void
@@ -130,13 +134,37 @@ function useRunQuery(
       return
     }
 
+    // Refused here rather than left to fail: the run would be accepted, the row
+    // written, and the reason would only surface once the background fiber tried
+    // to open a connection it has no password for.
+    //
+    // `databaseId` is kept as its own argument because a worksheet can point at
+    // a database that no longer exists — then there is no DTO to check, and the
+    // backend is the one that says so.
+    if (database !== undefined && isConnectionUnreadable(database)) {
+      toast.error("Can't run this query", {
+        description: secretStorageMessages.cannotRunUnreadableConnection(
+          database.name
+        )
+      })
+
+      return
+    }
+
     // Running is a good moment to stop waiting out the debounce: the statement
     // is already taken from the editor, so this only makes the saved copy match
     // what just ran. Nothing waits on it — the query carries its own SQL.
     flushSave()
 
     startQuery({ content: activeStatement.text, databaseId, worksheetId })
-  }, [activeStatement, databaseId, flushSave, startQuery, worksheetId])
+  }, [
+    activeStatement,
+    database,
+    databaseId,
+    flushSave,
+    startQuery,
+    worksheetId
+  ])
 }
 
 /**
@@ -176,19 +204,20 @@ export function useWorksheetSession(openWorksheetId: string | undefined) {
     [queueSave, recordEditedContent]
   )
 
-  const handleRunQuery = useRunQuery(
-    activeStatement,
-    currentWorksheet?.databaseId,
-    openWorksheetId,
-    flushSave
-  )
-
   const currentDatabase = useMemo(
     () =>
       databases.data.find(
         (database) => database.id === currentWorksheet?.databaseId
       ),
     [databases.data, currentWorksheet?.databaseId]
+  )
+
+  const handleRunQuery = useRunQuery(
+    activeStatement,
+    currentDatabase,
+    currentWorksheet?.databaseId,
+    openWorksheetId,
+    flushSave
   )
 
   return {
@@ -342,8 +371,7 @@ function Workspace(): ReactElement {
 
         <StatusBar
           cursorPosition={cursorPosition}
-          databaseId={currentWorksheet?.databaseId ?? undefined}
-          databaseName={currentDatabase?.name}
+          database={currentDatabase}
           query={query}
           saveState={saveState}
         />

--- a/src/app/components/ConnectionPicker.test.tsx
+++ b/src/app/components/ConnectionPicker.test.tsx
@@ -226,6 +226,29 @@ describe('ConnectionPicker', () => {
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
   })
 
+  it('marks a connection whose stored details cannot be read', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<ConnectionPicker />, {
+      databases: [testDatabase, { ...testDatabase2, connectionInfo: null }],
+      openWorksheetId: 'ws-123',
+      worksheets: [testWorksheet]
+    })
+
+    await user.click(screen.getByRole('button'))
+
+    const marks = screen.getAllByRole('img', {
+      name: "Squeal can't read this connection's saved details. Re-enter them to repair it."
+    })
+
+    // Only the broken one, and it stays selectable — a worksheet pointing at it
+    // has to be able to point somewhere else.
+    expect(marks).toHaveLength(1)
+    expect(
+      screen.getByRole('option', { name: /Staging DB/ })
+    ).toBeInTheDocument()
+  })
+
   it('offers to add a database when none are configured', async () => {
     const user = userEvent.setup()
 

--- a/src/app/components/ConnectionPicker.tsx
+++ b/src/app/components/ConnectionPicker.tsx
@@ -1,4 +1,9 @@
-import { ChevronDownIcon, DatabaseIcon, SearchIcon } from 'lucide-react'
+import {
+  ChevronDownIcon,
+  DatabaseIcon,
+  SearchIcon,
+  TriangleAlertIcon
+} from 'lucide-react'
 import {
   type KeyboardEvent,
   ReactElement,
@@ -12,7 +17,8 @@ import {
 } from 'react'
 import invariant from 'tiny-invariant'
 
-import type { DatabaseDto } from '@/glue/databases'
+import { isConnectionUnreadable, type DatabaseDto } from '@/glue/databases'
+import { secretStorageMessages } from '@/glue/secret-storage'
 
 import { useCollections } from '../collections-context'
 import { useDatabases, useWorksheets } from '../hooks/queries'
@@ -479,6 +485,23 @@ function ConnectionPopover({
             <DatabaseIcon className="size-3 shrink-0 text-text3" />
 
             <span className="max-w-[200px] truncate">{database.name}</span>
+
+            {/* Still selectable: refusing the choice would strand a worksheet
+                whose connection broke. Running is what asks for a password, and
+                that is where the run is refused. */}
+            {isConnectionUnreadable(database) && (
+              <span
+                aria-label={secretStorageMessages.unreadableConnection}
+                className="ml-auto flex shrink-0 items-center"
+                role="img"
+                title={secretStorageMessages.unreadableConnection}
+              >
+                <TriangleAlertIcon
+                  aria-hidden
+                  className="size-3 text-err"
+                />
+              </span>
+            )}
           </div>
         ))}
       </div>

--- a/src/app/components/DatabaseExplorer.test.tsx
+++ b/src/app/components/DatabaseExplorer.test.tsx
@@ -105,6 +105,12 @@ const multiSchemaSchema: SchemaInfo = {
 }
 
 describe('DatabaseExplorer', () => {
+  // Several tests below assert that no schema was requested, and the mock is
+  // shared across the file.
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('renders the header and search input', () => {
     renderWithProviders(<DatabaseExplorer />, { databases: [testDatabase] })
 
@@ -493,6 +499,112 @@ describe('DatabaseExplorer', () => {
     expect(
       screen.getByRole('button', { name: 'Test Database' })
     ).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  describe('a connection whose stored details cannot be read', () => {
+    const unreadableDatabase: DatabaseDto = {
+      ...testDatabase,
+      connectionInfo: null,
+      id: 'db-unreadable',
+      name: 'Broken Connection'
+    }
+
+    // One line, not a sentence per row: with several broken connections a
+    // paragraph each buries the list it describes, so the row carries a short
+    // action and the marker's tooltip carries the explanation.
+    it('marks the row and asks for nothing it cannot get', () => {
+      renderWithProviders(<DatabaseExplorer />, {
+        databases: [unreadableDatabase]
+      })
+
+      expect(screen.getByText('Re-enter details')).toBeInTheDocument()
+
+      expect(
+        screen.getByRole('img', {
+          name: "Squeal can't read this connection's saved details. Re-enter them to repair it."
+        })
+      ).toBeInTheDocument()
+
+      // The list already said the secret is unreadable, so the schema request
+      // would only fail for a reason that is already known.
+      expect(apiClient.getDatabaseSchema).not.toHaveBeenCalled()
+    })
+
+    it('keeps the whole row to a single line', () => {
+      renderWithProviders(<DatabaseExplorer />, {
+        databases: [unreadableDatabase]
+      })
+
+      // The sentence lives in the tooltip, so it must not also be on screen.
+      expect(screen.queryByText(/Squeal can't read/)).not.toBeInTheDocument()
+    })
+
+    it('opens the connection form when the row is clicked', async () => {
+      const user = userEvent.setup()
+
+      const { store } = renderWithProviders(<DatabaseExplorer />, {
+        databases: [unreadableDatabase]
+      })
+
+      await user.click(screen.getByText('Broken Connection'))
+
+      expect(store.getState().ui.editorScreen).toEqual({
+        databaseId: 'db-unreadable',
+        type: 'edit-database'
+      })
+    })
+
+    it('still asks for the schemas of the connections it can read', () => {
+      renderWithProviders(<DatabaseExplorer />, {
+        databases: [unreadableDatabase, testDatabase]
+      })
+
+      expect(apiClient.getDatabaseSchema).toHaveBeenCalledTimes(1)
+      expect(apiClient.getDatabaseSchema).toHaveBeenCalledWith('db-123')
+    })
+  })
+
+  describe('a schema that will not load', () => {
+    const failureMessage =
+      'Failed to load schema for "Test Database": connection refused'
+
+    const expandedOptions = {
+      databaseExplorer: {
+        expandedDatabases: { 'db-123': { isExpanded: true, query: '' } }
+      },
+      databases: [testDatabase]
+    }
+
+    it('gives the reason instead of an empty tree', async () => {
+      vi.mocked(apiClient.getDatabaseSchema).mockRejectedValue(
+        new Error(failureMessage)
+      )
+
+      renderWithProviders(<DatabaseExplorer />, expandedOptions)
+
+      expect(await screen.findByText(failureMessage)).toBeInTheDocument()
+
+      // Marked on the row as well, so a collapsed one is not silent.
+      expect(
+        screen.getByRole('img', { name: failureMessage })
+      ).toBeInTheDocument()
+    })
+
+    it('asks again when the retry is taken', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(apiClient.getDatabaseSchema).mockRejectedValue(
+        new Error(failureMessage)
+      )
+
+      renderWithProviders(<DatabaseExplorer />, expandedOptions)
+
+      await user.click(await screen.findByRole('button', { name: 'Retry' }))
+
+      await waitFor(() => {
+        expect(apiClient.getDatabaseSchema).toHaveBeenCalledTimes(2)
+      })
+    })
   })
 
   describe('querying a table from the context menu', () => {

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -391,16 +391,11 @@ export function DatabaseExplorer(): ReactElement {
             {renderedRows.map((row) => (
               <DatabaseRow
                 key={row.database.id}
-                database={row.database}
                 dropIndicator={dropIndicatorFor(row.database.id)}
                 expansion={expandedDatabases[row.database.id]}
-                hasMultipleSchemas={row.hasMultipleSchemas}
                 isSortingDisabled={isSortingDisabled}
-                isUnreadable={row.isUnreadable}
-                schemaError={row.schemaError}
-                searchMatch={row.searchMatch}
+                row={row}
                 searchQuery={normalizedSearchQuery}
-                tables={row.tables}
                 onDelete={handleDeleteDatabase}
                 onEdit={handleEditDatabase}
                 onRefresh={refresh}
@@ -485,22 +480,19 @@ function DatabaseExplorerHeader({
 }
 
 interface DatabaseRowProps {
-  database: DatabaseDto
   dropIndicator: DropIndicator
   /** The user's own decision, or `undefined` if they have never made one. */
   expansion: DatabaseExpansion | undefined
-  hasMultipleSchemas: boolean
   isSortingDisabled: boolean
-  isUnreadable: boolean
+  // Six of this component's props were the six fields of one row, listed out
+  // again here and passed one by one at the call site. Taking the row itself
+  // means adding something a row carries does not touch this signature.
+  row: RenderedDatabaseRow
+  /** Normalized, so trailing whitespace does not count as a new question. */
+  searchQuery: string
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
   onRefresh: (database: DatabaseDto) => void
-  schemaError?: string
-  /** Only for deciding whether the row is open — what it shows is `tables`. */
-  searchMatch?: DatabaseMatch
-  /** Normalized, so trailing whitespace does not count as a new question. */
-  searchQuery: string
-  tables: TableInfo[]
 }
 
 // A decision only speaks for the context it was made in:
@@ -589,20 +581,24 @@ function useRowActivation({
 }
 
 function DatabaseRow({
-  database,
   dropIndicator,
   expansion,
-  hasMultipleSchemas,
   isSortingDisabled,
-  isUnreadable,
+  row,
+  searchQuery,
   onDelete,
   onEdit,
-  onRefresh,
-  schemaError,
-  searchMatch,
-  searchQuery,
-  tables
+  onRefresh
 }: DatabaseRowProps): ReactElement {
+  const {
+    database,
+    hasMultipleSchemas,
+    isUnreadable,
+    schemaError,
+    searchMatch,
+    tables
+  } = row
+
   const isDatabaseExpanded =
     !isUnreadable && isRowExpanded(expansion, searchMatch, searchQuery)
 
@@ -622,6 +618,11 @@ function DatabaseRow({
     transform,
     transition
   } = useSortable({ disabled: isSortingDisabled, id: database.id })
+
+  // While filtering only dragging is off, so skip the sortable props entirely —
+  // spreading them would mark the row aria-disabled even though clicking still
+  // works.
+  const sortableProps = isSortingDisabled ? {} : { ...attributes, ...listeners }
 
   return (
     // The transform lives on the wrapper so an expanded subtree moves with the
@@ -643,10 +644,7 @@ function DatabaseRow({
         isExpanded={isDatabaseExpanded}
         isUnreadable={isUnreadable}
         schemaError={schemaError}
-        // While filtering only dragging is off, so skip the sortable props
-        // entirely — spreading them would mark the row aria-disabled even
-        // though clicking still works.
-        sortableProps={isSortingDisabled ? {} : { ...attributes, ...listeners }}
+        sortableProps={sortableProps}
         onActivate={handleActivate}
         onDelete={onDelete}
         onEdit={onEdit}

--- a/src/app/components/DatabaseExplorer.tsx
+++ b/src/app/components/DatabaseExplorer.tsx
@@ -9,7 +9,8 @@ import {
   RefreshCwIcon,
   SearchIcon,
   Table2Icon,
-  Trash2
+  Trash2,
+  TriangleAlertIcon
 } from 'lucide-react'
 import { ReactElement, useCallback } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -51,14 +52,26 @@ import {
   ContextMenuTrigger
 } from './ui/context-menu'
 import type { SchemaInfo, TableInfo } from '@/databases/adapter'
-import { DatabaseDto } from '@/glue/databases'
+import { DatabaseDto, isConnectionUnreadable } from '@/glue/databases'
+import { secretStorageMessages } from '@/glue/secret-storage'
 import { DropIndicatorLine } from './DropIndicatorLine'
 
 interface RenderedDatabaseRow {
   database: DatabaseDto
   hasMultipleSchemas: boolean
+  /** The row's stored secret could not be read, so there is nothing to browse. */
+  isUnreadable: boolean
+  /** Why this database's schema could not be loaded, if it could not. */
+  schemaError?: string
   searchMatch?: DatabaseMatch
   tables: TableInfo[]
+}
+
+// Only what this module needs from a schema query, so the row builder stays a
+// pure function the tests can call directly.
+interface SchemaResult {
+  data: SchemaInfo | undefined
+  error: Error | null
 }
 
 // Builds the rows to render: while searching, only databases with a match
@@ -74,29 +87,36 @@ interface RenderedDatabaseRow {
 // resolving it here is what lets the list component take a plain array of
 // tables. `DatabaseRow` is still handed the match, but only to decide whether
 // the row is open.
+//
+// A row also carries why it has no tables when it has none. Both reasons look
+// identical in a tree — an empty subtree — and neither is: one needs the
+// password re-entered, the other names a server that did not answer.
 function computeRenderedRows(
   databases: DatabaseDto[],
-  schemas: (SchemaInfo | undefined)[],
+  schemaResults: (SchemaResult | undefined)[],
   searchQuery: string
 ): RenderedDatabaseRow[] {
   const isSearching = searchQuery.trim().length > 0
 
   const rows = databases.map((database, index) => {
+    const schema = schemaResults[index]?.data
+
     const searchMatch = isSearching
-      ? (computeDatabaseMatch(database, schemas[index], searchQuery) ??
-        undefined)
+      ? (computeDatabaseMatch(database, schema, searchQuery) ?? undefined)
       : undefined
 
     return {
       database,
-      hasMultipleSchemas: spansMultipleSchemas(schemas[index]),
+      hasMultipleSchemas: spansMultipleSchemas(schema),
+      isUnreadable: isConnectionUnreadable(database),
+      schemaError: schemaResults[index]?.error?.message,
       searchMatch,
       // Reading the schema here rather than in the expanded row gives up no
       // laziness: the caller fetches every schema unconditionally. If a
       // conditional prefetch is ever reintroduced, the tables have to be
       // threaded from wherever that fetch lands instead of being read again
       // further down.
-      tables: searchMatch?.tables ?? schemas[index]?.tables ?? []
+      tables: searchMatch?.tables ?? schema?.tables ?? []
     }
   })
 
@@ -291,13 +311,20 @@ export function DatabaseExplorer(): ReactElement {
   // Prefetch every schema in the background so search and expansion are instant,
   // and reuse those results as the source for what each row shows, matched or
   // not.
+  //
+  // A database whose secret cannot be read is asked for nothing: the request
+  // would fail for a reason already known from the list, and with retries it
+  // fails several times per row on every launch.
   const schemaResults = useDatabaseSchemas(
-    databases.data.map((database) => database.id)
+    databases.data.map((database) => ({
+      databaseId: database.id,
+      isEnabled: !isConnectionUnreadable(database)
+    }))
   )
 
   const renderedRows = computeRenderedRows(
     databases.data,
-    schemaResults.map((result) => result.data),
+    schemaResults,
     databaseSearchQuery
   )
 
@@ -369,6 +396,8 @@ export function DatabaseExplorer(): ReactElement {
                 expansion={expandedDatabases[row.database.id]}
                 hasMultipleSchemas={row.hasMultipleSchemas}
                 isSortingDisabled={isSortingDisabled}
+                isUnreadable={row.isUnreadable}
+                schemaError={row.schemaError}
                 searchMatch={row.searchMatch}
                 searchQuery={normalizedSearchQuery}
                 tables={row.tables}
@@ -462,9 +491,11 @@ interface DatabaseRowProps {
   expansion: DatabaseExpansion | undefined
   hasMultipleSchemas: boolean
   isSortingDisabled: boolean
+  isUnreadable: boolean
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
   onRefresh: (database: DatabaseDto) => void
+  schemaError?: string
   /** Only for deciding whether the row is open — what it shows is `tables`. */
   searchMatch?: DatabaseMatch
   /** Normalized, so trailing whitespace does not count as a new question. */
@@ -514,35 +545,74 @@ function isRowExpanded(
   return searchMatch?.expandDatabase === true ? true : expandedByUser
 }
 
+interface RowActivationOptions {
+  databaseId: string
+  isExpanded: boolean
+  isUnreadable: boolean
+  onEdit: (databaseId: string) => void
+  searchQuery: string
+}
+
+// What clicking a row does.
+//
+// Expanding is stamped with the query it answers, and derived from the resolved
+// state — what the user is actually looking at — so the write always matches
+// what they just clicked.
+//
+// An unreadable row has no tree to open, so its click goes where the only useful
+// action is: the form that repairs it. Toggling instead would answer a click
+// with nothing happening.
+function useRowActivation({
+  databaseId,
+  isExpanded,
+  isUnreadable,
+  onEdit,
+  searchQuery
+}: RowActivationOptions): () => void {
+  const dispatch = useAppDispatch()
+
+  return useCallback(() => {
+    if (isUnreadable) {
+      onEdit(databaseId)
+
+      return
+    }
+
+    dispatch(
+      setDatabaseExpanded({
+        databaseId,
+        isExpanded: !isExpanded,
+        query: searchQuery
+      })
+    )
+  }, [databaseId, dispatch, isExpanded, isUnreadable, onEdit, searchQuery])
+}
+
 function DatabaseRow({
   database,
   dropIndicator,
   expansion,
   hasMultipleSchemas,
   isSortingDisabled,
+  isUnreadable,
   onDelete,
   onEdit,
   onRefresh,
+  schemaError,
   searchMatch,
   searchQuery,
   tables
 }: DatabaseRowProps): ReactElement {
-  const dispatch = useAppDispatch()
+  const isDatabaseExpanded =
+    !isUnreadable && isRowExpanded(expansion, searchMatch, searchQuery)
 
-  const isDatabaseExpanded = isRowExpanded(expansion, searchMatch, searchQuery)
-
-  // Stamped with the query it answers, and derived from the resolved state —
-  // what the user is actually looking at — so the write always matches what
-  // they just clicked.
-  const handleToggle = useCallback(() => {
-    dispatch(
-      setDatabaseExpanded({
-        databaseId: database.id,
-        isExpanded: !isDatabaseExpanded,
-        query: searchQuery
-      })
-    )
-  }, [database.id, dispatch, isDatabaseExpanded, searchQuery])
+  const handleActivate = useRowActivation({
+    databaseId: database.id,
+    isExpanded: isDatabaseExpanded,
+    isUnreadable,
+    searchQuery,
+    onEdit
+  })
 
   const {
     attributes,
@@ -571,44 +641,144 @@ function DatabaseRow({
       <DatabaseRowHeader
         database={database}
         isExpanded={isDatabaseExpanded}
+        isUnreadable={isUnreadable}
+        schemaError={schemaError}
         // While filtering only dragging is off, so skip the sortable props
         // entirely — spreading them would mark the row aria-disabled even
         // though clicking still works.
         sortableProps={isSortingDisabled ? {} : { ...attributes, ...listeners }}
+        onActivate={handleActivate}
         onDelete={onDelete}
         onEdit={onEdit}
         onRefresh={onRefresh}
-        onToggle={handleToggle}
       />
 
       {isDatabaseExpanded && (
-        <DatabaseTableList
+        <DatabaseRowBody
           database={database}
           hasMultipleSchemas={hasMultipleSchemas}
+          schemaError={schemaError}
           tables={tables}
+          onRefresh={onRefresh}
         />
       )}
     </div>
   )
 }
 
+interface DatabaseRowBodyProps {
+  database: DatabaseDto
+  hasMultipleSchemas: boolean
+  onRefresh: (database: DatabaseDto) => void
+  schemaError?: string
+  tables: TableInfo[]
+}
+
+// What an open row holds: its tables, or why they are missing.
+function DatabaseRowBody({
+  database,
+  hasMultipleSchemas,
+  onRefresh,
+  schemaError,
+  tables
+}: DatabaseRowBodyProps): ReactElement {
+  if (schemaError !== undefined) {
+    return (
+      <DatabaseRowNotice
+        actionLabel="Retry"
+        message={schemaError}
+        onAction={() => onRefresh(database)}
+      />
+    )
+  }
+
+  return (
+    <DatabaseTableList
+      database={database}
+      hasMultipleSchemas={hasMultipleSchemas}
+      tables={tables}
+    />
+  )
+}
+
+interface DatabaseRowNoticeProps {
+  actionLabel: string
+  message: string
+  onAction: () => void
+}
+
+// Why an expanded row has no tables, in the place the tables would have been,
+// with the one action that changes it — rather than an empty subtree that looks
+// like a database with nothing in it. Only reached for a row the user opened, so
+// the sentence is never repeated down the whole list.
+function DatabaseRowNotice({
+  actionLabel,
+  message,
+  onAction
+}: DatabaseRowNoticeProps): ReactElement {
+  return (
+    <div className="pt-[1px] pr-[6px] pb-[3px] pl-[26px]">
+      <p className="text-[11.5px] leading-relaxed text-text2">{message}</p>
+
+      <button
+        className="text-[11.5px] text-accent hover:underline"
+        type="button"
+        onClick={onAction}
+      >
+        {actionLabel}
+      </button>
+    </div>
+  )
+}
+
+interface RowWarningIconProps {
+  className?: string
+  label: string
+}
+
+// The accessible name and the tooltip both live on the wrapper rather than on
+// the SVG: `title` is an HTML attribute, and browsers do not treat it as one
+// when it lands on an svg element.
+function RowWarningIcon({
+  className,
+  label
+}: RowWarningIconProps): ReactElement {
+  return (
+    <span
+      aria-label={label}
+      className={cn('flex flex-none items-center', className)}
+      role="img"
+      title={label}
+    >
+      <TriangleAlertIcon
+        aria-hidden
+        className="size-[10px] text-err"
+      />
+    </span>
+  )
+}
+
 interface DatabaseRowHeaderProps {
   database: DatabaseDto
   isExpanded: boolean
+  isUnreadable: boolean
+  onActivate: () => void
   onDelete: (database: DatabaseDto) => void
   onEdit: (databaseId: string) => void
   onRefresh: (database: DatabaseDto) => void
-  onToggle: () => void
+  schemaError?: string
   sortableProps: Record<string, unknown>
 }
 
 function DatabaseRowHeader({
   database,
   isExpanded,
+  isUnreadable,
+  onActivate,
   onDelete,
   onEdit,
   onRefresh,
-  onToggle,
+  schemaError,
   sortableProps
 }: DatabaseRowHeaderProps): ReactElement {
   return (
@@ -616,23 +786,52 @@ function DatabaseRowHeader({
       <ContextMenuTrigger>
         <button
           {...sortableProps}
-          aria-expanded={isExpanded}
+          // Nothing expands, so the row does not claim to: aria-expanded on a
+          // control that opens nothing tells a screen reader to wait for a
+          // subtree that never arrives.
+          aria-expanded={isUnreadable ? undefined : isExpanded}
           className="flex h-[var(--item-h)] w-full cursor-default items-center gap-[6px] rounded-[6px] px-[6px] text-left text-text2 hover:bg-hover"
           type="button"
-          onClick={onToggle}
+          onClick={onActivate}
         >
-          <ChevronRight
-            className={cn(
-              'size-[10px] flex-none text-text3 transition-transform duration-150',
-              isExpanded ? 'rotate-90' : ''
-            )}
-          />
+          {isUnreadable ? (
+            <RowWarningIcon
+              label={secretStorageMessages.unreadableConnection}
+            />
+          ) : (
+            <ChevronRight
+              className={cn(
+                'size-[10px] flex-none text-text3 transition-transform duration-150',
+                isExpanded ? 'rotate-90' : ''
+              )}
+            />
+          )}
 
           <Database className="size-[13px] flex-none text-text3" />
 
           <span className="min-w-0 truncate text-[12.5px] text-text">
             {database.name}
           </span>
+
+          {/* The whole row already opens the repair form, so this is a label
+              rather than a control — a button inside a button. Kept to one line
+              and one short phrase: with several broken connections, a sentence
+              per row buries the list it is describing, and the marker's tooltip
+              is where the full explanation lives. */}
+          {isUnreadable && (
+            <span className="ml-auto flex-none text-[11px] text-accent">
+              Re-enter details
+            </span>
+          )}
+
+          {/* A readable connection whose schema would not load keeps its
+              chevron — there is still a subtree, carrying the reason. */}
+          {schemaError !== undefined && (
+            <RowWarningIcon
+              className="ml-auto"
+              label={schemaError}
+            />
+          )}
         </button>
       </ContextMenuTrigger>
 

--- a/src/app/components/StatusBar.test.tsx
+++ b/src/app/components/StatusBar.test.tsx
@@ -1,26 +1,46 @@
-import { screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SchemaInfo } from '@/databases/adapter'
-import type { QueryDto, UpdateStatusResponse } from '@/glue/api/schemas'
+import type { QueryDto } from '@/glue/api/schemas'
+import { DatabaseDto } from '@/glue/databases'
 
 import { renderWithProviders } from '../test-utils'
 import { StatusBar } from './StatusBar'
 
-// `StatusBar` mounts `useServerVersion` and `UpdateIndicator`, and both fetch.
-// Seeded here so they read the cache instead: unseeded they are six real
-// requests to `127.0.0.1:7847`, which is the port `yarn start` binds — measured
-// by listening on it. They resolve to nothing this file asserts on, so all
-// three cases pass either way; what it costs is two `RequestError` stack traces
-// printed above the assertion diff whenever one of them does fail.
-const schema: SchemaInfo = { databaseName: 'pagila', tables: [] }
-const updateStatus: UpdateStatusResponse = {
-  currentVersion: '1.2.0',
-  lastCheckedAt: 1_700_000_000_000,
-  message: 'Updates are only available in a packaged build.',
-  releaseNotesUrl: null,
-  state: 'unsupported',
-  version: null
+vi.mock('../api-client', () => ({
+  apiClient: {
+    getDatabaseSchema: vi.fn(async () => ({
+      databaseName: 'pagila',
+      tables: []
+    })),
+    getDatabases: vi.fn(async () => []),
+    getQueries: vi.fn(async () => []),
+    getUpdateStatus: vi.fn(async () => ({
+      currentVersion: '1.4.2',
+      lastCheckedAt: null,
+      message: null,
+      releaseNotesUrl: null,
+      state: 'idle',
+      version: null
+    })),
+    getWorksheets: vi.fn(async () => [])
+  }
+}))
+
+import { apiClient } from '../api-client'
+
+const testDatabase: DatabaseDto = {
+  connectionInfo: {
+    database: 'pagila',
+    host: 'localhost',
+    port: 5432,
+    username: 'postgres'
+  },
+  createdAt: 1,
+  id: 'database-1',
+  name: 'Pagila',
+  sortOrder: null,
+  type: 'postgres'
 }
 
 /**
@@ -38,7 +58,7 @@ function count(value: number): string {
 function query(overrides: Partial<QueryDto> = {}): QueryDto {
   return {
     content: 'SELECT * FROM film',
-    databaseId: 'db-1',
+    databaseId: 'database-1',
     error: null,
     finishedAt: 3373,
     id: 'q-1',
@@ -54,35 +74,65 @@ function query(overrides: Partial<QueryDto> = {}): QueryDto {
   }
 }
 
-function renderStatusBar(current: QueryDto): void {
-  renderWithProviders(
+function renderStatusBar(
+  database: DatabaseDto | undefined,
+  current?: QueryDto
+) {
+  return renderWithProviders(
     <StatusBar
       cursorPosition={undefined}
-      databaseId="db-1"
-      databaseName="Pagila"
+      database={database}
       query={current}
-      saveState="saved"
+      saveState="idle"
     />,
-    { schemas: { 'db-1': schema }, updateStatus }
+    { databases: database ? [database] : [] }
   )
 }
 
-// The row count in the status bar is the only place a truncated result says so
-// once the results pane has scrolled away, and `+` is the whole of the saying.
-// Without it the reader is told the query returned exactly 100 rows when the
-// driver stopped counting at 100 — a number they may go on to trust.
-//
-// Truncation reaches here through `query.result.truncated`, which is now the
-// only place it is carried; the copy `QueryDto` used to hold beside the result
-// had no readers and is gone. These cases are what stop the remaining one from
-// being dropped or inverted unnoticed.
-//
-// Scoped to the row-count summary. The connection-health dot, its tooltips and
-// the save-state label share this component and are covered by nothing — each
-// can be replaced with a constant and every case below stays green.
 describe('StatusBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('names the connection and reads its server version', async () => {
+    renderStatusBar(testDatabase)
+
+    expect(screen.getByText('Pagila')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(apiClient.getDatabaseSchema).toHaveBeenCalledWith('database-1')
+    })
+  })
+
+  it('says so when the worksheet has no connection', () => {
+    renderStatusBar(undefined)
+
+    expect(screen.getByText('No database')).toBeInTheDocument()
+    expect(apiClient.getDatabaseSchema).not.toHaveBeenCalled()
+  })
+
+  // The version rides along with the schema, and there is no schema to load for
+  // a connection whose stored secret cannot be read — asking spends a failing
+  // request on an answer the database list already gave.
+  it('asks for no schema when the stored details cannot be read', () => {
+    renderStatusBar({ ...testDatabase, connectionInfo: null })
+
+    expect(screen.getByText('Pagila')).toBeInTheDocument()
+    expect(apiClient.getDatabaseSchema).not.toHaveBeenCalled()
+  })
+
+  // The row count in the status bar is the only place a truncated result says
+  // so once the results pane has scrolled away, and `+` is the whole of the
+  // saying. Without it the reader is told the query returned exactly 100 rows
+  // when the driver stopped counting at 100 — a number they may go on to trust.
+  //
+  // Truncation reaches here through `query.result.truncated`, which is now the
+  // only place it is carried; the copy `QueryDto` used to hold beside the
+  // result had no readers and is gone. These cases are what stop the remaining
+  // one from being dropped or inverted unnoticed.
   it('marks a truncated row count so the number is not read as a total', () => {
     renderStatusBar(
+      testDatabase,
       query({
         result: {
           fields: [{ name: 'title' }],
@@ -99,7 +149,7 @@ describe('StatusBar', () => {
   })
 
   it('leaves a complete row count unmarked', () => {
-    renderStatusBar(query())
+    renderStatusBar(testDatabase, query())
 
     expect(screen.getByText(`${count(100)} rows in 2.37 s`)).toBeInTheDocument()
   })
@@ -114,6 +164,7 @@ describe('StatusBar', () => {
   // absence alone waves through.
   it('groups a large row count so the digits can be read', () => {
     renderStatusBar(
+      testDatabase,
       query({
         result: {
           fields: [{ name: 'title' }],

--- a/src/app/components/StatusBar.tsx
+++ b/src/app/components/StatusBar.tsx
@@ -2,6 +2,7 @@ import { ActivityIcon } from 'lucide-react'
 import { ReactElement } from 'react'
 
 import type { QueryDto } from '@/glue/api/schemas'
+import type { DatabaseDto } from '@/glue/databases'
 
 import type { SaveState } from '../hooks/useWorksheetAutosave'
 import { useServerVersion } from '../hooks/queries'
@@ -14,8 +15,8 @@ type ConnectionHealth = 'failed' | 'succeeded' | 'unknown'
 
 interface StatusBarProps {
   cursorPosition: CursorPosition | undefined
-  databaseId: string | undefined
-  databaseName: string | undefined
+  /** The worksheet's connection, or undefined when it has none this app knows. */
+  database: DatabaseDto | undefined
   query: QueryDto | undefined
   saveState: SaveState
 }
@@ -66,13 +67,12 @@ function formatRunSummary(query: QueryDto | undefined): string | undefined {
 
 export function StatusBar({
   cursorPosition,
-  databaseId,
-  databaseName,
+  database,
   query,
   saveState
 }: StatusBarProps): ReactElement {
   const dispatch = useAppDispatch()
-  const serverVersion = useServerVersion(databaseId)
+  const serverVersion = useServerVersion(database)
 
   const health = getConnectionHealth(query)
   const runSummary = formatRunSummary(query)
@@ -89,7 +89,7 @@ export function StatusBar({
           style={{ backgroundColor: healthColors[health] }}
         />
 
-        {databaseName ?? 'No database'}
+        {database?.name ?? 'No database'}
       </span>
 
       {serverVersion !== undefined && (

--- a/src/app/hooks/queries.ts
+++ b/src/app/hooks/queries.ts
@@ -14,6 +14,7 @@ import type {
   SecretStorageResponse,
   UpdateStatusResponse
 } from '@/glue/api/schemas'
+import { isConnectionUnreadable, type DatabaseDto } from '@/glue/databases'
 import { canceledQueryMessage } from '@/glue/queries'
 
 const queryPollInterval = 250
@@ -101,17 +102,27 @@ function useDatabaseSchema(databaseId: string | undefined) {
   })
 }
 
+export interface DatabaseSchemaRequest {
+  databaseId: string
+  /** False for a database whose schema cannot be loaded, so nothing is asked. */
+  isEnabled: boolean
+}
+
 // Warms every database's schema in the background so search and expansion are
 // instant, and is the source the explorer reads each row's tables from. Uses
 // the same query keys as useDatabaseSchema, so the version read there is a
-// cache hit rather than a second request. Results line up by index with
-// databaseIds.
-export function useDatabaseSchemas(databaseIds: string[]) {
+// cache hit rather than a second request. Results line up by index with the
+// requests.
+//
+// A per-request `isEnabled` rather than a pre-filtered list, because callers
+// line the results up with their own database array by index — dropping the
+// databases that must not be asked would shift every index after them.
+export function useDatabaseSchemas(requests: DatabaseSchemaRequest[]) {
   return useQueries({
-    queries: databaseIds.map((databaseId) => ({
+    queries: requests.map(({ databaseId, isEnabled }) => ({
       queryKey: queryKeys.schema(databaseId),
       queryFn: () => apiClient.getDatabaseSchema(databaseId),
-      enabled: Boolean(databaseId),
+      enabled: Boolean(databaseId) && isEnabled,
       staleTime: Infinity
     }))
   })
@@ -122,9 +133,20 @@ export function useDatabaseSchemas(databaseIds: string[]) {
 // rather than a request of its own. Undefined until the schema has loaded, and
 // whenever the probe could not answer — a database that reports no version is
 // normal, not an error.
+//
+// Takes the row rather than its id so it can tell the two "no version" cases
+// apart: a connection whose stored secret cannot be read has no schema to load,
+// and asking anyway spends a failing request on an answer already known. The
+// worksheet's own databaseId is not enough — it can still name a row that was
+// deleted.
 export function useServerVersion(
-  databaseId: string | undefined
+  database: DatabaseDto | undefined
 ): string | undefined {
+  const databaseId =
+    database === undefined || isConnectionUnreadable(database)
+      ? undefined
+      : database.id
+
   const schema = useDatabaseSchema(databaseId)
 
   return schema.data?.serverVersion

--- a/src/glue/databases.ts
+++ b/src/glue/databases.ts
@@ -1,3 +1,14 @@
 // Re-exported from the API contract so the renderer keeps one import path
 // for database shapes.
+import type { DatabaseDto } from './api/schemas'
+
 export type { DatabaseDto } from './api/schemas'
+
+// The row exists but its stored secret could not be decrypted, so the API had
+// no connection details to send — most often because the OS keychain key that
+// sealed them is gone. Named rather than compared inline, because a null here
+// means "needs repair", not "no connection info": the row still has to be
+// listed, and the edit form is what fixes it.
+export function isConnectionUnreadable(database: DatabaseDto): boolean {
+  return database.connectionInfo === null
+}

--- a/src/glue/secret-storage.ts
+++ b/src/glue/secret-storage.ts
@@ -21,6 +21,8 @@ export function safeStorageName(platform: string): string {
 }
 
 export const secretStorageMessages = {
+  cannotRunUnreadableConnection: (databaseName: string): string =>
+    `Squeal can't read the saved details for "${databaseName}". Open the connection and re-enter them.`,
   keychainUnavailable: (storageName: string): string =>
     `Squeal could not get access to ${storageName}. If your system asked for permission, choose Allow and try again — or skip and save your passwords unencrypted.`,
   noKeyring:
@@ -30,5 +32,11 @@ export const secretStorageMessages = {
   // Nothing else in the response can tell the two apart, which is why this is
   // said rather than inferred.
   sealingFailed: (count: number, storageName: string): string =>
-    `Squeal has permission to use ${storageName}, but it refused to encrypt, so ${count} saved ${count === 1 ? 'connection is' : 'connections are'} still stored unencrypted. Once ${storageName} is working again, open each connection and save it to encrypt it.`
+    `Squeal has permission to use ${storageName}, but it refused to encrypt, so ${count} saved ${count === 1 ? 'connection is' : 'connections are'} still stored unencrypted. Once ${storageName} is working again, open each connection and save it to encrypt it.`,
+
+  // The sidebar marks such a row with a warning icon and a short inline action;
+  // this is the icon's accessible name and tooltip, so it is the one place that
+  // explains the state in full. A sentence per row would bury a list of them.
+  unreadableConnection:
+    "Squeal can't read this connection's saved details. Re-enter them to repair it."
 }

--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -21,6 +21,14 @@ export class QueryExecutionError extends Schema.TaggedError<QueryExecutionError>
 export class SecretDecryptError extends Schema.TaggedError<SecretDecryptError>()(
   'SecretDecryptError',
   {
+    // What the keychain actually said. `message` is the copy the user reads and
+    // is the same sentence however decryption failed, so without this the log
+    // cannot tell a mode gate refusing to touch the keychain from a key that no
+    // longer opens the value. For the log only — never returned to the renderer.
+    cause: Schema.optional(Schema.String),
+    // Attached by whoever knows which row this was, so a handler can name the
+    // connection in a user-facing error without a second lookup.
+    databaseName: Schema.optional(Schema.String),
     message: Schema.String
   }
 ) {}

--- a/src/server/http/databases.test.ts
+++ b/src/server/http/databases.test.ts
@@ -323,6 +323,40 @@ describe('database routes', () => {
     )
   })
 
+  // A secret this build cannot read is an expected state with a repair the user
+  // can carry out. Left to the internal-error backstop it answered a 500 whose
+  // body says "restart Squeal", which is neither true nor actionable.
+  it('answers a schema request for an unreadable secret with its own message', async () => {
+    const error = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+        const appDatabase = yield* AppDatabase
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        // The only row in a fresh test database, so no filter is needed.
+        yield* appDatabase.execute((db) =>
+          db.update(databasesTable).set({ connectionInfo: 'not-decryptable' })
+        )
+
+        return yield* client.databases
+          .schema({ path: { id: created.database.id } })
+          .pipe(Effect.flip)
+      })
+    )
+
+    expect(error).toEqual(
+      expect.objectContaining({
+        _tag: 'SchemaLoadFailedError',
+        databaseName: 'Pagila',
+        message:
+          'Stored connection info could not be read. Edit the connection and save it again.'
+      })
+    )
+  })
+
   it('reports unknown ids on reorder', async () => {
     const error = await run(
       Effect.gen(function* () {

--- a/src/server/http/handlers/databases.ts
+++ b/src/server/http/handlers/databases.ts
@@ -4,6 +4,7 @@ import { Cause, Effect, Option } from 'effect'
 import type { DatabaseAdapter } from '@/databases/adapter'
 import { SquealApi } from '@/glue/api/api'
 import { DatabaseNotFoundError, SchemaLoadFailedError } from '@/glue/api/errors'
+import type { SecretDecryptError } from '@/server/errors'
 import { AdapterFactory } from '@/server/services/adapter-factory'
 import { DatabaseService } from '@/server/services/database-service'
 import { orDieInternal } from '../internal-errors'
@@ -50,7 +51,13 @@ export const DatabasesLive = HttpApiBuilder.group(
           const service = yield* DatabaseService
           const adapterFactory = yield* AdapterFactory
 
-          const record = yield* service.getWithSecrets(path.id)
+          // A secret this build cannot read is an expected state with a repair
+          // the user can carry out, not a bug — left to orDieInternal it becomes
+          // a 500 whose body says "restart Squeal", which is neither true nor
+          // something they can act on.
+          const record = yield* service
+            .getWithSecrets(path.id)
+            .pipe(Effect.catchTag('SecretDecryptError', schemaLoadFailed))
 
           if (Option.isNone(record)) {
             return yield* new DatabaseNotFoundError({
@@ -90,6 +97,17 @@ export const DatabasesLive = HttpApiBuilder.group(
         }).pipe(orDieInternal)
       )
 )
+
+function schemaLoadFailed(error: SecretDecryptError) {
+  return Effect.fail(
+    new SchemaLoadFailedError({
+      // getWithSecrets names the row it read; the fallback only covers a caller
+      // that did not, and reads as part of the sentence.
+      databaseName: error.databaseName ?? 'this connection',
+      message: error.message
+    })
+  )
+}
 
 function loadSchema(adapter: DatabaseAdapter, databaseName: string) {
   return Effect.tryPromise(() => adapter.getSchema()).pipe(

--- a/src/server/services/database-service.test.ts
+++ b/src/server/services/database-service.test.ts
@@ -692,7 +692,15 @@ describe('DatabaseService', () => {
       })
     )
 
-    expect(unreadable._tag).toEqual('SecretDecryptError')
+    // Named, so a handler answering the user can say which connection to go and
+    // repair without looking the row up again.
+    expect(unreadable).toEqual(
+      expect.objectContaining({
+        _tag: 'SecretDecryptError',
+        databaseName: 'Broken'
+      })
+    )
+
     expect(updated.name).toEqual('Repaired')
 
     // The repaired row is readable again. The password is blank because the

--- a/src/server/services/database-service.ts
+++ b/src/server/services/database-service.ts
@@ -176,7 +176,7 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
           transformDatabase(record).pipe(
             Effect.catchTag('SecretDecryptError', (error) =>
               Effect.logWarning(
-                `Could not read connection info for database ${record.id}: ${error.message}`
+                `Could not read connection info for database ${record.id}: ${describeSecretDecryptError(error)}`
               ).pipe(Effect.as(toUnreadableDatabase(record)))
             )
           )
@@ -265,14 +265,17 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
             return Option.none<DatabaseWithSecrets>()
           }
 
+          // Named here because this is the last frame that knows which row it
+          // was: callers get an id at best, and a handler answering the user
+          // should be able to say which connection to go and repair.
           const connectionInfo = yield* parseConnectionInfo(
             record.value.connectionInfo
-          )
+          ).pipe(Effect.mapError(withDatabaseName(record.value.name)))
 
           const connection = yield* toDatabaseConnection(
             record.value.type as DatabaseType,
             connectionInfo
-          )
+          ).pipe(Effect.mapError(withDatabaseName(record.value.name)))
 
           return Option.some<DatabaseWithSecrets>({
             connection,
@@ -550,6 +553,29 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
     })
   }
 ) {}
+
+// The user-facing sentence is the same however decryption failed, so the log
+// gets the keychain's own words appended when there are any.
+function describeSecretDecryptError(error: SecretDecryptError): string {
+  if (error.cause === undefined) {
+    return error.message
+  }
+
+  return `${error.message} (${error.cause})`
+}
+
+// Rebuilt field by field rather than spread: the error is an Error subclass, so
+// a spread would also hand the constructor properties that are not fields.
+function withDatabaseName(
+  databaseName: string
+): (error: SecretDecryptError) => SecretDecryptError {
+  return (error) =>
+    new SecretDecryptError({
+      cause: error.cause,
+      databaseName,
+      message: error.message
+    })
+}
 
 // The stored password may only be lent back to the server it was saved for,
 // reached the way it was saved to be reached. Host and port decide where the

--- a/src/server/services/secret-storage.ts
+++ b/src/server/services/secret-storage.ts
@@ -20,8 +20,9 @@ export class SecretStorage extends Effect.Service<SecretStorage>()(
     sync: () => ({
       decrypt: (value: string) =>
         Effect.try({
-          catch: () =>
+          catch: (cause) =>
             new SecretDecryptError({
+              cause: String(cause),
               message:
                 'A stored connection secret could not be decrypted. Edit the connection and re-enter its password.'
             }),


### PR DESCRIPTION
## What was happening

The database browser expanded into nothing for seven of eight connections, and
the backend logged a warning per row:

```
Could not read connection info for database 635291ee-…: A stored connection
secret could not be decrypted. Edit the connection and re-enter its password.
```

**The decrypt failure is environmental, not a regression.**
`settings.secretStorageMode` is `keychain`, every row carries a well-formed
`enc:v1:` value whose payload decodes to Chromium's `v10` OSCrypt prefix, and
exactly one row decrypts — the one that has been re-saved since. Chromium mints
a fresh random key when its keychain item is missing, silently, so a keychain
reset or an OS migration rotates the key with nothing to catch. Those secrets are
unrecoverable; the app already has the repair (edit the connection, re-enter the
password).

**The bug is the silence.** `connectionInfo: null` — the state the list endpoint
already reports for such a row — was read in exactly one place in the renderer,
`EditorScreen`, to blank the form. Everywhere else the row rendered as normal,
fired a schema request that could only fail, and dropped the failure:
`useDatabaseSchema` / `useDatabaseSchemas` are read for `.data` alone. The 500 it
answered was wrong too — `getWithSecrets` fails with the internal
`SecretDecryptError`, which `orDieInternal` turns into a defect, so an expected
state with a user-carryable repair came back as _"Squeal's backend reported an
error. Restart Squeal and try again."_

## What changed

- **Sidebar** — such a row is marked and carries `Re-enter details`; clicking
  anywhere on it opens the form that repairs it. One line per row, with the
  sentence in the marker's tooltip: with several broken connections a paragraph
  each buries the list it describes.
- **No doomed requests** — no schema is asked for those rows. On this database
  that is **8 requests at launch down to 1**, where 7 of the 8 were each retried
  three times. The status bar's version probe took the same path, so
  `useServerVersion` now takes the row rather than its id — which also stops it
  asking after a database that was deleted.
- **Other schema failures** (server down, connection refused) get the same marker
  and, once the row is open, their reason and a `Retry` instead of an empty
  subtree. Previously just as silent.
- **Connection picker** marks such a row but keeps it selectable — refusing the
  choice would strand a worksheet whose connection broke.
- **Run refuses up front**: `Squeal can't read the saved details for "Guvnor
  (Prod)". Open the connection and re-enter them.` Before, the run was accepted
  and the reason only surfaced once the background fiber reached
  `loadConnection`.
- **Server** — the schema route answers the already-declared
  `SchemaLoadFailedError` (503) carrying the secret's own message and naming the
  connection, instead of a 500 defect.
- **Diagnosis** — `SecretStorage.decrypt` threw the keychain's own error away, so
  the warning could not tell a mode gate refusing to touch the keychain from a
  key that no longer opens the value. It is carried now:

  ```
  … Edit the connection and re-enter its password.
    (Error: Error while decrypting the ciphertext provided to safeStorage.decryptString.)
  ```

## Verification

`yarn typecheck`, `yarn lint`, `npx prettier --check .`, `yarn test` (964
passed), and `npx fallow@3.2.0` all clean.

Driven against the running app over CDP: seven marked rows, the readable one
expanding to its tables normally, **one** `GET /databases/:id/schema` in the
traces (the readable row, 200), the repair form opening from a marked row, and
Run refused with no query row created.

## Notes for review

- `src/glue/databases.ts` gains `isConnectionUnreadable`. Its import of the
  contract stays `import type`, so the module emits no runtime import and does
  not pull Effect Schema into the renderer for a null check.
- `DatabaseRow` crossed fallow's cognitive threshold once it grew the new state,
  hence `useRowActivation` and `DatabaseRowBody`. `yarn typecheck`/`lint`/`test`
  all pass while fallow fails, so it is worth running before calling a change
  green.
- The second commit is unrelated to the fix: three wall-clock-timing tests
  (`effect-tracer.test.ts` linger-window batching, `TraceDashboard.test.tsx`,
  `DatabaseForm.test.tsx`) flake in the full suite and pass 3/3 in isolation.
  Confirmed pre-existing by running the baseline six times, and logged as
  friction rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
