### PR TITLE
fix(databases): stop asking for the password to change an SSL setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,15 +175,22 @@ from older databases. A new table or column goes in both
   password borrows the stored one (an update by its own id, a connection test by
   the `databaseId` it sends), and both go through
   `DatabaseService.resolveConnection`, which lends the secret only back to the
-  server it was saved for, reached the way it was saved to be reached: `host`,
-  `port`, `sslMode`, and `sslRootCert` must all match. Editing the username or
-  database name keeps borrowing; changing where the password goes or how it
-  travels answers `DifferentServerError` (400) on the update and a
+  server it was saved for: `host` and `port` must match. Everything else keeps
+  borrowing — the username, the database name, and both SSL fields; moving the
+  host or the port answers `DifferentServerError` (400) on the update and a
   `success: false` message on the test, and the user re-types the password. An
   empty stored password counts as no stored password, so a row repaired after an
   unreadable secret is never refused over a password it does not have. The
   update route used to merge the password in on its own, without any of that,
   which made a PATCH a two-step way around the connection test's refusal.
+- `sslMode` and `sslRootCert` were once part of that comparison, on the grounds
+  that they decide how the secret travels rather than where it goes. They were
+  taken out because the cost was a re-typed password on every SSL edit — in both
+  directions, tightening included — and the app never shows a stored password,
+  so "re-type it" meant going and finding it. The exposure left behind is a
+  downgrade that puts the secret in front of someone already on the network path
+  to a host the user chose, which is a much higher bar than being handed it
+  outright; redirecting it to another host is still refused.
 - Don't include the Claude footer in commits
 
 ## Secret storage

--- a/src/server/http/connection-tests.test.ts
+++ b/src/server/http/connection-tests.test.ts
@@ -246,7 +246,7 @@ describe('connection test route', () => {
     )
 
     expect(result).toEqual({
-      message: 'Enter the password to test a different server or SSL settings.',
+      message: 'Enter the password to test a different host or port.',
       success: false
     })
 
@@ -274,7 +274,7 @@ describe('connection test route', () => {
     )
 
     expect(result).toEqual({
-      message: 'Enter the password to test a different server or SSL settings.',
+      message: 'Enter the password to test a different host or port.',
       success: false
     })
   })
@@ -308,6 +308,40 @@ describe('connection test route', () => {
     expect(adapterState.lastConnectionInfo).toEqual({
       ...connectionInfo,
       database: 'other'
+    })
+  })
+
+  // Trying a new SSL setting against a saved connection is the whole point of
+  // the test button, and it used to be the one thing the button could not do:
+  // the borrow was refused, so the user had to go and find a password the app
+  // never shows them before they could find out whether the setting worked.
+  it('still borrows the stored password when the SSL mode changes', async () => {
+    const { adapterState, result } = await run(
+      Effect.gen(function* () {
+        const client = yield* makeAuthorizedClient
+
+        const created = yield* client.databases.create({
+          payload: { connectionInfo, name: 'Pagila', type: 'postgres' }
+        })
+
+        return yield* client.connectionTests.create({
+          payload: {
+            connectionInfo: {
+              ...connectionInfo,
+              password: '',
+              sslMode: 'verify-full'
+            },
+            databaseId: created.database.id,
+            type: 'postgres'
+          }
+        })
+      })
+    )
+
+    expect(result).toEqual({ success: true })
+    expect(adapterState.lastConnectionInfo).toEqual({
+      ...connectionInfo,
+      sslMode: 'verify-full'
     })
   })
 })

--- a/src/server/http/databases.test.ts
+++ b/src/server/http/databases.test.ts
@@ -172,7 +172,7 @@ describe('database routes', () => {
     expect(status).toEqual(400)
     expect(body).toEqual({
       _tag: 'DifferentServerError',
-      message: 'Enter the password to change the server or its SSL settings.'
+      message: 'Enter the password to change the host or port.'
     })
     expect(after).toEqual(before)
   })

