### PR TITLE
fix(main): stop a window opening over a backend that is shutting down

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,65 +1,170 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+// @vitest-environment node
+import { Exit } from 'effect'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const {
-  mockAppOn,
-  mockGetAllWindows,
-  mockIpcHandle,
-  mockBrowserWindowConstructor
-} = vi.hoisted(() => ({
-  mockAppOn: vi.fn(),
-  mockGetAllWindows: vi.fn(),
-  mockIpcHandle: vi.fn(),
-  mockBrowserWindowConstructor: vi.fn()
+// `src/main.ts` is a script, not a module: importing it registers every ipc
+// handler and every `app` event listener as a side effect, and there is no
+// exported function to call instead. So the way to drive it is to import it and
+// then fire the listeners it registered — which is what `fire` below does, and
+// why every case re-imports it through `vi.resetModules()` for a fresh set of
+// module-level lifecycle values.
+const electron = vi.hoisted(() => ({
+  errorBoxes: 0,
+  exits: [] as number[],
+  hasSingleInstanceLock: true,
+  ipcHandlers: new Map<string, (...args: never[]) => unknown>(),
+  listeners: new Map<string, Array<(...args: never[]) => unknown>>(),
+
+  // What `BrowserWindow.getAllWindows()` answers. The constructor deliberately
+  // does not add to it: `windows` counts what the app built, this says what the
+  // app currently has, and the cases that matter are the ones where those two
+  // differ — a dock click on an app whose last window is already closed.
+  openWindows: [] as FakeWindow[],
+  preventedQuits: 0,
+  windows: 0
 }))
 
-vi.mock('electron', () => {
-  class BrowserWindow {
-    webContents = {
-      on: vi.fn(),
-      setWindowOpenHandler: vi.fn()
-    }
+// The runtime is the app's whole backend — the layer graph, the app database,
+// the HTTP server. None of it is what these cases are about: they are about
+// which of `main.ts`'s lifecycle branches runs. Both of its methods are
+// therefore stubs the case drives directly, so that "the backend is still
+// booting" and "shutdown is wedged" become states a test can hold open.
+const backend = vi.hoisted(() => ({
+  boot: undefined as (() => Promise<unknown>) | undefined,
+  dispose: undefined as (() => Promise<void>) | undefined,
+  disposeCalls: 0,
+  runtimes: 0
+}))
 
-    static getAllWindows = mockGetAllWindows
+const logger = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn()
+}))
 
-    constructor(options: unknown) {
-      mockBrowserWindowConstructor(options)
-    }
-
-    loadFile = vi.fn()
-    loadURL = vi.fn()
-  }
-
-  return {
-    app: {
-      commandLine: { appendSwitch: vi.fn() },
-      exit: vi.fn(),
-      getAppPath: () => '/app',
-      getPath: () => '/tmp',
-      isPackaged: false,
-      on: mockAppOn,
-      quit: vi.fn(),
-      requestSingleInstanceLock: () => true
+vi.mock('electron', () => ({
+  app: {
+    commandLine: { appendSwitch: () => undefined },
+    dock: undefined,
+    exit: (code: number) => {
+      electron.exits.push(code)
     },
-    BrowserWindow,
-    dialog: { showErrorBox: vi.fn(), showOpenDialog: vi.fn() },
-    ipcMain: { handle: mockIpcHandle },
-    shell: { openExternal: vi.fn() }
-  }
-})
+    getAppPath: () => '/squeal',
+    getPath: () => '/squeal/temp',
+    isPackaged: false,
+    on: (event: string, listener: (...args: never[]) => unknown) => {
+      electron.listeners.set(event, [
+        ...(electron.listeners.get(event) ?? []),
+        listener
+      ])
+    },
+    quit: () => undefined,
+    requestSingleInstanceLock: () => electron.hasSingleInstanceLock
+  },
+  BrowserWindow: class {
+    static getAllWindows() {
+      return electron.openWindows
+    }
+
+    webContents = {
+      on: () => undefined,
+      setWindowOpenHandler: () => undefined
+    }
+
+    constructor() {
+      electron.windows += 1
+    }
+
+    loadFile() {
+      return undefined
+    }
+
+    loadURL() {
+      return undefined
+    }
+  },
+  dialog: {
+    showErrorBox: () => {
+      electron.errorBoxes += 1
+    },
+    showOpenDialog: () => Promise.resolve({ canceled: true, filePaths: [] })
+  },
+  ipcMain: {
+    handle: (channel: string, handler: (...args: never[]) => unknown) => {
+      electron.ipcHandlers.set(channel, handler)
+    }
+  },
+  shell: { openExternal: () => Promise.resolve() }
+}))
 
 vi.mock('electron-squirrel-startup', () => ({ default: false }))
 
-vi.mock('./server/runtime', () => ({
-  makeMainRuntime: vi.fn()
+// A boot failure writes its stack to a file under `app.getPath('temp')`, which
+// is a directory this fake `app` invents. Left real, the write is the one thing
+// in here that reaches the machine running the suite — and it throws when the
+// invented directory is not there, turning a case about the dialog into a case
+// about `ENOENT`.
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs')>()),
+  writeFileSync: () => undefined
 }))
 
-// Injected by the Forge Vite plugin at build time, so nothing defines them when
-// the module is imported directly. An empty dev-server URL is the packaged
-// shape, which is the one that does not need a running server to load.
-Object.assign(globalThis, {
-  MAIN_WINDOW_VITE_DEV_SERVER_URL: '',
-  MAIN_WINDOW_VITE_NAME: 'main_window'
-})
+vi.mock('tiny-typescript-logger', () => ({ log: logger }))
+
+vi.mock('./server/runtime', () => ({
+  makeMainRuntime: () => {
+    backend.runtimes += 1
+
+    return {
+      dispose: () => {
+        backend.disposeCalls += 1
+
+        return backend.dispose?.() ?? Promise.resolve()
+      },
+      runPromiseExit: () => backend.boot?.() ?? Promise.resolve(Exit.void)
+    }
+  }
+}))
+
+/** Import a fresh `main.ts`, with its module-level lifecycle values reset. */
+async function importMain(): Promise<void> {
+  vi.resetModules()
+
+  await import('./main')
+}
+
+/**
+ * Call what `main.ts` registered for an `app` event.
+ *
+ * Returns the listener's own promise where it has one — the `ready` listener is
+ * `async`, and the point of several cases below is what it does *after* the
+ * boot it awaits comes back.
+ */
+function fire(event: string, ...args: unknown[]): unknown {
+  const listeners = electron.listeners.get(event)
+
+  if (listeners === undefined || listeners.length === 0) {
+    throw new Error(
+      `\`main.ts\` registered no listener for '${event}'. Registered: ${[...electron.listeners.keys()].join(', ')}.`
+    )
+  }
+
+  return listeners.map((listener) =>
+    (listener as (...values: unknown[]) => unknown)(...args)
+  )[0]
+}
+
+/** Call what `main.ts` registered for an ipc channel. */
+function ipc(channel: string): (...args: unknown[]) => unknown {
+  const handler = electron.ipcHandlers.get(channel)
+
+  if (handler === undefined) {
+    throw new Error(
+      `\`main.ts\` registered no handler for '${channel}'. Registered: ${[...electron.ipcHandlers.keys()].join(', ')}.`
+    )
+  }
+
+  return handler as (...args: unknown[]) => unknown
+}
 
 type FakeWindow = {
   close: ReturnType<typeof vi.fn>
@@ -73,10 +178,11 @@ type FakeWindow = {
   unmaximize: ReturnType<typeof vi.fn>
 }
 
-function createWindow(
+/** Give the app a window, and hand it back to assert on. */
+function openWindow(
   state: { maximized?: boolean; minimized?: boolean } = {}
 ): FakeWindow {
-  return {
+  const browserWindow: FakeWindow = {
     close: vi.fn(),
     focus: vi.fn(),
     isDestroyed: () => false,
@@ -87,56 +193,346 @@ function createWindow(
     restore: vi.fn(),
     unmaximize: vi.fn()
   }
+
+  electron.openWindows.push(browserWindow)
+
+  return browserWindow
 }
 
-// The registrations happen while the module body runs, so the import is what
-// produces them and it has to happen after the mocks are in place.
-async function bootMain(): Promise<void> {
-  vi.resetModules()
-
-  await import('./main')
+/** Let every already-settled promise run its continuation. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
 }
 
-function appHandler(event: string): () => void {
-  const registration = mockAppOn.mock.calls.find(([name]) => name === event)
-
-  if (!registration) {
-    throw new Error(`No handler was registered for the ${event} app event.`)
+/** The `before-quit` event, counting the times the quit was held. */
+function quitEvent(): { preventDefault: () => void } {
+  return {
+    preventDefault: () => {
+      electron.preventedQuits += 1
+    }
   }
-
-  return registration[1] as () => void
 }
 
-function ipcHandler(channel: string): () => void {
-  const registration = mockIpcHandle.mock.calls.find(
-    ([name]) => name === channel
-  )
+beforeEach(() => {
+  electron.errorBoxes = 0
+  electron.exits = []
+  electron.hasSingleInstanceLock = true
+  electron.ipcHandlers.clear()
+  electron.listeners.clear()
+  electron.openWindows = []
+  electron.preventedQuits = 0
+  electron.windows = 0
 
-  if (!registration) {
-    throw new Error(`No handler was registered for the ${channel} channel.`)
-  }
+  backend.boot = () => Promise.resolve(Exit.void)
+  backend.dispose = () => Promise.resolve()
+  backend.disposeCalls = 0
+  backend.runtimes = 0
 
-  return registration[1] as () => void
-}
+  logger.error.mockClear()
+  logger.warn.mockClear()
+
+  vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined)
+  vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+// The four things `main.ts` decides — open a window, hold a quit, dispose the
+// backend, exit the process — all read module-level lifecycle state, and each
+// of the cases below is a moment where two of those decisions overlap.
+describe('the app lifecycle', () => {
+  it('opens a window once the backend has booted', async () => {
+    await importMain()
+
+    await fire('ready')
+
+    expect(electron.windows).toEqual(1)
+  })
+
+  // The window is the case above, so it is not that windows are never made; it
+  // is that this one would be made over a backend already mid-`dispose()` and a
+  // few seconds from `app.exit(0)` — a window whose every request 500s or
+  // vanishes, for the moment it survives.
+  //
+  // The quit lands in the gap between the boot promise resolving and the
+  // continuation that reads it, which is why the boot here is held open across
+  // the quit rather than resolved before it.
+  it('opens no window when a quit arrives while the backend is still booting', async () => {
+    let finishBoot = (): void => undefined
+
+    backend.boot = () =>
+      new Promise((resolve) => {
+        finishBoot = () => {
+          resolve(Exit.void)
+        }
+      })
+
+    await importMain()
+
+    const ready = fire('ready')
+
+    fire('before-quit', quitEvent())
+    finishBoot()
+
+    await ready
+    await flush()
+
+    expect({
+      disposals: backend.disposeCalls,
+      exits: electron.exits,
+      windows: electron.windows
+    }).toEqual({ disposals: 1, exits: [0], windows: 0 })
+  })
+
+  // Both halves matter and they pull in opposite directions. Disposing twice
+  // would tear the same resources down under a shutdown already running; *not*
+  // preventing the second quit is worse, and is a bug this app has had — a
+  // second Cmd+Q, or `window-all-closed` firing `app.quit()`, completes the quit
+  // and kills the process mid-flush, which is the whole thing the handler is
+  // there to stop.
+  it('holds every quit signal that arrives during shutdown, and disposes once', async () => {
+    backend.dispose = () => new Promise(() => undefined)
+
+    await importMain()
+
+    await fire('ready')
+
+    fire('before-quit', quitEvent())
+    fire('before-quit', quitEvent())
+    fire('before-quit', quitEvent())
+
+    await flush()
+
+    expect({
+      disposals: backend.disposeCalls,
+      heldQuits: electron.preventedQuits
+    }).toEqual({ disposals: 1, heldQuits: 3 })
+  })
+
+  // The losing second instance quits before `ready`, so it never builds a
+  // runtime. Holding its quit would prevent a quit with nothing to shut down,
+  // and nothing would ever release it: the release is in the dispose callback
+  // that this path does not reach.
+  it('lets a quit through when there is no backend to shut down', async () => {
+    await importMain()
+
+    fire('before-quit', quitEvent())
+
+    await flush()
+
+    expect({
+      disposals: backend.disposeCalls,
+      exits: electron.exits,
+      heldQuits: electron.preventedQuits
+    }).toEqual({ disposals: 0, exits: [], heldQuits: 0 })
+  })
+
+  // A shutdown that never finishes must not hold the app open, so the exit is
+  // deliberate. What is missing is any way to tell it apart afterwards: the
+  // timeout and a clean shutdown reach the same `app.exit(0)` and say nothing,
+  // and a backend that wedges every time leaves no trace of having done so.
+  it('says so when the backend does not shut down in time, and exits anyway', async () => {
+    vi.useFakeTimers()
+
+    backend.dispose = () => new Promise(() => undefined)
+
+    await importMain()
+
+    await fire('ready')
+
+    fire('before-quit', quitEvent())
+
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect({
+      exits: electron.exits,
+      warnings: logger.warn.mock.calls.map(([message]) => message)
+    }).toEqual({
+      exits: [0],
+      warnings: [expect.stringContaining('did not shut down within 3000ms')]
+    })
+  })
+
+  // The same silence from the other side. A `dispose()` that rejects reaches
+  // the same `app.exit(0)`, and until it said something the rejection showed up
+  // only as an unhandled-rejection warning from a process already leaving —
+  // printed, if the terminal got to it at all, after the message about the exit.
+  it('says so when the backend errors while shutting down, and exits anyway', async () => {
+    backend.dispose = () =>
+      Promise.reject(new Error('the span writer is already closed'))
+
+    await importMain()
+
+    await fire('ready')
+
+    fire('before-quit', quitEvent())
+
+    await flush()
+
+    expect({
+      exits: electron.exits,
+      warnings: logger.warn.mock.calls.map(([message]) => message)
+    }).toEqual({
+      exits: [0],
+      warnings: [expect.stringContaining('the span writer is already closed')]
+    })
+  })
+
+  // The other half of the same branch, and the reason it cannot simply be
+  // silenced: a backend that genuinely failed to start leaves an app with no
+  // window and no explanation, so this one says so and goes.
+  it('reports a boot failure that is not a shutdown, and exits nonzero', async () => {
+    backend.boot = () => Promise.resolve(Exit.fail(new Error('port in use')))
+
+    await importMain()
+
+    await fire('ready')
+
+    expect({
+      dialogs: electron.errorBoxes,
+      exits: electron.exits,
+      windows: electron.windows
+    }).toEqual({ dialogs: 1, exits: [1], windows: 0 })
+  })
+
+  // A quit while the layer is still building interrupts the build, so the boot
+  // comes back a failure. Reported as one it raises a modal over an app already
+  // three seconds from `app.exit(0)` — a dialog nobody asked for, about a
+  // shutdown the user started, on a window that is about to disappear under it.
+  it('raises no dialog when the boot fails because the quit interrupted it', async () => {
+    let failBoot = (): void => undefined
+
+    backend.boot = () =>
+      new Promise((resolve) => {
+        failBoot = () => {
+          resolve(Exit.fail(new Error('interrupted')))
+        }
+      })
+
+    await importMain()
+
+    const ready = fire('ready')
+
+    fire('before-quit', quitEvent())
+    failBoot()
+
+    await ready
+    await flush()
+
+    expect({ dialogs: electron.errorBoxes, exits: electron.exits }).toEqual({
+      dialogs: 0,
+      exits: [0]
+    })
+  })
+
+  // A dock click on macOS reaches `activate` whether or not the app is on its
+  // way out, and the last-window-closed app it is meant to revive looks exactly
+  // like the mid-quit one: no windows. Between `before-quit` and `app.exit(0)`
+  // there is a whole dispose budget for that click to land in, and the window it
+  // would open is the same doomed window the boot path now refuses to open.
+  it('opens no window when a dock click lands during shutdown', async () => {
+    backend.dispose = () => new Promise(() => undefined)
+
+    await importMain()
+
+    await fire('ready')
+
+    fire('before-quit', quitEvent())
+    fire('activate')
+
+    await flush()
+
+    expect(electron.windows).toEqual(1)
+  })
+
+  // The control for the case above: outside a shutdown the dock click is the
+  // only thing that brings a closed-down macOS app back, so refusing it always
+  // would be the worse bug.
+  it('opens a window when a dock click lands on a running app', async () => {
+    await importMain()
+
+    await fire('ready')
+
+    fire('activate')
+
+    expect(electron.windows).toEqual(2)
+  })
+
+  // `dispose()` is called outside the `try` on purpose — it has to start
+  // synchronously, inside the `before-quit` handler, because `quitAndInstall`
+  // depends on that. What that placement must not cost is the exit: a throw
+  // rather than a rejected promise would otherwise skip the `finally`, and the
+  // quit has already been prevented, so nothing is left to release it. The app
+  // would be unquittable by every means except killing it.
+  it('exits when the backend throws on its way down rather than rejecting', async () => {
+    backend.dispose = () => {
+      throw new Error('the runtime was already finalized')
+    }
+
+    await importMain()
+
+    await fire('ready')
+
+    fire('before-quit', quitEvent())
+
+    await flush()
+
+    expect(electron.exits).toEqual([0])
+  })
+
+  // The losing second instance quits on the lock, before anything is built.
+  // Booting here would give a second process its own handle on the one shared
+  // SQLite file and let it write through the moment before it goes away.
+  it('boots no backend when another instance already holds the lock', async () => {
+    electron.hasSingleInstanceLock = false
+
+    await importMain()
+
+    await fire('ready')
+
+    expect({
+      runtimes: backend.runtimes,
+      windows: electron.windows
+    }).toEqual({ runtimes: 0, windows: 0 })
+  })
+
+  // The timeout is a three-second timer, and a clean shutdown wins the race
+  // long before it fires. Left pending it keeps the event loop alive with a
+  // callback that resolves a promise nobody is waiting on any more — which is
+  // exactly the acquire-without-release the memory rules are about, on the one
+  // path where the process is not already leaving.
+  it('leaves no timer pending once the backend is down', async () => {
+    vi.useFakeTimers()
+
+    await importMain()
+
+    await fire('ready')
+
+    fire('before-quit', quitEvent())
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(vi.getTimerCount()).toEqual(0)
+  })
+})
 
 // The window functions are unit tested in `main/window.test.ts`; what is left
 // untested by those is the wiring — which channel reaches which function. A
 // minimize wired to close is a data-losing bug that every test over there still
-// passes.
-describe('main', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockGetAllWindows.mockReturnValue([])
-  })
-
+// passes. The handlers are registered while the module body runs, so importing
+// `main.ts` is all these need; none of them waits for `ready`.
+describe('the title bar and the dock', () => {
   it('closes the window from the title bar', async () => {
-    const browserWindow = createWindow()
+    const browserWindow = openWindow()
 
-    mockGetAllWindows.mockReturnValue([browserWindow])
+    await importMain()
 
-    await bootMain()
-
-    ipcHandler('window-close')()
+    ipc('window-close')()
 
     expect({
       closed: browserWindow.close.mock.calls.length,
@@ -146,13 +542,11 @@ describe('main', () => {
   })
 
   it('maximizes the window from the title bar', async () => {
-    const browserWindow = createWindow()
+    const browserWindow = openWindow()
 
-    mockGetAllWindows.mockReturnValue([browserWindow])
+    await importMain()
 
-    await bootMain()
-
-    ipcHandler('window-maximize')()
+    ipc('window-maximize')()
 
     expect({
       closed: browserWindow.close.mock.calls.length,
@@ -162,13 +556,11 @@ describe('main', () => {
   })
 
   it('minimizes the window from the title bar', async () => {
-    const browserWindow = createWindow()
+    const browserWindow = openWindow()
 
-    mockGetAllWindows.mockReturnValue([browserWindow])
+    await importMain()
 
-    await bootMain()
-
-    ipcHandler('window-minimize')()
+    ipc('window-minimize')()
 
     expect({
       closed: browserWindow.close.mock.calls.length,
@@ -177,32 +569,27 @@ describe('main', () => {
     }).toEqual({ closed: 0, maximized: 0, minimized: 1 })
   })
 
-  it('opens a window when the app is activated with none open', async () => {
-    await bootMain()
+  // The other half of the dock-click cases above: a running app that still has
+  // its window gets nothing new. `activate` fires on every dock click, not only
+  // the ones with no window behind them.
+  it('opens no second window when a dock click lands on an app that has one', async () => {
+    await importMain()
 
-    appHandler('activate')()
+    await fire('ready')
 
-    expect(mockBrowserWindowConstructor).toHaveBeenCalledTimes(1)
-  })
+    openWindow()
 
-  it('opens no second window when the app is activated with one open', async () => {
-    mockGetAllWindows.mockReturnValue([createWindow()])
+    fire('activate')
 
-    await bootMain()
-
-    appHandler('activate')()
-
-    expect(mockBrowserWindowConstructor).toHaveBeenCalledTimes(0)
+    expect(electron.windows).toEqual(1)
   })
 
   it('raises the running window when a second instance is launched', async () => {
-    const browserWindow = createWindow({ minimized: true })
+    const browserWindow = openWindow({ minimized: true })
 
-    mockGetAllWindows.mockReturnValue([browserWindow])
+    await importMain()
 
-    await bootMain()
-
-    appHandler('second-instance')()
+    fire('second-instance')
 
     expect({
       focused: browserWindow.focus.mock.calls.length,

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,9 +65,18 @@ if (!hasSingleInstanceLock) {
   app.quit()
 }
 
-let runtime: MainRuntime | undefined
-let quitting = false
-let disposed = false
+// One value rather than a runtime beside two booleans. Three booleans gave
+// eight combinations for a four-state lifecycle, and the states that cannot
+// have a runtime could still name one — which is how `createWindow()` came to
+// run without consulting any of them. Here the runtime is present exactly where
+// it is usable, so the question has to be asked to reach it.
+type Lifecycle =
+  | { runtime: MainRuntime; status: 'booting' }
+  | { runtime: MainRuntime; status: 'quitting' }
+  | { runtime: MainRuntime; status: 'running' }
+  | { status: 'idle' }
+
+let lifecycle: Lifecycle = { status: 'idle' }
 
 // Long enough for a normal flush, short enough that a wedged dependency cannot
 // hold the app open.
@@ -148,7 +157,7 @@ function describeError(error: unknown): string {
 // not a boot failure, so it must not raise a dialog racing the before-quit
 // handler's own exit.
 function isShutdownInterruption(cause: Cause.Cause<unknown>): boolean {
-  return quitting || Cause.isInterruptedOnly(cause)
+  return lifecycle.status === 'quitting' || Cause.isInterruptedOnly(cause)
 }
 
 function reportBootFailure(error: unknown): void {
@@ -170,6 +179,66 @@ function reportBootFailure(error: unknown): void {
   )
 }
 
+/**
+ * Shut the backend down, then leave — within `disposeTimeoutMs` either way.
+ *
+ * Disposing closes the HTTP server, interrupts the retention fibers and any
+ * running queries, and releases the app database. None of that is allowed to
+ * hold the app open, so the exit happens on every path; what the two warnings
+ * add is a way to tell those paths apart afterwards, since all three reach the
+ * same `app.exit(0)` and a backend that wedges on every quit otherwise leaves
+ * no trace of having done so.
+ */
+async function shutDown(runtime: MainRuntime): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const reportFailure = (error: unknown) => {
+    log.warn(
+      `The backend errored while shutting down: ${describeError(error)}. Exiting anyway — whatever it still held is released by the process going away.`
+    )
+
+    return 'failed' as const
+  }
+
+  try {
+    const timeout = new Promise<'timedOut'>((resolve) => {
+      timer = setTimeout(() => {
+        resolve('timedOut')
+      }, disposeTimeoutMs)
+    })
+
+    // Handled on the disposal itself rather than after the race, because the
+    // race may already have been won by the timeout — and an unhandled
+    // rejection from a process on its way out prints, if at all, after the exit
+    // it belongs to.
+    //
+    // Called inside the `try` but still synchronously, before the first await:
+    // `quitAndInstall` primes an installer that only runs once this process is
+    // gone, so the teardown has to start before the `before-quit` handler that
+    // reached here returns. What the `try` adds is the exit on the last path
+    // that lacked one — a `dispose()` that throws where it should have rejected
+    // would otherwise skip the `finally`, and the quit it skips has already
+    // been prevented, so nothing would be left to release it.
+    const disposal = runtime
+      .dispose()
+      .then(() => 'disposed' as const, reportFailure)
+
+    if ((await Promise.race([disposal, timeout])) === 'timedOut') {
+      log.warn(
+        `The backend did not shut down within ${disposeTimeoutMs}ms. Exiting anyway — any queries still running were left for their own server to clean up.`
+      )
+    }
+  } catch (error) {
+    reportFailure(error)
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer)
+    }
+
+    app.exit(0)
+  }
+}
+
 app.on('ready', async () => {
   // A losing second instance is already quitting; booting the backend here
   // would still write to the shared database before the process goes away.
@@ -181,12 +250,14 @@ app.on('ready', async () => {
 
   apiToken = randomBytes(32).toString('hex')
 
-  runtime = makeMainRuntime({
+  const runtime = makeMainRuntime({
     allowedOrigins: corsAllowedOrigins(),
     // Lets local agents read traces with plain curl during development.
     publicTraceReads: !app.isPackaged,
     token: apiToken
   })
+
+  lifecycle = { runtime, status: 'booting' }
 
   // Forces the runtime layer to build: the app database initializes,
   // interrupted queries are reconciled, the encryption migration runs
@@ -205,6 +276,17 @@ app.on('ready', async () => {
     return
   }
 
+  // The same question the failure arm asks through `isShutdownInterruption`,
+  // asked on this arm too. A quit that landed while the boot was in flight has
+  // already started disposing the runtime this window would talk to, and is
+  // seconds from `app.exit(0)`: what it opens is a window whose every request
+  // fails, for as long as it survives.
+  if (lifecycle.status !== 'booting') {
+    return
+  }
+
+  lifecycle = { runtime, status: 'running' }
+
   createWindow()
 })
 
@@ -216,8 +298,12 @@ app.on('second-instance', () => {
 // closes the HTTP server, interrupts the retention fiber and any running
 // queries (best-effort canceling their server-side statements), and releases
 // the app database.
+//
+// `idle` is the losing second instance and anything else that quits before
+// `ready`: it has nothing to shut down, and holding its quit would hold it
+// forever, since what releases the hold is the exit at the end of `shutDown`.
 app.on('before-quit', (event) => {
-  if (runtime === undefined || disposed) {
+  if (lifecycle.status === 'idle') {
     return
   }
 
@@ -227,26 +313,15 @@ app.on('before-quit', (event) => {
   // process mid-flush, defeating the whole point of this handler.
   event.preventDefault()
 
-  if (quitting) {
+  if (lifecycle.status === 'quitting') {
     return
   }
 
-  quitting = true
+  const { runtime } = lifecycle
 
-  let timer: ReturnType<typeof setTimeout> | undefined
+  lifecycle = { runtime, status: 'quitting' }
 
-  const timeout = new Promise((resolve) => {
-    timer = setTimeout(resolve, disposeTimeoutMs)
-  })
-
-  void Promise.race([runtime.dispose(), timeout]).finally(() => {
-    if (timer !== undefined) {
-      clearTimeout(timer)
-    }
-
-    disposed = true
-    app.exit(0)
-  })
+  void shutDown(runtime)
 })
 
 app.on('window-all-closed', () => {
@@ -256,6 +331,15 @@ app.on('window-all-closed', () => {
 })
 
 app.on('activate', () => {
+  // The same refusal the boot path makes, on the other door into `createWindow`.
+  // A shutting-down app has no windows either, so a dock click here is
+  // indistinguishable from the last-window-closed app this exists to revive —
+  // except that what it would open talks to a runtime already inside
+  // `dispose()`, seconds from `app.exit(0)`.
+  if (lifecycle.status !== 'running') {
+    return
+  }
+
   // Asked through the same lookup as everywhere else, so there is one answer to
   // "is there a window?" rather than two spellings of it that can drift.
   if (!getMainWindow()) {


### PR DESCRIPTION
Closes #58

## The defect

`src/main.ts` held the lifecycle as a runtime beside two booleans — eight combinations for a four-state app — and asked "are we quitting?" on exactly one arm of one `if`. The failure arm of boot asked it through `isShutdownInterruption`; the success arm called `createWindow()` with nothing.

A quit arriving while the boot is still in flight, where the layer build wins the race against the interruption that quit's `dispose()` starts, comes back `Exit.void` — and opens a window over a runtime already inside `dispose()`, seconds from `app.exit(0)`. Every request that window makes fails for as long as it survives.

`disposed` was dead in the other direction: it is set immediately before `app.exit(0)`, which Electron documents as emitting neither `before-quit` nor `will-quit`, so its term in the guard could never be true. It duplicated the `quitting` guard four lines below.

## The change

One `Lifecycle` value — `idle | booting | running | quitting` — carrying the runtime in exactly the states that can use one. The guards then read as the questions they always were:

- `idle` is the losing second instance and anything quitting before `ready`. Its quit must **not** be held, because what releases the hold is the exit at the end of `shutDown`.
- `!== 'booting'` on the boot success arm is the missing check.
- `!== 'running'` on `activate` is the same check on the other door into `createWindow()`. A shutting-down app has no windows either, so on macOS a dock click during the dispose window is indistinguishable from the last-window-closed app that handler exists to revive — and opens the same doomed window.

`preventDefault()` ordering in `before-quit` is preserved exactly: every quit signal during the dispose window keeps being prevented, and only the first starts a shutdown.

Two `log.warn`s give the dispose window a voice. The timeout is deliberate and stays, but the wedged path, the erroring path and the clean one all reached the same `app.exit(0)` in silence, so a backend that hangs on every quit left no trace — and a rejected `dispose()` surfaced only as an unhandled rejection printed, if at all, after the exit it belonged to.

`dispose()` also moved inside the `try` that owns the exit. It still runs synchronously inside the `before-quit` handler, which `quitAndInstall` depends on, but a `dispose()` that throws where it should have rejected no longer skips the `finally` — which would leave the quit prevented with nothing left to release it, and the app unquittable by anything short of killing the process.

## Scope, versus the issue

#58 scoped an extraction of the transition logic into a pure `src/main/lifecycle.ts`, on the grounds that `src/main.ts` cannot be imported under vitest. It can. Mocking `electron`, `electron-squirrel-startup`, `node:fs` and `./server/runtime`, then firing the listeners the module registered, drives every branch — which is what the new `src/main.test.ts` does, with `vi.resetModules()` per case for fresh module-level state.

So there is no new module, and the thirteen cases test the real handlers rather than a copy of their logic. The `apiToken` sentinel the issue raised was withdrawn by the issue itself; the "worth adding while here" `log.warn` is included.

## Tests

Written first, against the unchanged file. Red: window-during-quit, dock-click-during-shutdown, the synchronous-throw exit, the timeout warning, the failed-shutdown warning. Green from the start, so the harness was not vacuous: window-on-boot, dock-click-while-running, the double-quit hold, quit-with-no-backend, the boot-failure dialog, the interrupted-boot silence, the single-instance guard, and the cleared timer.

Mutation-checked afterwards — eighteen must-kill mutants all died:

- the boot guard removed; `lifecycle` never entering `booting`
- the quit no longer held; held only on the first signal; a second signal starting a second shutdown; a backend-less quit held anyway
- the lifecycle left unchanged on shutdown
- `activate` opening a window mid-dispose; `activate` refusing a running app; the whole `activate` body dropped
- a synchronous throw from `dispose()` skipping the exit
- the single-instance guard removed
- the shutdown timer left pending; the exit removed entirely
- either warning dropping the number or the error it carries
- an interrupted boot reported as a boot failure

Three must-survive mutants survived: reading the runtime without destructuring, and rewording each warning around the value it reports.

`yarn typecheck`, `eslint`, `prettier --check` clean. Full `vitest run`: 964 passed, 1 failed — `src/databases/sqlite-adapter.test.ts:100`, a pre-existing Windows path failure byte-identical on `main`.

## Left open

- `createWindow`'s body is still uncovered, including the two security controls (`will-navigate` origin deny, `setWindowOpenHandler`). The fake `webContents` discards both handlers, so pinning them needs a different fake — worth its own change.
- `window-all-closed`, `second-instance` and the ipc handlers are uncovered for the same reason.
- `src/main.test.ts` lands in the jsdom `renderer` vitest project, saved only by its `// @vitest-environment node` pragma; `vitest.config.ts` scopes the backend project to `src/glue` and `src/server`.
