### PR TITLE
fix(seed): read .env so a documented override is honoured

### DIFF
--- a/scripts/seed-config.test.ts
+++ b/scripts/seed-config.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { createRequire } from 'module'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -110,12 +110,25 @@ function resolveTargets(overrides: Record<string, string> = {}): SeedTargets {
 }
 
 /** Run the seed itself, from `directory`, and return everything it said. */
-function runSeed(): string {
+function runSeed(overrides: Record<string, string>): string {
+  // Structural rather than per-case. With nothing setting `SQLITE_PATH` the
+  // seed falls back to the repository's own `seed-sqlite/pagila.sqlite` — the
+  // developer's sample database, which `seedSqlite` deletes before it writes.
+  // One case here that forgets to point it somewhere else is enough to lose
+  // that file, and the case would still pass.
+  const target = resolveTargets(overrides).sqlitePath
+
+  if (!resolve(directory, target).startsWith(resolve(directory))) {
+    throw new Error(
+      `This case would run the seed against '${target}', which is outside the temporary directory it was given. Point SQLITE_PATH — in the case's \`.env\` or in its overrides — at a path under it.`
+    )
+  }
+
   try {
     execFileSync(process.execPath, [tsxCli, seedScript], {
       cwd: directory,
       encoding: 'utf-8',
-      env: childEnvironment({ SQLITE_PATH: join(directory, 'pagila.sqlite') }),
+      env: childEnvironment(overrides),
       stdio: 'pipe',
       timeout: 60_000
     })
@@ -223,6 +236,100 @@ describe('the seed targets', () => {
       `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`
     )
 
-    expect(runSeed()).toContain(unreachableHost)
+    expect(
+      runSeed({ SQLITE_PATH: join(directory, 'pagila.sqlite') })
+    ).toContain(unreachableHost)
+  })
+
+  // `14` is `SQLITE_CANTOPEN`, and the message libsql raises says only that:
+  // no mention of `SQLITE_PATH`, of `.env`, or of the directory being the
+  // thing that is missing. The reader has to know libsql's error codes are
+  // SQLite's and go look up the number.
+  //
+  // The check runs before `seedPostgres`, which is why the Postgres in this
+  // `.env` is one that cannot resolve and the assertion says the output does
+  // not mention it. Config that is wrong should be caught before the seed
+  // drops a schema, not after.
+  it('names SQLITE_PATH when the directory it points into is missing', () => {
+    const missingDirectory = join(directory, 'no-such-dir')
+    const missingPath = join(missingDirectory, 'pagila.sqlite')
+
+    writeDotEnv(
+      `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`,
+      `SQLITE_PATH=${missingPath}`
+    )
+
+    const output = runSeed({})
+
+    expect({
+      beforeTouchingPostgres: !output.includes(unreachableHost),
+      // Quoted on its own, not merely present. The path the seed would have
+      // written starts with the missing directory, so a message naming only
+      // that path already contains it as a substring while leaving the reader
+      // to work out which segment is the part that is not there. Only a
+      // message that names the directory by itself closes the quote here.
+      namesTheDirectory: output.includes(`'${missingDirectory}'`),
+      namesTheSource: output.includes('SQLITE_PATH'),
+      // A phrase, which is as close as a test gets to "the message says what
+      // to do about it": there is no shape to look for, only the instruction
+      // itself. So rewording it turns this red even when the rewording is an
+      // improvement — a cost taken knowingly, because the alternative is a
+      // message that can quietly stop saying anything actionable.
+      saysWhatToDo: output.includes('Create the directory')
+    }).toEqual({
+      beforeTouchingPostgres: true,
+      namesTheDirectory: true,
+      namesTheSource: true,
+      saysWhatToDo: true
+    })
+  })
+
+  // `existsSync` answers for a file as readily as for a directory, so a
+  // `SQLITE_PATH` one segment too deep — the sample database itself taken for
+  // the directory to put it in — walks straight past the check and reaches
+  // libsql, which fails with the bare `14` the check exists to replace.
+  it('names SQLITE_PATH when what it points into is a file', () => {
+    const file = join(directory, 'not-a-directory')
+
+    writeFileSync(file, '', 'utf-8')
+    writeDotEnv(
+      `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`,
+      `SQLITE_PATH=${join(file, 'pagila.sqlite')}`
+    )
+
+    const output = runSeed({})
+
+    expect({
+      beforeTouchingPostgres: !output.includes(unreachableHost),
+      namesTheSource: output.includes('SQLITE_PATH'),
+      namesWhatIsWrong: output.includes(file)
+    }).toEqual({
+      beforeTouchingPostgres: true,
+      namesTheSource: true,
+      namesWhatIsWrong: true
+    })
+  })
+
+  // `.env.example` ships a relative `SQLITE_PATH` and `.env` is read from the
+  // working directory, so relative is the shape a developer most likely has.
+  // Printed back as written, the message tells someone looking at a repository
+  // that visibly contains `seed-sqlite/` that `./seed-sqlite` does not exist,
+  // and never says what `./` was resolved against — the same complaint the
+  // check makes of libsql, in the other direction.
+  it('resolves a relative SQLITE_PATH before naming the directory', () => {
+    writeDotEnv(
+      `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`,
+      'SQLITE_PATH=./no-such-dir/pagila.sqlite'
+    )
+
+    const output = runSeed({})
+
+    expect({
+      beforeTouchingPostgres: !output.includes(unreachableHost),
+      namesTheResolvedDirectory: output.includes(join(directory, 'no-such-dir'))
+    }).toEqual({
+      beforeTouchingPostgres: true,
+      namesTheResolvedDirectory: true
+    })
   })
 })

