### PR TITLE
refactor(updates): tell what the updater is doing from what it knows

### DIFF
--- a/src/main/updates/updater.test.ts
+++ b/src/main/updates/updater.test.ts
@@ -94,6 +94,18 @@ const idleStatus: UpdateStatus = {
   version: null
 }
 
+// What a downloaded 1.3.0 projects to, and so what a claim on it hands back.
+// Written out rather than compared against `status()`: an assertion between two
+// calls of the same implementation is satisfied by whatever the two agree on,
+// which is every answer it could give.
+const readyStatus: UpdateStatus = {
+  ...idleStatus,
+  lastCheckedAt: 1_000,
+  releaseNotesUrl: 'https://github.com/Artmann/squeal/releases/tag/v1.3.0',
+  state: 'ready',
+  version: '1.3.0'
+}
+
 describe('parseVersion', () => {
   it('reads the version release-please produces', () => {
     expect(parseVersion('v1.3.0')).toEqual('1.3.0')
@@ -292,6 +304,93 @@ describe('createUpdater', () => {
     ])
   })
 
+  // The status bar shows nothing while a check runs, which is the behaviour
+  // this keeps: an update the last check found is knowledge, and a check in
+  // flight is what the updater is doing. Whether the two should be shown
+  // together is a question about the indicator, not about this value.
+  it('leaves the available update behind while it checks again', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.found('1.3.0', updateMessages.linux)
+    subject.updater.check()
+
+    expect(subject.updater.status()).toEqual({
+      ...idleStatus,
+      lastCheckedAt: 1_000,
+      state: 'checking'
+    })
+  })
+
+  // A release can be pulled between two checks, and the second check is the
+  // one that still holds.
+  it('clears an update a later check no longer finds', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.found('1.3.0', updateMessages.linux)
+    subject.updater.check()
+    subject.emit.notFound()
+
+    expect(subject.updater.status()).toEqual({
+      ...idleStatus,
+      lastCheckedAt: 1_000
+    })
+  })
+
+  // The message named the check that failed. Carried into the next one it
+  // describes an attempt that is still in flight, and `GET /updates` serves it
+  // verbatim.
+  it('leaves the failure behind when it checks again', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.failed(new Error('offline'))
+    subject.updater.check()
+
+    expect(subject.updater.status()).toEqual({
+      ...idleStatus,
+      lastCheckedAt: 1_000,
+      state: 'checking'
+    })
+  })
+
+  it('leaves the failure behind when the download starts', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.failed(new Error('offline'))
+    subject.updater.check()
+    subject.emit.downloading()
+
+    expect(subject.updater.status()).toEqual({
+      ...idleStatus,
+      lastCheckedAt: 1_000,
+      state: 'downloading'
+    })
+  })
+
+  // The sequence packaged Linux sits in: an update it cannot install, then a
+  // later check that fails. What the failed check knows is that it failed —
+  // the version and the notes URL belong to a check that is no longer the
+  // latest word, and an error offering a release to download is a claim this
+  // one cannot make.
+  it('leaves the available update behind when a later check fails', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.found('1.3.0', updateMessages.linux)
+    subject.updater.check()
+    subject.emit.failed(new Error('the feed went away'))
+
+    expect(subject.updater.status()).toEqual({
+      ...idleStatus,
+      lastCheckedAt: 1_000,
+      message: updateMessages.checkFailed,
+      state: 'error'
+    })
+  })
+
   it('retries after a failure', () => {
     const subject = makeSubject()
 
@@ -337,7 +436,7 @@ describe('createUpdater', () => {
     subject.updater.check()
     subject.emit.downloaded('1.3.0')
 
-    expect(subject.updater.beginInstall()).toEqual(subject.updater.status())
+    expect(subject.updater.beginInstall()).toEqual(readyStatus)
   })
 
   it('hands nothing to the backend until the claim is completed', () => {
@@ -375,7 +474,7 @@ describe('createUpdater', () => {
     subject.updater.completeInstall()
 
     expect({ claims, installs: subject.state.installs }).toEqual({
-      claims: [subject.updater.status(), null, null],
+      claims: [readyStatus, null, null],
       installs: 1
     })
   })
@@ -397,6 +496,28 @@ describe('createUpdater', () => {
     }).toEqual({ claim: null, installs: 0, state: 'available' })
   })
 
+  // The claim answers for the whole status, not for the knowledge behind it.
+  // Those came apart when the two were split: a download running over an
+  // already-ready update leaves `knowledge` at `ready` while the updater is
+  // plainly busy, and a guard reading only `knowledge` would hand out a claim
+  // and answer it with a `downloading` status — a 200 saying "restart to
+  // update" for an install that is being swapped under it. No backend emits
+  // that pair today; this module exists because it holds state for an event
+  // source it cannot ask, so the guard covers the state rather than the paths
+  // known to reach it.
+  it('refuses a claim while a download is running', () => {
+    const subject = makeSubject()
+
+    subject.updater.check()
+    subject.emit.downloaded('1.3.0')
+    subject.emit.downloading()
+
+    expect({
+      claim: subject.updater.beginInstall(),
+      installs: subject.state.installs
+    }).toEqual({ claim: null, installs: 0 })
+  })
+
   it('does not let a later check reopen the claim', () => {
     const subject = makeSubject()
 
@@ -408,7 +529,13 @@ describe('createUpdater', () => {
     // can still arrive — a second downloaded must not license a second swap.
     subject.emit.downloaded('1.4.0')
 
-    expect(subject.updater.beginInstall()).toEqual(null)
+    // The version comes along too. The claim is what is refused; the update on
+    // disk is now 1.4.0, and reporting the one it replaced would offer a
+    // restart into a version that is no longer there.
+    expect({
+      claim: subject.updater.beginInstall(),
+      version: subject.updater.status().version
+    }).toEqual({ claim: null, version: '1.4.0' })
   })
 
   it('does not let a later download reopen the claim', () => {

--- a/src/main/updates/updater.ts
+++ b/src/main/updates/updater.ts
@@ -160,22 +160,27 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+// What the updater is doing right now. Nothing else is ever in flight: an
+// install is claimed rather than reported, and by the time one is handed over
+// the process is on its way out.
+type Activity = 'checking' | 'downloading' | 'idle'
+
+// What the last completed check learned, and the only thing that owns a
+// message, a version, or a notes URL. Held apart from the activity because the
+// two answer different questions: sharing one slot is what let a finished
+// check's message describe an attempt still in flight, and let an update found
+// by one check outlive the check that failed to find it again.
+type Knowledge =
+  | { kind: 'available'; message: string; version: string }
+  | { kind: 'error'; message: string }
+  | { kind: 'none' }
+  | { kind: 'ready'; version: string | null }
+  | { kind: 'unsupported'; message: string }
+
 export function createUpdater(options: UpdaterOptions): Updater {
   const { backend, currentVersion, logError, now, unsupported } = options
 
-  const idleStatus: UpdateStatus = {
-    currentVersion,
-    lastCheckedAt: null,
-    message: null,
-    releaseNotesUrl: null,
-    state: 'idle',
-    version: null
-  }
-
-  let status: UpdateStatus =
-    unsupported === null
-      ? idleStatus
-      : { ...idleStatus, message: unsupported, state: 'unsupported' }
+  let activity: Activity = 'idle'
 
   // One-way: once someone holds the claim there is nothing to release it for,
   // and the process is on its way out. Nothing resets it if the holder is
@@ -184,8 +189,82 @@ export function createUpdater(options: UpdaterOptions): Updater {
   // was going to be abandoned anyway.
   let claimed = false
 
+  let knowledge: Knowledge =
+    unsupported === null
+      ? { kind: 'none' }
+      : { kind: 'unsupported', message: unsupported }
+
+  let lastCheckedAt: number | null = null
+
+  // The one place the two halves become the flat status the contract declares.
+  // An activity outranks the knowledge behind it, which is how the state label
+  // has always read; what it no longer does is carry that knowledge's fields
+  // into a state which has not earned them.
+  function project(): UpdateStatus {
+    const base = { currentVersion, lastCheckedAt }
+
+    if (activity !== 'idle') {
+      return {
+        ...base,
+        message: null,
+        releaseNotesUrl: null,
+        state: activity,
+        version: null
+      }
+    }
+
+    switch (knowledge.kind) {
+      case 'available':
+        return {
+          ...base,
+          message: knowledge.message,
+          releaseNotesUrl: releaseNotesUrl(knowledge.version),
+          state: 'available',
+          version: knowledge.version
+        }
+
+      case 'error':
+        return {
+          ...base,
+          message: knowledge.message,
+          releaseNotesUrl: null,
+          state: 'error',
+          version: null
+        }
+
+      case 'none':
+        return {
+          ...base,
+          message: null,
+          releaseNotesUrl: null,
+          state: 'idle',
+          version: null
+        }
+
+      case 'ready':
+        return {
+          ...base,
+          message: null,
+          releaseNotesUrl: releaseNotesUrl(knowledge.version),
+          state: 'ready',
+          version: knowledge.version
+        }
+
+      case 'unsupported':
+        return {
+          ...base,
+          message: knowledge.message,
+          releaseNotesUrl: null,
+          state: 'unsupported',
+          version: null
+        }
+    }
+  }
+
   function fail(error: unknown, message: string): void {
-    status = { ...status, lastCheckedAt: now(), message, state: 'error' }
+    activity = 'idle'
+    knowledge = { kind: 'error', message }
+    lastCheckedAt = now()
 
     logError(`Squeal could not update itself: ${describeError(error)}`)
   }
@@ -196,44 +275,36 @@ export function createUpdater(options: UpdaterOptions): Updater {
     unsupported === null
       ? backend.subscribe({
           downloaded: (version) => {
-            status = {
-              ...status,
-              lastCheckedAt: now(),
-              message: null,
-              releaseNotesUrl: releaseNotesUrl(version),
-              state: 'ready',
-              version
-            }
+            activity = 'idle'
+            knowledge = { kind: 'ready', version }
+            lastCheckedAt = now()
           },
 
           downloading: () => {
-            status = { ...status, state: 'downloading' }
+            activity = 'downloading'
           },
 
           failed: (error) => {
             // Which message applies depends on how far the attempt got, and
-            // only the state we are leaving still knows that.
+            // only the activity it is ending still knows that.
             fail(
               error,
-              status.state === 'downloading'
+              activity === 'downloading'
                 ? updateMessages.downloadFailed
                 : updateMessages.checkFailed
             )
           },
 
           found: (version, message) => {
-            status = {
-              ...status,
-              lastCheckedAt: now(),
-              message,
-              releaseNotesUrl: releaseNotesUrl(version),
-              state: 'available',
-              version
-            }
+            activity = 'idle'
+            knowledge = { kind: 'available', message, version }
+            lastCheckedAt = now()
           },
 
           notFound: () => {
-            status = { ...idleStatus, lastCheckedAt: now() }
+            activity = 'idle'
+            knowledge = { kind: 'none' }
+            lastCheckedAt = now()
           }
         })
       : (): void => undefined
@@ -247,29 +318,33 @@ export function createUpdater(options: UpdaterOptions): Updater {
       // the duplicate hand-off, so the bundle was never swapped twice. What it
       // cannot do is say so: it closes after the answer has already gone out,
       // and the second caller is told 200 for an install that was dropped.
-      if (status.state !== 'ready' || claimed) {
+      //
+      // Off the projection rather than `knowledge`, because that is what the
+      // caller is handed: an activity in flight outranks the knowledge behind
+      // it there, so reading only `knowledge` would license a claim and answer
+      // it with a status that does not say ready.
+      if (project().state !== 'ready' || claimed) {
         return null
       }
 
       claimed = true
 
-      return status
+      return project()
     },
 
     check(): void {
       // Squirrel downloads the update again for every extra `checkForUpdates()`
       // call, and once one is ready there is nothing left to learn.
       const busy =
-        status.state === 'checking' ||
-        status.state === 'downloading' ||
-        status.state === 'ready' ||
-        status.state === 'unsupported'
+        activity !== 'idle' ||
+        knowledge.kind === 'ready' ||
+        knowledge.kind === 'unsupported'
 
       if (busy) {
         return
       }
 
-      status = { ...status, state: 'checking' }
+      activity = 'checking'
 
       try {
         backend.check()
@@ -289,7 +364,7 @@ export function createUpdater(options: UpdaterOptions): Updater {
     },
 
     status(): UpdateStatus {
-      return status
+      return project()
     }
   }
 }


### PR DESCRIPTION
Closes #82.

`UpdateStatus` was a state label with side fields carried over by spread. Every transition did `{ ...status, state: ... }`, so `message`, `version` and `releaseNotesUrl` outlived the check that produced them. Three combinations were reachable, and `GET /updates` served all three verbatim:

| Sequence | Reported |
|---|---|
| `error` → `check()` | `state: 'checking'` carrying "Squeal could not check for updates" — a message about an attempt already superseded by the one in flight |
| `error` → `check()` → `downloading` | the same message again |
| Linux: `available` → failing check | `state: 'error'` still carrying the version and release-notes URL of an update the failed check had not confirmed |

None are visible today only because `UpdateIndicator` renders for `available` and `ready` alone.

## The change

`state` conflated **activity** (`checking`, `downloading`) with **knowledge** from the last completed check (`idle`, `available`, `ready`, `error`, `unsupported`). Those are now two bindings — an `Activity`, and a `Knowledge` union which is the only thing that owns a message, a version or a notes URL — with `project()` as the single place they become the flat status the contract declares.

An activity still outranks the knowledge behind it, which is how the label has always read. What it no longer does is carry that knowledge's fields into a state which has not earned them. The `error` arm of `Knowledge` has no version to carry, so the third contradiction is now *unrepresentable* rather than merely untaken.

**The wire type does not change** and no call site moves: `electron-updater.ts`, `services/updater.ts`, the handler, the schema and the renderer are all untouched. The `installing` state the original report wanted kept separate is already gone, replaced by the `claimed` latch when the install-readiness fix landed.

## One guard the split put at risk

`beginInstall` reads `project().state`, not `knowledge.kind`. It asks whether the caller may be handed a ready status, and a download running over an already-ready update answers `ready` to the knowledge and `downloading` to the projection. Reading the knowledge alone takes the claim and answers `POST /updates/install` with a 200 whose body says `downloading`, where the old total guard answered 409.

No backend emits that pair today — Squirrel cannot `check()` past a ready update, and the GitHub backend never reports a download at all. But this module exists because it holds state for an event source it cannot query, so the guard covers the state rather than the paths known to reach it.

## Testing

Five cases were written first and watched fail against the previous implementation, each on the exact field carried over:

```
× leaves the available update behind while it checks again
× leaves the failure behind when it checks again
× leaves the failure behind when the download starts
× leaves the available update behind when a later check fails
× refuses a claim while a download is running

- "message": null,
+ "message": "Squeal could not check for updates. …"
- "releaseNotesUrl": null,
+ "releaseNotesUrl": ".../releases/tag/v1.3.0",
- "claim": null,
+ "claim": { …, "state": "downloading" },
```

A sixth, "clears an update a later check no longer finds", passed when written — `notFound` was the one transition that already reset from `idleStatus`. It is here because nothing else pinned that reset, and the refactor had to preserve it.

Two existing assertions turned out not to be assertions: `beginInstall()` was compared against `status()`, one implementation output against another, satisfied by whatever the two agreed on. They now name the object, which is what makes a claim that drops the version or the notes URL fail.

**Mutation:** 23 mutants that are defects all died — the activity never projected, the activity leaking the last message or version, each of the three `busy` guards dropped individually, `fail` leaving the activity running or not recording the check, `notFound` keeping the last update, both claim guards, the claim guard reading only the knowledge, a second download keeping the version it replaced, a claim handing back a status with no version or no notes URL, and the download/check message swap. 4 that are not defects survived: renaming `project`, reordering the switch arms, stamping `lastCheckedAt` before the knowledge, and spelling the claim guard as an equality.

**Gates:** `eslint` clean, `prettier --check` clean, `tsc -p tsconfig.renderer.json` reports nothing in `src/main/updates`. Full suite: 1211 passed, with only the two known failures on `main` (`sqlite-adapter.test.ts` "connects and executes SELECT 1", and the `DatabaseForm` timing flake that passes in isolation).

## Follow-ups this surfaced, not fixed here

- `fail()` overwrites `knowledge` unconditionally, so a failed check **erases a downloaded, installable update** and the user loses the "Restart to update" button. Pre-existing — the old code overwrote the state label the same way — but under this decomposition it is a one-line fix, so it is worth its own change rather than being smuggled into a behaviour-preserving refactor.
- `updateMessages.downloadFailed` says "you can download it from the release page" while the `error` status carries no `releaseNotesUrl`. Not a regression (the reachable pairs had no URL before either), but the pairing is worth revisiting against the actionable-error rule.
- Moving `activity = 'checking'` after `backend.check()` survives mutation: a backend that emitted synchronously would strand the activity and the `busy` guard would then block every future check for the life of the process. Neither real backend does, and the old code had the same shape.
