### PR TITLE
chore(test): lift the database mock to module scope

### DIFF
--- a/src/main/queries/query-retention.test.ts
+++ b/src/main/queries/query-retention.test.ts
@@ -1,13 +1,10 @@
 import { sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import { deleteExpiredQueries } from './query-retention'
 

--- a/src/main/queries/reconcile-queries.test.ts
+++ b/src/main/queries/reconcile-queries.test.ts
@@ -1,13 +1,10 @@
 import { sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import {
   interruptedQueryMessage,

--- a/src/main/tracing/span-writer.test.ts
+++ b/src/main/tracing/span-writer.test.ts
@@ -1,12 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import { spansTable } from '@/database/schema'
 import { SpanRecord } from '@/glue/tracing/spans'

--- a/src/main/tracing/trace-retention.test.ts
+++ b/src/main/tracing/trace-retention.test.ts
@@ -1,12 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from '@/test/api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
 
 import { spansTable } from '@/database/schema'
 import { generateSpanId, generateTraceId } from '@/glue/tracing/ids'

--- a/src/test/api-test-helper.test.ts
+++ b/src/test/api-test-helper.test.ts
@@ -2,13 +2,10 @@ import { getTableName } from 'drizzle-orm'
 import invariant from 'tiny-invariant'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  getTestDatabase,
-  resetTestDatabase,
-  setupApiMocks
-} from './api-test-helper'
-
-setupApiMocks()
+// Above the imports below it, not merely near them: the `@/database` mock
+// registers as this module is evaluated, and anything evaluated first misses
+// it. See the note in the helper.
+import { getTestDatabase, resetTestDatabase } from './api-test-helper'
 
 import { appTables } from '@/database/app-tables'
 import { database } from '@/database'

--- a/src/test/api-test-helper.ts
+++ b/src/test/api-test-helper.ts
@@ -14,29 +14,31 @@ import { createTables } from '@/database/tables'
 // The database every mocked reader sees, replaced on each reset.
 let testDatabase: LibSQLDatabase
 
-/**
- * Point `@/database` at a test database.
- *
- * Import this module *above* the modules under test. The `vi.mock` registers
- * when this module is evaluated, so anything imported before it binds to the
- * real `@/database` — and that fails silently rather than loudly:
- * `src/database/index.ts` builds its drizzle instance eagerly against
- * `process.cwd()/squeal.sqlite3`, so the test would quietly read and write the
- * developer's own database instead of an empty one.
- *
- * Where the call sits does not matter; vitest hoists the `vi.mock` above
- * everything in this module regardless.
- */
-export function setupApiMocks() {
-  // A getter, not a value: a module that imports `database` does so before the
-  // first `resetTestDatabase()` has run, and has to keep seeing the current one
-  // afterwards.
-  vi.mock('@/database', () => ({
-    get database() {
-      return testDatabase
-    }
-  }))
-}
+// Registered on import, which is also the only thing that decides whether it
+// works. Import this module *above* the modules under test: anything evaluated
+// before it binds to the real `@/database`, which `src/database/index.ts`
+// builds eagerly against `process.cwd()/squeal.sqlite3`. The test then reads
+// and writes the developer's own database instead of an empty one.
+//
+// It does not go quiet about it — `resetTestDatabase()` only replaces the
+// in-memory database, so rows pile up across cases and the counts stop
+// matching. Measured on `trace-retention.test.ts`: misordered, all three cases
+// fail. But they fail on a count, naming neither the import order nor the file
+// that has by then appeared in the repository root, and the first case passes
+// while writing to it.
+//
+// `database-mock-import-order.test.ts` makes the mistake on purpose, so this
+// paragraph stays something the suite checks rather than something a comment
+// asserts.
+//
+// A getter, not a value: a module that imports `database` does so before the
+// first `resetTestDatabase()` has run, and has to keep seeing the current one
+// afterwards.
+vi.mock('@/database', () => ({
+  get database() {
+    return testDatabase
+  }
+}))
 
 /** A fresh in-memory database. Call this in `beforeEach` for test isolation. */
 export async function resetTestDatabase(): Promise<void> {

--- a/src/test/database-mock-import-order.test.ts
+++ b/src/test/database-mock-import-order.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Above the helper on purpose. This is the mistake the notes in the five call
+// sites warn about, made here so the warning stays something the suite can
+// check rather than something a comment asserts.
+import { database } from '@/database'
+
+import { getTestDatabase, resetTestDatabase } from '@/test/api-test-helper'
+
+// `@/database` builds its drizzle instance as it is evaluated, against
+// `process.cwd()/squeal.sqlite3` outside Electron — which is why importing it
+// for real is normally the thing to avoid. Pointed at `:memory:` instead, so
+// this file can import it and still write nothing. What is under test is which
+// instance a module ends up bound to, not where that instance points.
+vi.mock('@/database/path', () => ({ databaseFilePath: ':memory:' }))
+
+// Identity, not shape: both are drizzle instances over an empty database and
+// compare equal on every field. Which object it is, is the whole question.
+describe('the @/database mock', () => {
+  it('misses a module evaluated before the helper registered it', async () => {
+    await resetTestDatabase()
+
+    expect(database).not.toBe(getTestDatabase())
+  })
+})


### PR DESCRIPTION
Closes #165. **Stacks on #164** — based on `refactor/trim-api-test-helper`, so
review that one first.

`api-test-helper.ts` registered its `@/database` mock inside an exported
`setupApiMocks()`. Vitest hoisted it out anyway and said so on every run:

> it will be hoisted and executed before any tests run … This will become an
> error in a future version.

So the call never did anything. What actually decides whether the mock applies
is where the *import* of the helper sits — and `setupApiMocks()` sitting
between two import blocks read as the line drawing that boundary. Warning
count: **1 per suite run → 0**.

## The issue's either/or

#165 weighed deleting `setupApiMocks()` against keeping it as a marker, and
worried a bare side-effect import invites a future editor to delete it. That
worry does not apply: all five call sites already import `getTestDatabase` or
`resetTestDatabase` by name, so nothing becomes side-effect-only.

## What the notes claim, and what is actually true

The first draft of this change said the misordering fails *silently*. It does
not, and the notes now say what it really does. Misordering
`trace-retention.test.ts` fails all three of its cases — `resetTestDatabase()`
replaces only the in-memory database, so rows accumulate and the counts stop
matching.

What it does not do is explain itself. The failure names a count, not the
import order, and not the `squeal.sqlite3` that has by then appeared in the
repository root. The first case passes while writing to it.

## The ordering rule now has a test

The first draft also claimed a test was impossible, because testing it means
importing the real `@/database`. That was wrong: the unsafe part is not
`@/database`, it is `src/database/path.ts` resolving to
`process.cwd()/squeal.sqlite3`. Mock that one module to `:memory:` and the
real import is harmless.

`src/test/database-mock-import-order.test.ts` makes the mistake on purpose and
asserts the two databases are different objects. Written in the *safe* order
instead it fails — which is what says the assertion has teeth — and it leaves
no file behind either way.

## Notes for review

- Mutation coverage comes from `api-test-helper.test.ts` (added in #164):
  removing the `vi.mock`, snapshotting a value instead of exposing a getter,
  a fresh database on every read, a reset that keeps the previous database,
  and a table-less test database are all killed. An explicit-return factory
  survives.
- `spans-table.test.ts` gets no note deliberately — it never imports
  `@/database`.
- **Pre-existing, not from this PR:** a full run still leaves a 0-byte
  `squeal.sqlite3` in the root, via `app-database.ts` reaching `@/database` in
  the backend project. Untouched here; identical on the parent commit.
- Gates clean; suite 955 passed with the known `sqlite-adapter` URL failure.