--- a/scripts/seed-config.test.ts
+++ b/scripts/seed-config.test.ts
@@ -1,0 +1,228 @@
+import { execFileSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { createRequire } from 'module'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+interface SeedTargets {
+  postgresUrl: string
+  sqlitePath: string
+}
+
+const requireFromTest = createRequire(import.meta.url)
+const repositoryRoot = join(import.meta.dirname, '..')
+const seedConfig = pathToFileURL(join(import.meta.dirname, 'seed-config.ts'))
+const seedScript = join(import.meta.dirname, 'seed.ts')
+const tsxCli = requireFromTest.resolve('tsx/cli')
+
+// The default SQLite target, spelled out here so the cases below can compare a
+// whole path. Asserting only its last two segments would let the seed write to
+// the repository's parent, or into `scripts/`, unnoticed.
+const defaultSqlitePath = join(repositoryRoot, 'seed-sqlite', 'pagila.sqlite')
+
+// RFC 2606 reserves `.invalid` and guarantees it never resolves, so pointing
+// the seed at it cannot reach a server. That, plus `seedPostgres` connecting
+// before it issues a statement, is what makes running the real script here safe.
+const unreachableHost = 'nowhere.invalid'
+
+let directory = ''
+
+/**
+ * `process.env` with everything that would decide the answer for us removed.
+ *
+ * The two targets go because leaving an already-set variable alone is the whole
+ * reason a shell export still beats `.env` — so whatever the developer running
+ * the suite happens to export would otherwise win every case here.
+ * `DOTENV_CONFIG_*` goes because it configures dotenv itself, and
+ * `DOTENV_CONFIG_QUIET=false` puts a banner on the child's stdout.
+ */
+function childEnvironment(
+  overrides: Record<string, string>
+): NodeJS.ProcessEnv {
+  const environment = { ...process.env, ...overrides }
+  const scrubbed = Object.keys(environment).filter(
+    (name) =>
+      name === 'POSTGRES_URL' ||
+      name === 'SQLITE_PATH' ||
+      name.startsWith('DOTENV_CONFIG_')
+  )
+
+  for (const name of scrubbed) {
+    if (!(name in overrides)) {
+      delete environment[name]
+    }
+  }
+
+  return environment
+}
+
+/**
+ * Load the targets in a directory, and under the loader `yarn seed` really runs
+ * on.
+ *
+ * A child process rather than an import, for two reasons. `.env` is read once,
+ * as `dotenv` is first loaded, and `vi.resetModules()` does not reach a module
+ * from `node_modules` — so in-process only the first case here would have
+ * measured anything and the rest would have read a stale cache. And `tsx` loads
+ * this repository as CommonJS, which is why `seed-config.ts` cannot use
+ * `import.meta.dirname`; running it any other way would not catch that.
+ */
+function resolveTargets(overrides: Record<string, string> = {}): SeedTargets {
+  const printer = join(directory, 'print-targets.ts')
+
+  writeFileSync(
+    printer,
+    [
+      `import { postgresUrl, sqlitePath } from ${JSON.stringify(seedConfig.href)}`,
+      '',
+      'console.log(JSON.stringify({ postgresUrl, sqlitePath }))',
+      ''
+    ].join('\n'),
+    'utf-8'
+  )
+
+  const output = execFileSync(process.execPath, [tsxCli, printer], {
+    cwd: directory,
+    encoding: 'utf-8',
+    env: childEnvironment(overrides),
+    timeout: 60_000
+  })
+
+  // The last line rather than all of stdout. Anything else printed on the way —
+  // a dotenv banner after a version bump, a `console.log` someone adds to the
+  // seed — would otherwise turn every case in this file red with a JSON parse
+  // error naming neither the seed nor the cause.
+  const printed = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .at(-1)
+
+  if (printed === undefined) {
+    throw new Error(
+      'Loading the seed targets printed nothing at all, so there is nothing to check. Run `npx tsx scripts/seed-config.ts` to see what the module does on load.'
+    )
+  }
+
+  return JSON.parse(printed) as SeedTargets
+}
+
+/** Run the seed itself, from `directory`, and return everything it said. */
+function runSeed(): string {
+  try {
+    execFileSync(process.execPath, [tsxCli, seedScript], {
+      cwd: directory,
+      encoding: 'utf-8',
+      env: childEnvironment({ SQLITE_PATH: join(directory, 'pagila.sqlite') }),
+      stdio: 'pipe',
+      timeout: 60_000
+    })
+  } catch (error) {
+    const failure = error as { stderr?: string; stdout?: string }
+
+    return `${failure.stdout ?? ''}${failure.stderr ?? ''}`
+  }
+
+  throw new Error(
+    'The seed ran to completion against a host that cannot resolve, which means it connected to something else. Check where `scripts/seed.ts` reads `POSTGRES_URL` from.'
+  )
+}
+
+function writeDotEnv(...lines: string[]): void {
+  writeFileSync(join(directory, '.env'), `${lines.join('\n')}\n`, 'utf-8')
+}
+
+// `yarn seed` drops and recreates schemas, so where it points has to be where
+// the developer asked it to point. `.env` is where CONTRIBUTING says to ask.
+//
+// The resolution lives in a module of its own so that most of this file can
+// exist: importing `seed.ts` runs the seed, and `sqlitePath` is unreachable
+// through the script anyway, because `seedPostgres` fails first and
+// `seedSqlite` is never called. The last case here does run the real script —
+// connecting is not itself the destructive act, so a host that cannot resolve
+// observes the whole bug without touching a database.
+describe('the seed targets', () => {
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), 'squeal-seed-env-'))
+  })
+
+  afterEach(() => {
+    rmSync(directory, { force: true, recursive: true })
+  })
+
+  it('takes both targets from .env', () => {
+    writeDotEnv(
+      'POSTGRES_URL=postgresql://someone@example.test:6000/other',
+      'SQLITE_PATH=./elsewhere/pagila.sqlite'
+    )
+
+    expect(resolveTargets()).toEqual({
+      postgresUrl: 'postgresql://someone@example.test:6000/other',
+      sqlitePath: './elsewhere/pagila.sqlite'
+    })
+  })
+
+  // What the script did before `.env` was read, and still has to do when there
+  // is none — the values `.env.example` documents, matching the services in
+  // `docker-compose.yml`. Port 5433, not 5432: Compose maps it that way to miss
+  // a Postgres already running on the host.
+  //
+  // The SQLite default is anchored to the repository rather than to the working
+  // directory, preserving what `__dirname` did before the extraction. Under
+  // `yarn seed` the two are always the same, since yarn runs scripts from the
+  // package root wherever it was invoked from; they part company under a bare
+  // `npx tsx scripts/seed.ts`, and the sample database lands somewhere else.
+  it('falls back to the docker-compose defaults without a .env', () => {
+    expect(resolveTargets()).toEqual({
+      postgresUrl: 'postgresql://postgres:postgres@localhost:5433/squeal',
+      sqlitePath: defaultSqlitePath
+    })
+  })
+
+  // `POSTGRES_URL=` with nothing after it is a half-finished edit, and dotenv
+  // sets it to the empty string rather than leaving it unset — measured. Under
+  // `||` that is falsy and the default wins, so the script would announce
+  // "Connected to PostgreSQL" and drop the schema on 5433, which is the exact
+  // failure this change exists to prevent. `??` keeps the empty string and the
+  // connection fails instead.
+  it('does not fall back when the override is set but empty', () => {
+    writeDotEnv('POSTGRES_URL=')
+
+    expect(resolveTargets()).toEqual({
+      postgresUrl: '',
+      sqlitePath: defaultSqlitePath
+    })
+  })
+
+  // What keeps CI, and a deliberate one-off override, winning over a stale
+  // `.env` left in the tree. It is dotenv's documented behaviour rather than
+  // anything this module does, and it is asserted because the point of the
+  // change is that `.env` now decides something destructive.
+  it('lets the surrounding environment win over .env', () => {
+    writeDotEnv('POSTGRES_URL=postgresql://someone@example.test:6000/other')
+
+    expect(
+      resolveTargets({
+        POSTGRES_URL: 'postgresql://shell@example.test:7000/shell'
+      })
+    ).toEqual({
+      postgresUrl: 'postgresql://shell@example.test:7000/shell',
+      sqlitePath: defaultSqlitePath
+    })
+  })
+
+  // Everything above tests the module the seed imports, and none of it reaches
+  // the seed. Putting the two inline `process.env` reads back at the top of
+  // `seed.ts` is issue #72 restored in full — `.env` ignored again, the schema
+  // on 5433 dropped again — and every case above stays green through it. This
+  // is the one that goes red.
+  it('points the seed itself at the server .env names', () => {
+    writeDotEnv(
+      `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`
+    )
+
+    expect(runSeed()).toContain(unreachableHost)
+  })
+})

