### PR TITLE
refactor(queries): drop the duplicated truncated flag

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -149,7 +149,6 @@ describe('running a query', () => {
         id: 'q-1',
         queriedAt: 1,
         result: null,
-        truncated: false,
         worksheetId: 'ws-1'
       }
     })

--- a/src/app/api-client.test.ts
+++ b/src/app/api-client.test.ts
@@ -109,7 +109,6 @@ const queryDto: QueryDto = {
   id: 'query-1',
   queriedAt: 1704067200000,
   result: null,
-  truncated: false,
   worksheetId: 'ws-123'
 }
 

--- a/src/app/components/DatabaseExplorer.test.tsx
+++ b/src/app/components/DatabaseExplorer.test.tsx
@@ -476,7 +476,6 @@ describe('DatabaseExplorer', () => {
           id: 'q-1',
           queriedAt: 1704067200000,
           result: null,
-          truncated: false,
           worksheetId: 'ws-users'
         }
       })

--- a/src/app/components/QueryResultContent.test.tsx
+++ b/src/app/components/QueryResultContent.test.tsx
@@ -22,7 +22,6 @@ const baseQuery: QueryDto = {
   id: 'query-1',
   queriedAt: 1000,
   result: null,
-  truncated: false,
   worksheetId: 'worksheet-1'
 }
 

--- a/src/app/components/ResultsPane.test.tsx
+++ b/src/app/components/ResultsPane.test.tsx
@@ -17,7 +17,6 @@ function query(overrides: Partial<QueryDto> = {}): QueryDto {
     id: 'q-1',
     queriedAt: 1000,
     result: null,
-    truncated: false,
     worksheetId: 'ws-1',
     ...overrides
   }

