### PR TITLE
chore(ci): check formatting through a declared script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Check formatting
-        run: npx prettier --check .
+        run: yarn format:check
 
   lint:
     name: Lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,8 @@ disposes on `before-quit`.
 
 - `yarn start` - Development mode
 - `yarn seed` - Seed PostgreSQL with Pagila sample data
-- `yarn lint` / `yarn format` - Code quality
+- `yarn lint` / `yarn format` - Code quality (`yarn format:check` is the
+  read-only form CI runs)
 - `yarn typecheck` - Runs two projects: `tsconfig.backend.json` (strict, covers
   `src/server` and `src/glue`) and `tsconfig.renderer.json`
 - `yarn test` - Vitest, split into a `backend` project (node environment) and a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ free of main-process imports. See `CLAUDE.md` for the architecture in detail.
 - `yarn test:watch` - Run the test suite in watch mode
 - `yarn lint` - Run ESLint
 - `yarn format` - Format code with Prettier
+- `yarn format:check` - Check formatting without writing (what CI runs)
 - `yarn seed` - Seed the sample databases
 - `yarn package` - Package the app
 - `yarn make` - Build distributable

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": ".vite/build/main.js",
   "scripts": {
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "generate-icons": "bun run scripts/generate-icons.ts",
     "lint": "eslint --ext .ts,.tsx .",
     "make": "electron-forge make",

--- a/scripts/declared-tools.test.ts
+++ b/scripts/declared-tools.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it } from 'vitest'
 
 import {
   invokedTools,
+  npxSpecifiers,
   toolsInvokedByScript,
-  unpinnedNpxTools
+  unpinnedNpxTools,
+  yarnScripts
 } from './declared-tools'
 
 const repositoryRoot = join(import.meta.dirname, '..')
@@ -27,6 +29,43 @@ describe('invokedTools', () => {
         workflows: ['        run: npx prettier --check .\n']
       })
     ).toEqual(['prettier'])
+  })
+})
+
+describe('npxSpecifiers', () => {
+  it('names what an unpinned invocation would fetch', () => {
+    expect(npxSpecifiers('npx prettier --check .')).toEqual(['prettier'])
+  })
+
+  // Kept whole, where `unpinnedNpxTools` drops the invocation entirely. A
+  // repository whose every `npx` names its own version gives that function
+  // nothing to return, and a guard reading only what the scan rejected cannot
+  // then tell "the workflows are clean" from "the scan stopped matching".
+  it('names a pinned invocation with the version it pins', () => {
+    expect(npxSpecifiers('npx --yes fallow@3.2.0')).toEqual(['fallow@3.2.0'])
+  })
+
+  it('names the package an invocation asks for rather than the bin', () => {
+    expect(npxSpecifiers('npx --package=typescript tsc --noEmit')).toEqual([
+      'typescript'
+    ])
+  })
+
+  it('names an invocation once however often a block runs it', () => {
+    expect(
+      npxSpecifiers('npx prettier --check .\nnpx prettier --write .')
+    ).toEqual(['prettier'])
+  })
+
+  it('finds nothing in a block that runs no npx', () => {
+    expect(npxSpecifiers('yarn typecheck')).toEqual([])
+  })
+
+  it('names every invocation in a block, in one order', () => {
+    expect(npxSpecifiers('npx tsx build.ts\nnpx fallow@3.2.0')).toEqual([
+      'fallow@3.2.0',
+      'tsx'
+    ])
   })
 })
 
@@ -137,6 +176,54 @@ describe('unpinnedNpxTools', () => {
   })
 })
 
+describe('yarnScripts', () => {
+  it('names the script a step runs', () => {
+    expect(yarnScripts('        run: yarn typecheck\n')).toEqual(['typecheck'])
+  })
+
+  it('names a script whose name carries a colon', () => {
+    expect(yarnScripts('run: yarn format:check')).toEqual(['format:check'])
+  })
+
+  it('reads the script out of an explicit run', () => {
+    expect(yarnScripts('yarn run --silent test')).toEqual(['test'])
+  })
+
+  // `install` is yarn's own, and the one every workflow starts with. Reported
+  // as a script it would be reported as missing, since package.json declares no
+  // such thing and never should.
+  it('says nothing about a command yarn answers itself', () => {
+    expect(yarnScripts('yarn install --frozen-lockfile')).toEqual([])
+  })
+
+  it('says nothing about a bare yarn', () => {
+    expect(yarnScripts('        cache: yarn\n')).toEqual([])
+  })
+
+  // Prose is scanned along with the steps, because a `run:` value may be a
+  // block scalar spanning lines that no line-oriented scan would reach. What
+  // keeps the prose out is the shape of a script name: the backticks a comment
+  // quotes its commands with are not part of one, and a token that cannot be a
+  // script name ends the invocation rather than passing the search to the next
+  // word — which would otherwise report the sentence's own vocabulary.
+  it('says nothing about a script quoted in a comment', () => {
+    expect(
+      yarnScripts('# One macOS runner: `yarn make:mac` builds a universal app')
+    ).toEqual([])
+  })
+
+  it('names a script once however many steps run it', () => {
+    expect(yarnScripts('run: yarn test\nrun: yarn test')).toEqual(['test'])
+  })
+
+  it('names every script a block runs, in one order', () => {
+    expect(yarnScripts('run: yarn typecheck\nrun: yarn lint')).toEqual([
+      'lint',
+      'typecheck'
+    ])
+  })
+})
+
 // The version of a tool the repository runs is part of the repository, not of
 // whatever the registry served the day a job happened to run. A tool that is
 // invoked but not declared has no version of its own here: it is whatever