--- a/scripts/seed-config.ts
+++ b/scripts/seed-config.ts
@@ -1,0 +1,43 @@
+// Loading this reads `.env`, which is why it is a module of its own rather than
+// two consts at the top of `seed.ts`: importing `seed.ts` runs the seed, and the
+// seed drops schemas. Keeping the targets separately importable is what lets a
+// test check where they point without pointing anything anywhere.
+//
+// `dotenv/config` is the same spelling `src/database/index.ts` and
+// `drizzle.config.ts` already use. It leaves an already-set variable alone, so
+// a shell export and CI still win over a `.env` left in the tree.
+import 'dotenv/config'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+// `import.meta.dirname` is undefined here — the repository has no
+// `"type": "module"`, so `tsx` loads this as CommonJS and only populates
+// `import.meta.url`. This spelling works under `tsx` and under vitest both.
+const scriptsDirectory = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * The PostgreSQL instance `yarn seed` loads the Pagila sample data into,
+ * dropping and recreating its public schema first.
+ *
+ * The default is the `postgres` service in `docker-compose.yml` — port 5433,
+ * not 5432, so it misses a Postgres already running on the host.
+ */
+export const postgresUrl =
+  process.env.POSTGRES_URL ??
+  'postgresql://postgres:postgres@localhost:5433/squeal'
+
+/**
+ * Where `yarn seed` writes the SQLite sample database, deleting whatever is
+ * already there.
+ *
+ * The default is anchored to the repository rather than the working directory,
+ * so it names one file wherever the script is launched from. An override is
+ * not: `.env` itself is read from the working directory, and `.env.example`
+ * documents a relative path, so `SQLITE_PATH=./seed-sqlite/pagila.sqlite` means
+ * whatever `./` meant to the caller. Under `yarn seed` the two are the same
+ * directory — yarn runs a script from the package root wherever it was invoked
+ * from — so they only part company under a bare `npx tsx scripts/seed.ts`.
+ */
+export const sqlitePath =
+  process.env.SQLITE_PATH ??
+  join(scriptsDirectory, '..', 'seed-sqlite', 'pagila.sqlite')

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,8 +1,8 @@
 import { createClient } from '@libsql/client'
 import { execSync } from 'child_process'