--- a/src/app/components/StatusBar.test.tsx
+++ b/src/app/components/StatusBar.test.tsx
@@ -1,0 +1,134 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { SchemaInfo } from '@/databases/adapter'
+import type { QueryDto, UpdateStatusResponse } from '@/glue/api/schemas'
+
+import { renderWithProviders } from '../test-utils'
+import { StatusBar } from './StatusBar'
+
+// `StatusBar` mounts `useServerVersion` and `UpdateIndicator`, and both fetch.
+// Seeded here so they read the cache instead: unseeded they are six real
+// requests to `127.0.0.1:7847`, which is the port `yarn start` binds — measured
+// by listening on it. They resolve to nothing this file asserts on, so all
+// three cases pass either way; what it costs is two `RequestError` stack traces
+// printed above the assertion diff whenever one of them does fail.
+const schema: SchemaInfo = { databaseName: 'pagila', tables: [] }
+const updateStatus: UpdateStatusResponse = {
+  currentVersion: '1.2.0',
+  lastCheckedAt: 1_700_000_000_000,
+  message: 'Updates are only available in a packaged build.',
+  releaseNotesUrl: null,
+  state: 'unsupported',
+  version: null
+}
+
+/**
+ * A row count as the reader's own machine would render it.
+ *
+ * Spelled this way rather than as a literal because the component formats for
+ * the ambient locale, and not every locale writes ASCII digits — `ar-EG` gives
+ * `١٠٠`, `fa-IR` `۱۰۰`. A hard-coded `'100'` turns these red on a machine set
+ * to one of them, and nothing in the vitest setup pins a locale.
+ */
+function count(value: number): string {
+  return new Intl.NumberFormat().format(value)
+}
+
+function query(overrides: Partial<QueryDto> = {}): QueryDto {
+  return {
+    content: 'SELECT * FROM film',
+    databaseId: 'db-1',
+    error: null,
+    finishedAt: 3373,
+    id: 'q-1',
+    queriedAt: 1000,
+    result: {
+      fields: [{ name: 'title' }],
+      rowCount: 100,
+      rows: [{ title: 'Alien' }],
+      truncated: false
+    },
+    worksheetId: 'ws-1',
+    ...overrides
+  }
+}
+
+function renderStatusBar(current: QueryDto): void {
+  renderWithProviders(
+    <StatusBar
+      cursorPosition={undefined}
+      databaseId="db-1"
+      databaseName="Pagila"
+      query={current}
+      saveState="saved"
+    />,
+    { schemas: { 'db-1': schema }, updateStatus }
+  )
+}
+
+// The row count in the status bar is the only place a truncated result says so
+// once the results pane has scrolled away, and `+` is the whole of the saying.
+// Without it the reader is told the query returned exactly 100 rows when the
+// driver stopped counting at 100 — a number they may go on to trust.
+//
+// Truncation reaches here through `query.result.truncated`, which is now the
+// only place it is carried; the copy `QueryDto` used to hold beside the result
+// had no readers and is gone. These cases are what stop the remaining one from
+// being dropped or inverted unnoticed.
+//
+// Scoped to the row-count summary. The connection-health dot, its tooltips and
+// the save-state label share this component and are covered by nothing — each
+// can be replaced with a constant and every case below stays green.
+describe('StatusBar', () => {
+  it('marks a truncated row count so the number is not read as a total', () => {
+    renderStatusBar(
+      query({
+        result: {
+          fields: [{ name: 'title' }],
+          rowCount: 100,
+          rows: [{ title: 'Alien' }],
+          truncated: true
+        }
+      })
+    )
+
+    expect(
+      screen.getByText(`${count(100)}+ rows in 2.37 s`)
+    ).toBeInTheDocument()
+  })
+
+  it('leaves a complete row count unmarked', () => {
+    renderStatusBar(query())
+
+    expect(screen.getByText(`${count(100)} rows in 2.37 s`)).toBeInTheDocument()
+  })
+
+  // Seven digits because every CLDR locale groups them — swept all 110 the
+  // runtime carries, and none leaves 1234567 bare. Four would not do: a dozen
+  // locales, Spanish and Italian among them, write 1234 unseparated.
+  //
+  // Two assertions rather than one. The absence catches a count printed
+  // straight through `String()`; the presence catches one that is formatted but
+  // no longer the number — `notation: 'compact'` renders `1.2M`, which the
+  // absence alone waves through.
+  it('groups a large row count so the digits can be read', () => {
+    renderStatusBar(
+      query({
+        result: {
+          fields: [{ name: 'title' }],
+          rowCount: 1234567,
+          rows: [{ title: 'Alien' }],
+          truncated: false
+        }
+      })
+    )
+
+    const summary = screen.getByText(/rows in 2\.37 s$/).textContent
+
+    expect({
+      grouped: summary?.includes(count(1234567)),
+      ungrouped: summary?.includes('1234567')
+    }).toEqual({ grouped: true, ungrouped: false })
+  })
+})

--- a/src/app/hooks/queries.test.tsx
+++ b/src/app/hooks/queries.test.tsx
@@ -29,7 +29,6 @@ const runningQuery: QueryDto = {
   id: 'q-1',
   queriedAt: 1,
   result: null,
-  truncated: false,
   worksheetId: 'ws-1'
 }
 

--- a/src/app/hooks/use-start-query.test.tsx
+++ b/src/app/hooks/use-start-query.test.tsx
@@ -50,7 +50,6 @@ describe('useStartQuery', () => {
         id: 'q-1',
         queriedAt: 1,
         result: null,
-        truncated: false,
         worksheetId: 'ws-1'
       }
     })

--- a/src/app/hooks/use-start-query.ts
+++ b/src/app/hooks/use-start-query.ts
@@ -38,7 +38,6 @@ function createOptimisticQuery(input: StartQueryInput): QueryDto {
     id: v7(),
     queriedAt: Date.now(),
     result: null,
-    truncated: false,
     worksheetId: input.worksheetId ?? ''
   }
 }

