### PR TITLE
fix(tests): repair fixtures the merge batch left stale

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -217,7 +217,6 @@ describe('canceling a query', () => {
     id: 'q-1',
     queriedAt: 1,
     result: null,
-    truncated: false,
     worksheetId: 'ws-1'
   }
 

--- a/src/app/api-client.test.ts
+++ b/src/app/api-client.test.ts
@@ -508,7 +508,7 @@ describe('apiClient', () => {
 
     it('records the status of a tagged error on the span', async () => {
       mockFetch.mockResolvedValueOnce(
-        respondWith(
+        jsonResponse(
           {
             _tag: 'DatabaseNotFoundError',
             databaseId: 'missing',

--- a/src/app/hooks/mutations.test.tsx
+++ b/src/app/hooks/mutations.test.tsx
@@ -30,7 +30,6 @@ const runningQuery: QueryDto = {
   id: 'q-1',
   queriedAt: 1,
   result: null,
-  truncated: false,
   worksheetId: 'ws-1'
 }
 

--- a/src/server/http/traceparent-propagation.test.ts
+++ b/src/server/http/traceparent-propagation.test.ts
@@ -25,10 +25,8 @@ async function handleRequest(
   // is decided in `SquealSpan`'s constructor, so a collector that skipped it
   // would not be measuring the thing under test.
   const tracer = makeSquealTracer({
-    persist: (records) => {
-      spans.push(...records)
-
-      return Promise.resolve(records.length)
+    emit: (record) => {
+      spans.push(record)
     }
   })
 


### PR DESCRIPTION
Merging today's batch of green pull requests left `main` red. Three of them renamed something their own tests were green against, while a test added in a parallel pull request kept using the old name. Each side passed CI on its own base and git reported no conflict, so the break only existed once both were on `main`.

- `makeSquealTracer` takes `emit`, one span at a time (`925275e`), not `persist` — `traceparent-propagation.test.ts` arrived from `ee2158a` still passing the old sink.
- The renderer's response helper is `jsonResponse` from `./test-fetch` (`fa78f4e`); one span test still called `respondWith`.
- `truncated` lives on the result, not on `QueryDto` (`faaea46`), so the two fixtures for a running query with `result: null` had nowhere to put it.

## Verification

- `yarn typecheck` — clean (the backend project's errors were masking two more in the renderer project).
- `yarn lint`, `yarn format --check` — clean.
- `yarn test` — 1205 passed. The two remaining failures are `DatabaseForm > drops a verdict that arrives after the connection changed` and `TraceDashboard > shows an error state and recovers on retry`; both pass when their file runs alone and both are already recorded in `.agents/friction-log/20260819113459-three-timing-sensitive`.