### PR TITLE
fix(seed): name the directory a bad SQLITE_PATH points into

### DIFF
--- a/scripts/seed-config.test.ts
+++ b/scripts/seed-config.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { createRequire } from 'module'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -110,12 +110,25 @@ function resolveTargets(overrides: Record<string, string> = {}): SeedTargets {
 }
 
 /** Run the seed itself, from `directory`, and return everything it said. */
-function runSeed(): string {
+function runSeed(overrides: Record<string, string>): string {
+  // Structural rather than per-case. With nothing setting `SQLITE_PATH` the
+  // seed falls back to the repository's own `seed-sqlite/pagila.sqlite` — the
+  // developer's sample database, which `seedSqlite` deletes before it writes.
+  // One case here that forgets to point it somewhere else is enough to lose
+  // that file, and the case would still pass.
+  const target = resolveTargets(overrides).sqlitePath
+
+  if (!resolve(directory, target).startsWith(resolve(directory))) {
+    throw new Error(
+      `This case would run the seed against '${target}', which is outside the temporary directory it was given. Point SQLITE_PATH — in the case's \`.env\` or in its overrides — at a path under it.`
+    )
+  }
+
   try {
     execFileSync(process.execPath, [tsxCli, seedScript], {
       cwd: directory,
       encoding: 'utf-8',
-      env: childEnvironment({ SQLITE_PATH: join(directory, 'pagila.sqlite') }),
+      env: childEnvironment(overrides),
       stdio: 'pipe',
       timeout: 60_000
     })
@@ -223,6 +236,100 @@ describe('the seed targets', () => {
       `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`
     )
 
-    expect(runSeed()).toContain(unreachableHost)
+    expect(
+      runSeed({ SQLITE_PATH: join(directory, 'pagila.sqlite') })
+    ).toContain(unreachableHost)
+  })
+
+  // `14` is `SQLITE_CANTOPEN`, and the message libsql raises says only that:
+  // no mention of `SQLITE_PATH`, of `.env`, or of the directory being the
+  // thing that is missing. The reader has to know libsql's error codes are
+  // SQLite's and go look up the number.
+  //
+  // The check runs before `seedPostgres`, which is why the Postgres in this
+  // `.env` is one that cannot resolve and the assertion says the output does
+  // not mention it. Config that is wrong should be caught before the seed
+  // drops a schema, not after.
+  it('names SQLITE_PATH when the directory it points into is missing', () => {
+    const missingDirectory = join(directory, 'no-such-dir')
+    const missingPath = join(missingDirectory, 'pagila.sqlite')
+
+    writeDotEnv(
+      `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`,
+      `SQLITE_PATH=${missingPath}`
+    )
+
+    const output = runSeed({})
+
+    expect({
+      beforeTouchingPostgres: !output.includes(unreachableHost),
+      // Quoted on its own, not merely present. The path the seed would have
+      // written starts with the missing directory, so a message naming only
+      // that path already contains it as a substring while leaving the reader
+      // to work out which segment is the part that is not there. Only a
+      // message that names the directory by itself closes the quote here.
+      namesTheDirectory: output.includes(`'${missingDirectory}'`),
+      namesTheSource: output.includes('SQLITE_PATH'),
+      // A phrase, which is as close as a test gets to "the message says what
+      // to do about it": there is no shape to look for, only the instruction
+      // itself. So rewording it turns this red even when the rewording is an
+      // improvement — a cost taken knowingly, because the alternative is a
+      // message that can quietly stop saying anything actionable.
+      saysWhatToDo: output.includes('Create the directory')
+    }).toEqual({
+      beforeTouchingPostgres: true,
+      namesTheDirectory: true,
+      namesTheSource: true,
+      saysWhatToDo: true
+    })
+  })
+
+  // `existsSync` answers for a file as readily as for a directory, so a
+  // `SQLITE_PATH` one segment too deep — the sample database itself taken for
+  // the directory to put it in — walks straight past the check and reaches
+  // libsql, which fails with the bare `14` the check exists to replace.
+  it('names SQLITE_PATH when what it points into is a file', () => {
+    const file = join(directory, 'not-a-directory')
+
+    writeFileSync(file, '', 'utf-8')
+    writeDotEnv(
+      `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`,
+      `SQLITE_PATH=${join(file, 'pagila.sqlite')}`
+    )
+
+    const output = runSeed({})
+
+    expect({
+      beforeTouchingPostgres: !output.includes(unreachableHost),
+      namesTheSource: output.includes('SQLITE_PATH'),
+      namesWhatIsWrong: output.includes(file)
+    }).toEqual({
+      beforeTouchingPostgres: true,
+      namesTheSource: true,
+      namesWhatIsWrong: true
+    })
+  })
+
+  // `.env.example` ships a relative `SQLITE_PATH` and `.env` is read from the
+  // working directory, so relative is the shape a developer most likely has.
+  // Printed back as written, the message tells someone looking at a repository
+  // that visibly contains `seed-sqlite/` that `./seed-sqlite` does not exist,
+  // and never says what `./` was resolved against — the same complaint the
+  // check makes of libsql, in the other direction.
+  it('resolves a relative SQLITE_PATH before naming the directory', () => {
+    writeDotEnv(
+      `POSTGRES_URL=postgresql://postgres:postgres@${unreachableHost}:5433/squeal`,
+      'SQLITE_PATH=./no-such-dir/pagila.sqlite'
+    )
+
+    const output = runSeed({})
+
+    expect({
+      beforeTouchingPostgres: !output.includes(unreachableHost),
+      namesTheResolvedDirectory: output.includes(join(directory, 'no-such-dir'))
+    }).toEqual({
+      beforeTouchingPostgres: true,
+      namesTheResolvedDirectory: true
+    })
   })
 })

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,8 +1,8 @@
 import { createClient } from '@libsql/client'
 import { execSync } from 'child_process'