-import { existsSync, unlinkSync } from 'fs'
+import { existsSync, statSync, unlinkSync } from 'fs'
 import { readdir, readFile } from 'fs/promises'
-import { join } from 'path'
+import { dirname, join, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { Client } from 'pg'
 
@@ -109,8 +109,50 @@ async function seedSqlite() {
   }
 }
 
+/**
+ * Fail on a SQLite target the seed cannot write into.
+ *
+ * Checked here rather than in `seedSqlite()`, where the path is finally used,
+ * because everything between the two drops and recreates a schema — a typo in
+ * `.env` is worth catching while the developer's Postgres is still intact.
+ *
+ * Left to the driver, the seed dies on `createClient` with
+ * `ConnectionFailed("Unable to open connection to local database
+ * /C:/…/no-such-dir/pagila.sqlite: 14")` — a numeric code, a path wearing the
+ * leading slash `pathToFileURL` gave it on Windows, and no mention of either
+ * the setting that chose it or which part of it does not exist.
+ *
+ * The configured path is quoted as it was written and the directory as it
+ * resolved, because those are two different things whenever `SQLITE_PATH` is
+ * relative — which is the shape `.env.example` ships. Told only that
+ * `./seed-sqlite` does not exist, a reader looking at a repository that
+ * visibly contains `seed-sqlite/` learns nothing.
+ */
+function checkSqliteDirectory() {
+  const directory = resolve(dirname(sqlitePath))
+  const status = statSync(directory, { throwIfNoEntry: false })
+
+  if (status?.isDirectory() === true) {
+    return
+  }
+
+  // `existsSync` alone would pass a file here, and the seed would go on to ask
+  // libsql to open a database under it — the same bare `14`, for a path that
+  // looks present.
+  const problem =
+    status === undefined
+      ? `its directory '${directory}' does not exist`
+      : `'${directory}' is a file, not the directory it would have to be`
+
+  throw new Error(
+    `The SQLite database is set to go to '${sqlitePath}', but ${problem}. Create the directory, or point SQLITE_PATH — from .env, or from your shell if you exported it there — at one that already exists.`
+  )
+}
+
 async function seed() {
   try {
+    checkSqliteDirectory()
+
     await seedPostgres()
     await seedMysql()
     await seedSqlite()

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -6,9 +6,7 @@ import { join } from 'path'
 import { pathToFileURL } from 'url'
 import { Client } from 'pg'
 
-const postgresUrl =
-  process.env.POSTGRES_URL ??
-  'postgresql://postgres:postgres@localhost:5433/squeal'
+import { postgresUrl, sqlitePath } from './seed-config'
 
 async function runSeedFiles(
   seedDirectory: string,
@@ -74,10 +72,6 @@ async function seedMysql() {
 
   console.log('MySQL seeded successfully!\n')
 }
-
-const sqlitePath =
-  process.env.SQLITE_PATH ??
-  join(__dirname, '..', 'seed-sqlite', 'pagila.sqlite')
 
 async function seedSqlite() {
   console.log('Seeding SQLite database...')

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,11 @@ import { configDefaults, defineConfig } from 'vitest/config'
 // Tests for backend code (pure glue modules and, as the Effect migration
 // lands, src/server) run in a plain node environment. Everything else keeps
 // the jsdom environment the React tests need.
-const backendTestPatterns = ['src/glue/**/*.test.ts', 'src/server/**/*.test.ts']
+const backendTestPatterns = [
+  'scripts/**/*.test.ts',
+  'src/glue/**/*.test.ts',
+  'src/server/**/*.test.ts'
+]
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
Closes #72.

CONTRIBUTING tells the reader to copy `.env.example` to `.env`, and `.env.example` documents `POSTGRES_URL` and `SQLITE_PATH` — but nothing loaded the file. `yarn seed` read `process.env` directly, so both overrides worked only when exported into the shell.

An override that silently does nothing is worse than no override here, because the seed drops and recreates the Postgres public schema. A developer who points `.env` at a scratch database gets `localhost:5433` dropped instead, and the script reports success.

Reproduced before fixing, with a `.env` naming a closed port:

```
before   scripts/seed.ts → connect ECONNREFUSED 127.0.0.1:5433   (the .env is ignored)
after    scripts/seed.ts → connect ECONNREFUSED 127.0.0.1:59999  (the .env decides)
```

## Deviation from the issue

The issue proposes one line at the top of `seed.ts`. This adds `scripts/seed-config.ts` instead, and the reason is testability rather than taste:

- `seed.ts` runs the seed as a side effect of being imported, so nothing can import it to read a value off it.
- `sqlitePath` is not reachable through the script at all — `seedPostgres` runs first, so a run that fails never gets as far as the SQLite target.

Resolving the two in a module of their own is what makes them observable. The import in `seed.ts` is still the one line the issue asked for.

## Tests

Four cases load the targets in a child process under `tsx`, one per temp directory with its own `.env`. In-process was tried first and is not viable: `.env` is read once as dotenv is first loaded, and `vi.resetModules()` does not reach a module from `node_modules`, so only the first case would have measured anything and the other three would have read a stale `process.env`. The child process also runs the loader `yarn seed` really uses — which is what caught `import.meta.dirname` being `undefined` under `tsx` (the repo has no `"type": "module"`, so `tsx` loads it as CommonJS).

The fifth case runs the real `scripts/seed.ts`, and it exists because the other four cover the module and none of them reach the script — putting the inline `process.env` reads back at the top of `seed.ts` restores the entire bug and leaves them green. That was verified by doing it:

```
× points the seed itself at the server .env names
AssertionError: expected 'Error seeding database: AggregateErro…' to contain 'nowhere.invalid'
Tests  1 failed | 4 passed (5)
```

Running the real seed is safe because connecting is not the destructive act — the seed issues its first statement only after `connect()` returns. `POSTGRES_URL` names a host under `.invalid`, which RFC 2606 guarantees never resolves, so the run dies at `getaddrinfo ENOTFOUND` in ~110ms and cannot reach any server. The whole file is 2.5s.

## Mutation pass

Eleven cases over both files. All nine that change where the seed points die:

| mutant | |
|---|---|
| the seed reads the environment inline again | killed |
| `\|\|` instead of `??` (an empty `POSTGRES_URL=` falls back — dotenv sets it to `''`, measured) | killed |
| `.env` never loaded | killed |
| `.env` overrides a shell export | killed |
| the default names port 5432 | killed |
| `SQLITE_PATH` quietly ignored | killed |
| the SQLite default anchored to the caller | killed |
| the SQLite default outside the repository | killed |
| the SQLite default inside `scripts/` | killed |
| bracket notation for the env reads | survives (same behaviour) |
| the default URL lifted into a named const | survives (same behaviour) |

## Conflicts to expect

- `vitest.config.ts` — `backendTestPatterns` gains `'scripts/**/*.test.ts'`. Three-way overlap with #157 and #158, which touch the same array.
- `scripts/seed.ts` — one import line. Overlaps #158.

## Known gaps, deliberately left

- **`scripts/` is typechecked by neither tsconfig project**, so `yarn typecheck` never looks at either new file. Both are clean under a scratch strict config; the only error in the directory is the pre-existing `scripts/generate-icons.ts(35,9): Cannot find name 'Bun'`. Closing this properly means adding `@types/bun` or an exclude, which belongs with #161.
- **A bad `SQLITE_PATH` is not actionable.** Pointing it at a missing directory gets `ConnectionFailed("… : 14")` — `SQLITE_CANTOPEN`, with nothing naming `SQLITE_PATH` or `.env`. Reachable before this change via a shell export, but newly likely now that `.env` decides it. Filed separately rather than widened into this PR.
- `todo.md:413` claims `SQLITE_PATH` is "used by `src/database/index.ts`". It is not — that module reads no environment variable. Pre-existing and untouched.

## Gates

`eslint` clean · both `tsc` projects clean · `prettier --check --end-of-line auto` clean · `fallow` 0 above threshold · full suite 956 passed, 1 failed — `src/databases/sqlite-adapter.test.ts > connects and executes SELECT 1`, which fails on `main` too.