@@ -220,13 +307,63 @@ describe('the tools this repository invokes', () => {
     expect(invoked).toContain('electron-forge')
   })
 
-  // And the same for the other half. Every tool the workflows reach for through
-  // `npx` is also named by a script, so the union above would look identical if
-  // the workflow scan silently stopped matching — this is the one assertion that
-  // fails when it does.
+  // And the same for the workflows, which the two guards below read the same
+  // way: both are satisfied by an empty result, so a scan that stopped matching
+  // reads exactly like a repository with nothing to report. Neither can say
+  // which it is, and this is what asks.
+  //
+  // Not the version, though — `fallow@3.2.0` is a dependency someone will bump,
+  // and a bump is not a scan that stopped working. What must not change is that
+  // each scan still finds the invocation ci.yml really makes.
   it('reads the workflows', () => {
     const workflow = readFileSync(join(workflowsDirectory, 'ci.yml'), 'utf-8')
 
-    expect(unpinnedNpxTools(workflow)).toEqual(['prettier'])
+    expect({
+      npx: npxSpecifiers(workflow).some((specifier) =>
+        specifier.startsWith('fallow@')
+      ),
+      yarn: yarnScripts(workflow).includes('format:check')
+    }).toEqual({ npx: true, yarn: true })
+  })
+
+  // The direction that makes moving a command out of `npx` and into a script
+  // safe: the script has to be there. Renamed, every workflow that calls it
+  // keeps looking correct and fails at the moment CI runs it — with a yarn
+  // error naming the script, and nothing naming the five steps that expected
+  // it.
+  it('runs no script the package.json does not declare', () => {
+    const undeclared = readdirSync(workflowsDirectory).flatMap((fileName) =>
+      yarnScripts(readFileSync(join(workflowsDirectory, fileName), 'utf-8'))
+        .filter((script) => manifest.scripts[script] === undefined)
+        .map((script) => ({ script, workflow: fileName }))
+    )
+
+    expect(
+      undeclared,
+      'A workflow runs a yarn script package.json does not declare. Declare it under `scripts`, or — if this is a command yarn answers itself, or a bin it falls back to running out of node_modules — move it into a script so `yarn run` resolves it. The scan reads whole files, so prose can land here too: a comment writing a command name as a bare word after "yarn" is read as an invocation.'
+    ).toEqual([])
+  })
+
+  // Being declared is not enough for something a workflow reaches through
+  // `npx`, which only *prefers* the copy in node_modules. Rename or drop the
+  // dependency and the same command fetches whatever the registry serves that
+  // day, and the job keeps passing against a version nobody chose. An
+  // invocation that pins its own version answers for itself; anything else
+  // belongs in a package.json script, where `yarn run` resolves the bin from
+  // node_modules and fails outright when it is not there.
+  it('fetches nothing a workflow has not pinned', () => {
+    const unpinned = readdirSync(workflowsDirectory)
+      .map((fileName) => ({
+        tools: unpinnedNpxTools(
+          readFileSync(join(workflowsDirectory, fileName), 'utf-8')
+        ),
+        workflow: fileName
+      }))
+      .filter((entry) => entry.tools.length > 0)
+
+    expect(
+      unpinned,
+      'A workflow fetches a tool through `npx` without saying which version, so the job runs whatever the registry serves that day. Pin it as `name@1.2.3`, or move the command into a package.json script, where `yarn run` resolves the bin from node_modules and fails outright when it is not there. The scan reads whole files, so prose can land here too: a comment writing a package name as a bare word after "npx" is read as an invocation.'
+    ).toEqual([])
   })
 })