-import { existsSync, unlinkSync } from 'fs'
+import { existsSync, statSync, unlinkSync } from 'fs'
 import { readdir, readFile } from 'fs/promises'
-import { join } from 'path'
+import { dirname, join, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import { Client } from 'pg'
 
@@ -109,8 +109,50 @@ async function seedSqlite() {
   }
 }
 
+/**
+ * Fail on a SQLite target the seed cannot write into.
+ *
+ * Checked here rather than in `seedSqlite()`, where the path is finally used,
+ * because everything between the two drops and recreates a schema — a typo in
+ * `.env` is worth catching while the developer's Postgres is still intact.
+ *
+ * Left to the driver, the seed dies on `createClient` with
+ * `ConnectionFailed("Unable to open connection to local database
+ * /C:/…/no-such-dir/pagila.sqlite: 14")` — a numeric code, a path wearing the
+ * leading slash `pathToFileURL` gave it on Windows, and no mention of either
+ * the setting that chose it or which part of it does not exist.
+ *
+ * The configured path is quoted as it was written and the directory as it
+ * resolved, because those are two different things whenever `SQLITE_PATH` is
+ * relative — which is the shape `.env.example` ships. Told only that
+ * `./seed-sqlite` does not exist, a reader looking at a repository that
+ * visibly contains `seed-sqlite/` learns nothing.
+ */
+function checkSqliteDirectory() {
+  const directory = resolve(dirname(sqlitePath))
+  const status = statSync(directory, { throwIfNoEntry: false })
+
+  if (status?.isDirectory() === true) {
+    return
+  }
+
+  // `existsSync` alone would pass a file here, and the seed would go on to ask
+  // libsql to open a database under it — the same bare `14`, for a path that
+  // looks present.
+  const problem =
+    status === undefined
+      ? `its directory '${directory}' does not exist`
+      : `'${directory}' is a file, not the directory it would have to be`
+
+  throw new Error(
+    `The SQLite database is set to go to '${sqlitePath}', but ${problem}. Create the directory, or point SQLITE_PATH — from .env, or from your shell if you exported it there — at one that already exists.`
+  )
+}
+
 async function seed() {
   try {
+    checkSqliteDirectory()
+
     await seedPostgres()
     await seedMysql()
     await seedSqlite()


### PR DESCRIPTION
Closes #169 (the first half; see "Left open" below).

## The problem

Point `SQLITE_PATH` at a directory that does not exist and `yarn seed` dies inside libsql:

```
ConnectionFailed("Unable to open connection to local database /C:/…/no-such-dir/pagila.sqlite: 14")
```

`14` is `SQLITE_CANTOPEN` — a SQLite code libsql passes straight through, so the reader has to know that to look it up. The path wears the leading slash `pathToFileURL` gave it on Windows, so it does not match what is in `.env`. And nothing says the missing part is the *directory*, or that `SQLITE_PATH` is what chose it.

Verified rather than assumed: a probe against the real `@libsql/client` reproduces that string verbatim, and confirms it is thrown at `createClient`, not at execute.

## The change

`scripts/seed.ts` checks the target before `seedPostgres()` runs — not in `seedSqlite()` where the path is finally used, because everything in between drops and recreates a schema, and a typo in `.env` is worth catching while the developer's Postgres is still intact.

```
The SQLite database is set to go to './seed-sqlite/pagila.sqlite', but its
directory 'C:\work\squeal\seed-sqlite' does not exist. Create the directory,
or point SQLITE_PATH — from .env, or from your shell if you exported it there
— at one that already exists.
```

Three details the obvious version gets wrong:

- **`existsSync` accepts a file.** A `SQLITE_PATH` one segment too deep — the sample database itself taken for the directory to put it in — passes that check and reaches libsql for the same bare `14`. `statSync().isDirectory()` is what actually asks the question, and gets its own branch in the message.
- **`dirname` of a relative path is relative**, and relative is the shape `.env.example` ships. Printed back as written, the message tells someone looking at a repository that visibly contains `seed-sqlite/` that `./seed-sqlite` does not exist, and never says what `./` resolved against. The configured path is now quoted as written, the directory as resolved.
- **dotenv leaves an already-set variable alone.** Told flatly to edit `.env`, someone who exported `SQLITE_PATH` in their shell edits it, re-runs, and gets the identical error. The message names `.env` as one possible source rather than the only one.

## Tests

Three cases in `scripts/seed-config.test.ts`, each running the real `scripts/seed.ts` in a temporary directory against an RFC 2606 `.invalid` Postgres host: a missing directory, a directory that is really a file, and a relative path.

`runSeed` now refuses to run a case whose effective `SQLITE_PATH` resolves outside that temporary directory. It used to pass one in as an environment override on every call, which beat `.env` unconditionally; now that cases set it in `.env` instead, that protection had quietly become something each case has to remember — and the fallback target is the developer's own `seed-sqlite/pagila.sqlite`, which `seedSqlite` deletes before writing. Probed by deleting the setting from a case: it stops with that path named rather than seeding over it.

Mutation-checked: eight mutants that should fail a case do (check absent; check moved after `seedPostgres`; a file accepted for the directory; the directory named as written rather than as resolved; the condition inverted; the setting name dropped; the whole path named where the directory alone was needed; the instruction dropped). Two that should not, do not (the file branch reworded; the directory resolved in two steps).

`tsc` (both projects), `eslint`, `prettier` and `vitest run` are clean apart from the pre-existing `src/databases/sqlite-adapter.test.ts:100` Windows path failure, which is byte-identical on `main`.

## Based on #168

This branch sits on `chore/seed-honours-dotenv`, because the check is only reachable once the seed reads `.env` at all. Merge that one first.

## Left open

- **The other half of #169.** dotenv drops a malformed `.env` line without saying so, and *does* expand escapes inside a double-quoted value — `SQLITE_PATH="C:\tmp\no-such-dir\p.sqlite"` parses to `C:\tmp`, a literal newline, then `o-such-dir\p.sqlite`. Different mechanism, separate fix. The new message at least prints the corrupted path.
- **`scripts/` is in neither `tsc` project.** `tsconfig.backend.json` covers `src/glue` and `src/server`; `tsconfig.renderer.json` covers `src`. Nothing in CI typechecks the file this PR changes — confirmed by planting a type error and watching both projects and eslint pass. Pre-existing, and growing.
- **A config error prints a stack.** `console.error('Error seeding database:', error)` puts the actionable sentence above ten frames of `tsx`/`node:internal` noise. Worth separating a configuration failure from a real one.
- **`execFileSync`'s `timeout: 60_000` exceeds vitest's `testTimeout: 20000`**, so it can never fire. Inherited from #168.