--- a/src/app/hooks/use-worksheet-messages.test.ts
+++ b/src/app/hooks/use-worksheet-messages.test.ts
@@ -17,7 +17,6 @@ function query(overrides: Partial<QueryDto> = {}): QueryDto {
     id: 'q-1',
     queriedAt: 1000,
     result: null,
-    truncated: false,
     worksheetId: 'ws-1',
     ...overrides
   }

--- a/src/glue/api/schemas.ts
+++ b/src/glue/api/schemas.ts
@@ -260,7 +260,6 @@ const QueryDto = Schema.Struct({
   id: Schema.String,
   queriedAt: Schema.Number,
   result: Schema.NullOr(QueryResultDto),
-  truncated: Schema.Boolean,
   worksheetId: Schema.String
 })
 export type QueryDto = Schema.Schema.Type<typeof QueryDto>

--- a/src/server/services/query-runner.ts
+++ b/src/server/services/query-runner.ts
@@ -503,7 +503,6 @@ function transformQueryRow(row: QueryRow): QueryDto {
     id: row.id,
     queriedAt: row.queriedAt,
     result: parsed,
-    truncated: parsed?.truncated ?? false,
     worksheetId: row.worksheetId
   }
 }


### PR DESCRIPTION
Closes the independently-shippable half of #74 — the half the issue itself
heads `## Ship this part first (independent, near-zero risk)`, and the half
#91 names as its prerequisite.

`QueryDto` carried `truncated` beside a `result` that carries its own, so the
two could disagree and nothing decided which was right. The outer one had no
readers.

## Why it is safe to delete

- There is no `truncated` column on the `queries` table — the outer field was
  derived per response in `transformQueryRow`, so no stored row, no older
  version's data and no migration is affected.
- Deleting the field makes the compiler name **10 sites, every one a `TS2353`
  on an object literal** — that is, only ever a write. Deleting the nested
  flag names 14, three of which are reads in the code that renders it.
- The one apparent counter-example, `query.truncated`, is the span attribute
  *key string* at `query-runner.ts:165`. Untouched, still emitting.

## Most of the diff is a test that did not exist

A control probe flipped each of the three surviving readers of the nested
flag. `use-worksheet-messages.ts` failed 5 tests and `ResultsPane.tsx` failed
2 — but `StatusBar.tsx` matched the baseline exactly. The `+` that tells the
reader 100 is a floor rather than a total could be dropped or inverted in
silence, and there was no `StatusBar.test.tsx` at all.

The new file goes red against a marker that is inverted, dropped, always on
or reading the row count instead of the flag; against a swapped singular and
plural; and against a count printed unformatted, grouped off, or abbreviated
to `1.2M`. An explicit `=== true`, or an `if` instead of a ternary, survives.

Two deliberate choices in it, both measured rather than assumed:

- It formats expected counts through `Intl.NumberFormat` instead of writing
  `100`, because the component formats for the ambient locale. Shimming the
  default to `ar-EG` (`١٠٠`) failed two of the three cases when they were
  spelled as literals.
- It seeds `renderWithProviders`. `StatusBar` mounts `useServerVersion` and
  `UpdateIndicator`, and unseeded the file made **six live requests to
  127.0.0.1:7847** — the port `yarn start` binds. Measured by listening on
  it: six before, none after. It was the only test in the repo doing real
  network I/O.

## Scope

The file covers the row-count summary only. The connection-health dot, its
tooltips and the save-state label share the component and are still covered
by nothing — a note in the file says so, rather than leaving the filename to
imply otherwise.

`Refs #74`, not `Closes`: the issue's `Schema.Union` half is still open, and
it carries the "canceled is a state that exists nowhere in the type" analysis
plus the sequencing contract #91 depends on. Auto-closing would take those
with it.

## Notes for review

- Overlaps PR #155 on `mutations.ts` / `queries.ts`.
- Gates clean; suite 954 passed with the one pre-existing
  `sqlite-adapter.test.ts` URL failure that is byte-identical to `main`.