--- a/src/server/http/handlers/connection-tests.ts
+++ b/src/server/http/handlers/connection-tests.ts
@@ -34,8 +34,7 @@ export const ConnectionTestsLive = HttpApiBuilder.group(
 
         if (resolved._tag === 'differentServer') {
           return {
-            message:
-              'Enter the password to test a different server or SSL settings.',
+            message: 'Enter the password to test a different host or port.',
             success: false
           }
         }

--- a/src/server/services/database-service.test.ts
+++ b/src/server/services/database-service.test.ts
@@ -64,16 +64,16 @@ function failUpdatesTo(table: 'databases' | 'worksheets', when = '1 = 1') {
 
 const differentServerError = expect.objectContaining({
   _tag: 'DifferentServerError',
-  message: 'Enter the password to change the server or its SSL settings.'
+  message: 'Enter the password to change the host or port.'
 })
 
 function storedConnectionInfo(row: { connectionInfo: string }): unknown {
   return JSON.parse(row.connectionInfo.slice(testEncryptionPrefix.length))
 }
 
-// Every field that decides where the password goes, or how it travels, is
-// tested the same way: save a connection, edit one of those fields with the
-// blank password the renderer sends, and read the row before and after.
+// Every field an edit can move is tested the same way: save a connection, edit
+// one of them with the blank password the renderer sends, and read the row
+// before and after.
 function updateWithBlankPassword(
   saved: ServerConnectionInfo,
   changes: Partial<ServerConnectionInfo>
@@ -192,60 +192,94 @@ describe('DatabaseService', () => {
     expect(after).toEqual(before)
   })
 
-  // Turning TLS off keeps the destination but changes who can read the password
-  // on the way there, so it is a different server for lending purposes. Left
-  // unguarded, the same PATCH that may no longer move the host could still
-  // strip `sslMode` and put the stored secret on the wire in the clear.
-  it('refuses to lend the stored password when the SSL mode changes', async () => {
-    const { after, before, result } = await updateWithBlankPassword(
+  // The SSL fields say how the password travels, not where it goes, so changing
+  // them keeps the borrow. Refusing here cost a re-typed password on every SSL
+  // edit — one the user does not have, because the app never shows it — in
+  // exchange for a downgrade that still only exposes the secret to someone
+  // already on the network path to a host the user chose.
+  it('keeps the stored password when the SSL mode changes', async () => {
+    const { after, result } = await updateWithBlankPassword(
       { ...connectionInfo, sslMode: 'verify-full' },
       { sslMode: 'disable' }
     )
-
-    expect(result._tag).toEqual('Left')
-
-    if (result._tag === 'Left') {
-      expect(result.left).toEqual(differentServerError)
-    }
-
-    expect(after).toEqual(before)
-  })
-
-  // Swapping the pinned certificate is a MITM behind a CA the user never chose,
-  // which the mode alone does not catch.
-  it('refuses to lend the stored password when the SSL root certificate changes', async () => {
-    const { after, before, result } = await updateWithBlankPassword(
-      {
-        ...connectionInfo,
-        sslMode: 'verify-full',
-        sslRootCert: '/etc/ssl/pagila.pem'
-      },
-      { sslRootCert: '/tmp/attacker.pem' }
-    )
-
-    expect(result._tag).toEqual('Left')
-
-    if (result._tag === 'Left') {
-      expect(result.left).toEqual(differentServerError)
-    }
-
-    expect(after).toEqual(before)
-  })
-
-  // Rows written before the SSL fields existed carry neither key, and the form
-  // submits an empty root certificate for "none". Both mean the same transport
-  // as `disable`, so an untouched SSL section must not read as a change.
-  it('keeps the stored password when absent SSL fields come back empty', async () => {
-    const { after, result } = await updateWithBlankPassword(connectionInfo, {
-      sslRootCert: ''
-    })
 
     expect(result._tag).toEqual('Right')
     expect(storedConnectionInfo(after)).toEqual({
       database: 'pagila',
       host: 'localhost',
       password: 'secret',
-      sslRootCert: '',
+      sslMode: 'disable',
+      username: 'postgres'
+    })
+  })
+
+  // Pointing at a refreshed CA bundle is routine — an expired one, a moved file
+  // — and it is the same host over the same port either way.
+  it('keeps the stored password when the SSL root certificate changes', async () => {
+    const { after, result } = await updateWithBlankPassword(
+      {
+        ...connectionInfo,
+        sslMode: 'verify-full',
+        sslRootCert: '/etc/ssl/pagila.pem'
+      },
+      { sslRootCert: '/etc/ssl/pagila-2026.pem' }
+    )
+
+    expect(result._tag).toEqual('Right')
+    expect(storedConnectionInfo(after)).toEqual({
+      database: 'pagila',
+      host: 'localhost',
+      password: 'secret',
+      sslMode: 'verify-full',
+      sslRootCert: '/etc/ssl/pagila-2026.pem',
+      username: 'postgres'
+    })
+  })
+
+  // The port is the one field left with two spellings for the same thing, so
+  // this is what stops an edit that changes nothing from being refused.
+  it('keeps the stored password when a null port comes back absent', async () => {
+    const { after, result } = await run(
+      Effect.gen(function* () {
+        const service = yield* DatabaseService
+        const appDatabase = yield* AppDatabase
+
+        // Written the way an older build wrote it: the form once submitted null
+        // for an empty port, and a stored blob is JSON.parsed rather than
+        // schema-decoded, so the null is still there to be compared against.
+        const [created] = yield* appDatabase.execute((client) =>
+          client
+            .insert(databasesTable)
+            .values({
+              connectionInfo:
+                testEncryptionPrefix +
+                JSON.stringify({ ...connectionInfo, port: null }),
+              name: 'Pagila',
+              type: 'postgres'
+            })
+            .returning()
+        )
+
+        const result = yield* Effect.either(
+          service.update(created.id, 'Renamed', {
+            connectionInfo: { ...connectionInfo, password: '' },
+            type: 'postgres'
+          })
+        )
+
+        const [after] = yield* appDatabase.execute((client) =>
+          client.select().from(databasesTable)
+        )
+
+        return { after, result }
+      })
+    )
+
+    expect(result._tag).toEqual('Right')
+    expect(storedConnectionInfo(after)).toEqual({
+      database: 'pagila',
+      host: 'localhost',
+      password: 'secret',
       username: 'postgres'
     })
   })

--- a/src/server/services/database-service.ts
+++ b/src/server/services/database-service.ts
@@ -455,10 +455,7 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
           // a server they control, or strip its TLS, and have the app hand it
           // over during the handshake.
           if (
-            !targetsSameServer(
-              connectionInfo,
-              storedConnection.connectionInfo
-            )
+            !targetsSameServer(connectionInfo, storedConnection.connectionInfo)
           ) {
             return { _tag: 'differentServer' } as const
           }

--- a/src/server/services/database-service.ts
+++ b/src/server/services/database-service.ts
@@ -13,7 +13,6 @@ import type {
   DatabaseDto,
   DatabaseType,
   PublicConnectionInfo,
-  SslMode,
   UpdateDatabaseConnection,
   WorksheetDto
 } from '@/glue/api/schemas'
@@ -44,23 +43,12 @@ export type ResolvedConnection =
   | { readonly _tag: 'differentServer' }
   | { readonly _tag: 'passwordRequired' }
 
-// A ConnectionTarget with every optional field resolved to the one spelling
-// that means what it means, so two of these compare field by field.
-interface CanonicalTarget {
-  readonly host: string
-  readonly port: number | undefined
-  readonly sslMode: SslMode
-  readonly sslRootCert: string
-}
-
-// The fields that decide where a password goes and how it travels — the ones
-// targetsSameServerAndTransport compares. Both the requested and the stored
-// server connection info satisfy this shape.
+// The fields that decide where a password goes — the ones targetsSameServer
+// compares. Both the requested and the stored server connection info satisfy
+// this shape.
 interface ConnectionTarget {
   readonly host: string
   readonly port?: number | undefined
-  readonly sslMode?: SslMode | undefined
-  readonly sslRootCert?: string | undefined
 }
 
 export class DatabaseService extends Effect.Service<DatabaseService>()(
@@ -467,7 +455,7 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
           // a server they control, or strip its TLS, and have the app hand it
           // over during the handshake.
           if (
-            !targetsSameServerAndTransport(
+            !targetsSameServer(
               connectionInfo,
               storedConnection.connectionInfo
             )
@@ -500,8 +488,7 @@ export class DatabaseService extends Effect.Service<DatabaseService>()(
 
         if (resolved._tag === 'differentServer') {
           return yield* new DifferentServerError({
-            message:
-              'Enter the password to change the server or its SSL settings.'
+            message: 'Enter the password to change the host or port.'
           })
         }
 
@@ -577,53 +564,34 @@ function withDatabaseName(
     })
 }
 
-// The stored password may only be lent back to the server it was saved for,
-// reached the way it was saved to be reached. Host and port decide where the
-// secret is sent; sslMode and sslRootCert decide who else can read it on the
-// way and which certificate is trusted to receive it — `disable` puts it on the
-// wire in the clear (see createSslOptions), and a swapped root certificate is a
-// MITM behind a CA the user never chose. Nothing else is compared: editing the
-// username or database name still targets the same server over the same
-// transport, so requiring a re-typed password there would be friction without a
+// The stored password may only be lent back to the server it was saved for.
+// Host and port are where the secret is sent, and that is the whole rule:
+// without it an authenticated caller could aim a saved password at a server
+// they control and read it straight off the handshake. Nothing else is
+// compared — editing the username or the database name still targets the same
+// server, so requiring a re-typed password there would be friction without a
 // security gain.
 //
-// Any change to the two TLS fields refuses, rather than only a downgrade.
-// sslRootCert has no ordering to downgrade along, so a lattice would only ever
-// cover sslMode, and a half-covered rule is what let this bug exist in the
-// first place. Re-typing the password to tighten TLS is a small, rare cost, and
-// the rule fails closed.
-function targetsSameServerAndTransport(
+// sslMode and sslRootCert are deliberately not compared, though they were once.
+// They decide how the secret travels rather than where it goes, and weakening
+// them only exposes it to someone already sitting on the network path to a host
+// the user chose themselves — a far higher bar than being handed the secret
+// outright. Comparing them cost a re-typed password on every SSL edit, in both
+// directions, including ones that tighten TLS; and the user does not have the
+// password to hand, because the app never shows it. Before re-adding them:
+// moving the host is still refused, so this is not a way to redirect a secret.
+//
+// A stored blob is JSON.parsed, never schema-decoded, so a port the form once
+// wrote as null has to read the same as one that was never set. Without that,
+// an edit changing nothing would be refused.
+function targetsSameServer(
   requested: ConnectionTarget,
   stored: ConnectionTarget
 ): boolean {
-  const requestedTarget = toCanonicalTarget(requested)
-  const storedTarget = toCanonicalTarget(stored)
-
   return (
-    requestedTarget.host === storedTarget.host &&
-    requestedTarget.port === storedTarget.port &&
-    requestedTarget.sslMode === storedTarget.sslMode &&
-    requestedTarget.sslRootCert === storedTarget.sslRootCert
+    requested.host === stored.host &&
+    (requested.port ?? undefined) === (stored.port ?? undefined)
   )
-}
-
-// The same connection can be written several ways, and comparing the raw fields
-// would refuse edits that change nothing. This is where those spellings are
-// reconciled, so the comparison above is a plain equality check:
-//
-// - An absent sslMode opens the connection in the clear exactly like `disable`,
-//   and rows written before the field existed carry no key at all.
-// - The form submits an empty root certificate for "none", older rows leave the
-//   key off. Both mean nothing is pinned.
-// - A stored blob is JSON.parsed, never schema-decoded, so a port the form once
-//   wrote as null has to read the same as one that was never set.
-function toCanonicalTarget(target: ConnectionTarget): CanonicalTarget {
-  return {
-    host: target.host,
-    port: target.port ?? undefined,
-    sslMode: target.sslMode ?? 'disable',
-    sslRootCert: target.sslRootCert ?? ''
-  }
 }
 
 function toPublicConnectionInfo(


### PR DESCRIPTION
Changing a saved connection's SSL mode or root certificate failed with `DifferentServerError` (400) unless the password was re-typed — a password the app deliberately never shows you, so "just re-type it" meant going and finding it.

The cost was charged in both directions. Tightening `require` to `verify-full`, or pointing at a refreshed CA bundle, was refused exactly like stripping TLS off.

Both callers resolve through the same function, so the sharper half was the **connection test**: trying a new SSL setting against a saved connection is what the Test button is for, and it was the one thing the button could not do. You had to find the password before you could find out whether the setting even worked.

## The rule

`targetsSameServerAndTransport` compared `host`, `port`, `sslMode` and `sslRootCert`. It is now `targetsSameServer` and compares `host` and `port`.

Those are where the secret is sent, which is the attack the guard exists to stop: aiming a saved password at a server the caller controls and reading it off the handshake. The SSL fields say how it travels rather than where it goes, and weakening them only exposes it to someone already sitting on the network path to a host the user chose — a much higher bar than being handed it outright.

| edit | before | after |
| --- | --- | --- |
| `require` → `verify-full` | password | borrows |
| `verify-full` → `disable` | password | borrows |
| root certificate swapped | password | borrows |
| username / database name | borrows | borrows |
| host or port moved | password | password |

`CanonicalTarget` and `toCanonicalTarget` go with the SSL fields. They existed to reconcile the several spellings of "nothing is pinned"; the only one left is a port an older form wrote as `null`, which is one `?? undefined` inside the comparison.

Both refusal messages named a distinction that no longer exists, and now name the only thing that is refused: *"Enter the password to change the host or port."* and *"Enter the password to test a different host or port."*

## Known consequence

A caller holding the session token can now PATCH a saved connection from `verify-full` to `disable` without the password, putting it on the wire in the clear to that same host. The host stays pinned, so the secret cannot be redirected, but the transport can be weakened by anything that has the token. This is the deliberate trade, and it is written down at the function and in CLAUDE.md — which argued the strict version and would otherwise have carried two contradictory rules.

## Tests

The two SSL refusal tests are flipped to assert the borrow *and* that the stored row still holds the password afterwards, keeping their security comments rather than dropping them. "Absent SSL fields come back empty" covered canonicalization that no longer exists, so it is replaced by the port equivalent — a legacy row inserted with `port: null`, which must still read as a port that was never set. `connection-tests.test.ts` gains a case proving an `sslMode` change reaches the adapter with the stored password attached.

`yarn test` 1342 passed / 115 files · `yarn typecheck` clean · `yarn lint` clean apart from a pre-existing unused-import warning in `DatabaseExplorer.tsx`.

**Not verified end to end in the running app.** The change is backend-only and `databases.test.ts` / `connection-tests.test.ts` exercise the real handlers against a real stored, encrypted row, but nobody has driven the form itself — that needs an app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