--- a/scripts/declared-tools.ts
+++ b/scripts/declared-tools.ts
@@ -18,6 +18,75 @@ const segmentSeparator = /&&|\|\||[|;\n]/
 const assignmentPrefix = /^[A-Za-z_][A-Za-z0-9_]*=/
 
 /**
+ * The commands yarn answers itself rather than looking up in `scripts`. Read as
+ * scripts they would be reported as missing, since package.json declares no
+ * such thing and never should.
+ *
+ * The lockfile is `yarn lockfile v1`, so this is that version's list rather
+ * than a guess at another's. What no list can cover is yarn's other fallback:
+ * `yarn prettier` runs the bin from node_modules when no script matches it, so
+ * a workflow written that way is reported as a script package.json is missing.
+ * Moving it into a script is the fix, and the one this guard exists to ask for.
+ */
+const yarnCommands = [
+  'access',
+  'add',
+  'audit',
+  'autoclean',
+  'bin',
+  'cache',
+  'check',
+  'config',
+  'create',
+  'dedupe',
+  'generate-lock-entry',
+  'global',
+  'help',
+  'import',
+  'info',
+  'init',
+  'install',
+  'licenses',
+  'link',
+  'list',
+  'login',
+  'logout',
+  'node',
+  'outdated',
+  'owner',
+  'pack',
+  'policies',
+  'publish',
+  'remove',
+  'tag',
+  'team',
+  'unlink',
+  'unplug',
+  'upgrade',
+  'upgrade-interactive',
+  'version',
+  'versions',
+  'why',
+  'workspace',
+  'workspaces'
+]
+
+/** The shape of a package.json script name. */
+const scriptName = /^[A-Za-z][A-Za-z0-9:_-]*$/
+
+/**
+ * Whether an `npx` specifier names the version it runs, which is what declaring
+ * it would have achieved. A leading `@` is a scope, not a version, so only a
+ * later one counts — and `name@latest` is not a version but the float this
+ * guard exists to catch, so it is not pinned.
+ */
+function isPinned(specifier: string): boolean {
+  const separator = specifier.lastIndexOf('@')
+
+  return separator > 0 && /^[~^><=]*\d/.test(specifier.slice(separator + 1))
+}
+
+/**
  * What an `npx` invocation would fetch, which is not always the first argument
  * that is not an option: `--package=name` names the package, and the command
  * after it is a bin inside that package — a bin name is not what a dependency
@@ -37,24 +106,14 @@ function npxSpecifier(argumentTokens: readonly string[]): string | undefined {
 
 /**
  * The tool an `npx` invocation would fetch, given the arguments after `npx`,
- * or `undefined` when the invocation says for itself which version it runs.
+ * or `undefined` when the invocation says for itself which version it runs. A
+ * pinned invocation stays on no list under the name it was written with, which
+ * no declared package provides.
  */
 function npxTool(argumentTokens: readonly string[]): string | undefined {
   const specifier = npxSpecifier(argumentTokens)
 
-  if (specifier === undefined) {
-    return undefined
-  }
-
-  // `name@3.2.0` carries its own version, which is what declaring it would have
-  // achieved. A leading `@` is a scope, not a version, so only a later one
-  // counts — and `name@latest` is not a version but the float this guard exists
-  // to catch, so it stays on the list under the name it was written with, which
-  // no declared package provides.
-  const separator = specifier.lastIndexOf('@')
-  const version = separator > 0 ? specifier.slice(separator + 1) : undefined
-
-  if (version !== undefined && /^[~^><=]*\d/.test(version)) {
+  if (specifier === undefined || isPinned(specifier)) {
     return undefined
   }
 
@@ -85,6 +144,27 @@ export function invokedTools(invocations: Invocations): string[] {
   ]
 
   return [...new Set(tools)].sort()
+}
+
+/**
+ * Every package an `npx` invocation in a block of shell names, pinned or not.
+ *
+ * Separate from `unpinnedNpxTools` because a repository that has pinned every
+ * one of its invocations gives that function nothing to return, and an empty
+ * result then cannot be told apart from a scan that has stopped matching. This
+ * answers what the scan saw rather than what it rejected, which is the form of
+ * the question that still has an answer.
+ */
+export function npxSpecifiers(shell: string): string[] {
+  const specifiers = [...shell.matchAll(/\bnpx\b([^\n&|;]*)/g)].flatMap(
+    (match) => {
+      const specifier = npxSpecifier(tokenize(match[1]))
+
+      return specifier === undefined ? [] : [specifier]
+    }
+  )
+
+  return [...new Set(specifiers)].sort()
 }
 
 /** Every tool a package.json script runs, in each segment of a chain. */
@@ -119,11 +199,36 @@ export function toolsInvokedByScript(script: string): string[] {
 
 /** Every unpinned `npx` invocation anywhere in a block of shell. */
 export function unpinnedNpxTools(shell: string): string[] {
-  const tools = [...shell.matchAll(/\bnpx\b([^\n&|;]*)/g)].flatMap((match) => {
-    const tool = npxTool(tokenize(match[1]))
+  return npxSpecifiers(shell).filter((specifier) => !isPinned(specifier))
+}
 
-    return tool === undefined ? [] : [tool]
-  })
+/**
+ * Every package.json script a block of shell asks yarn to run.
+ *
+ * Scanned over the whole block rather than over its `run:` values, because a
+ * `run:` may be a block scalar whose commands are on the lines below it, and a
+ * line-oriented scan would quietly cover none of them. What that costs is the
+ * prose: a comment quoting `yarn make:mac` reads as an invocation. It is the
+ * shape of a script name that rules those out — the backticks a comment quotes
+ * with are not part of one, and a first token that cannot be a script name ends
+ * the invocation rather than passing the search along to the next word, which
+ * would report the sentence's own vocabulary.
+ */
+export function yarnScripts(shell: string): string[] {
+  const scripts = [...shell.matchAll(/\byarn\b([^\n&|;]*)/g)].flatMap(
+    (match) => {
+      const tokens = tokenize(match[1]).filter(
+        (token) => !token.startsWith('-')
+      )
+      const command = tokens[0] === 'run' ? tokens[1] : tokens[0]
 
-  return [...new Set(tools)].sort()
+      if (command === undefined || !scriptName.test(command)) {
+        return []
+      }
+
+      return yarnCommands.includes(command) ? [] : [command]
+    }
+  )
+
+  return [...new Set(scripts)].sort()
 }


### PR DESCRIPTION
`npx prettier --check .` only *prefers* the copy in `node_modules`. #107 put an exact `prettier` in devDependencies so that preference has something to resolve to, but the fallback never went away: rename the dependency, or drop it, and the same command fetches whatever the registry serves that day — and the Format job keeps passing against a version nobody chose.

`yarn format:check` has no such path. `yarn run` resolves the bin from `node_modules` and fails outright when it is not there, so the version CI formats against is the one this repository declares, or there is no run.

## The catch the issue names

Removing the last unpinned `npx` leaves `reads the workflows` with nothing to assert. Deleting it is not the fix — it existed because every tool the workflows reach for is also named by a script, so the union would look identical if the workflow scan silently stopped matching, and an empty result means either "the workflows are clean" or "the scan is broken".

So the scan gained a way to be asked **what it saw** rather than what it rejected. `npxSpecifiers` reports every invocation with the version it names; `unpinnedNpxTools` is now that list minus the pinned ones — one scan, one pinning rule, and an anchor with an answer again. (Verified behaviourally identical to the old implementation over 1131 inputs.)

## Three real-file guards, where there was one

- **`reads the workflows`** — both scans still find what ci.yml really contains. Asserted on `fallow@` rather than `fallow@3.2.0`, so a routine bump is not a test failure.
- **nothing a workflow fetches is unpinned** — being declared is no longer enough for something reached through `npx`.
- **no workflow runs a script package.json does not declare** — the other side of moving a command into a script. Renamed, every step calling it still *looks* correct and fails when CI runs it.

`yarnScripts` scans whole files rather than each `run:` value, because a `run:` may be a block scalar whose commands sit on the lines below it — release.yml has four. The cost is that prose is scanned too; the shape of a script name is what keeps it out.

## TDD

Two rounds, both watched red first: the twelve scanner cases on a missing function, then `runs no script the package.json does not declare` with both scanners implemented but `format:check` not yet declared — red on exactly `{ script: 'format:check' }`.

## Review

A fresh-context review found nothing blocking and three things in the test half, all fixed here: the version anchor cried wolf on a bump; blinding `yarnScripts` on the real workflows left all 43 cases green; and a four-entry `yarnCommands` produced false failures for `yarn cache clean`, `yarn upgrade`, `yarn workspace …` and a comment saying "yarn workspaces are not used here". `yarnCommands` is now yarn 1's own list, and both `toEqual([])` guards carry an actionable message naming the escape hatches.

Re-checked after: the blinding mutants and a typo in the workflow's script name die; bumping the pin, a comment naming a yarn command, and a step chaining `yarn cache clean` survive.

## Gates

`yarn lint`, `prettier --check`, `yarn typecheck` clean. `vitest run`: 1032 passed, 1 failure — `src/databases/sqlite-adapter.test.ts:100`, pre-existing and byte-identical on `main`.

Closes #162