### PR TITLE
chore(typecheck): compile the build scripts and root configs too

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "electron-forge start",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit -p tsconfig.backend.json && tsc --noEmit -p tsconfig.renderer.json"
+    "typecheck": "tsc --noEmit -p tsconfig.backend.json && tsc --noEmit -p tsconfig.renderer.json && tsc --noEmit -p tsconfig.tooling.json"
   },
   "keywords": [],
   "author": {

--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process'
-import { existsSync, mkdirSync, rmSync } from 'fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
 import pngToIco from 'png-to-ico'
@@ -32,7 +32,7 @@ async function generateIco() {
   const icoBuffer = await pngToIco(pngPaths)
   const icoPath = join(iconsDirectory, 'icon.ico')
 
-  await Bun.write(icoPath, icoBuffer)
+  writeFileSync(icoPath, icoBuffer)
 
   console.log('  Created icon.ico')
 }

--- a/scripts/mysql-seed.test.ts
+++ b/scripts/mysql-seed.test.ts
@@ -189,6 +189,11 @@ describe('pipeFileToCommand', () => {
       source
     ).catch((error: unknown) => error as Error)
 
+    // `.catch` widens the result to include the `void` the call resolves with,
+    // so this is what stands between a pipe that stopped rejecting and a
+    // TypeError on `undefined.cause` — which would report the wrong thing.
+    invariant(failure, 'Piping to a command that exits 3 should have rejected.')
+
     expect((failure.cause as { status: number }).status).toEqual(3)
   })
 })

--- a/scripts/tsconfig-coverage.test.ts
+++ b/scripts/tsconfig-coverage.test.ts
@@ -1,0 +1,247 @@
+import { execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import invariant from 'tiny-invariant'
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalize,
+  typecheckedProjects,
+  uncoveredFiles
+} from './tsconfig-coverage'
+
+const repositoryRoot = join(import.meta.dirname, '..')
+
+describe('uncoveredFiles', () => {
+  it('names a file no project resolved', () => {
+    expect(
+      uncoveredFiles(
+        ['scripts/seed.ts', 'src/main.ts'],
+        [{ files: ['./src/main.ts'], name: 'tsconfig.renderer.json' }]
+      )
+    ).toEqual(['scripts/seed.ts'])
+  })
+
+  it('says nothing when every file is in some project', () => {
+    expect(
+      uncoveredFiles(
+        ['scripts/seed.ts', 'src/main.ts'],
+        [
+          { files: ['./scripts/seed.ts'], name: 'tsconfig.tooling.json' },
+          { files: ['./src/main.ts'], name: 'tsconfig.renderer.json' }
+        ]
+      )
+    ).toEqual([])
+  })
+
+  // `tsc --showConfig` writes the paths it resolved with a `./` on the front
+  // and `git ls-files` does not, so a comparison that took them at face value
+  // would report every file in the repository.
+  it('reads a resolved path as the file git names without the prefix', () => {
+    expect(
+      uncoveredFiles(
+        ['src/main.ts'],
+        [{ files: ['./src/main.ts'], name: 'tsconfig.renderer.json' }]
+      )
+    ).toEqual([])
+  })
+
+  // Neither producer spells a path with a backslash today — `git ls-files` and
+  // `tsc --showConfig` both emit forward slashes, on Windows included. This is
+  // what says the comparison does not depend on that staying true: a separator
+  // is a separator, not a different file, so the guard can never answer "add
+  // every file in the repository to a project" over a spelling.
+  it('reads a windows separator as the same file', () => {
+    expect(
+      uncoveredFiles(
+        ['src/main.ts'],
+        [{ files: ['.\\src\\main.ts'], name: 'tsconfig.renderer.json' }]
+      )
+    ).toEqual([])
+  })
+
+  // Missing from every project is still one missing file, not one per project.
+  it('names a file once however many projects leave it out', () => {
+    expect(
+      uncoveredFiles(
+        ['forge.config.ts'],
+        [
+          { files: ['./src/main.ts'], name: 'tsconfig.renderer.json' },
+          { files: ['./src/server/runtime.ts'], name: 'tsconfig.backend.json' }
+        ]
+      )
+    ).toEqual(['forge.config.ts'])
+  })
+
+  it('names what it found in one order', () => {
+    expect(uncoveredFiles(['vitest.config.ts', 'forge.config.ts'], [])).toEqual(
+      ['forge.config.ts', 'vitest.config.ts']
+    )
+  })
+})
+
+describe('typecheckedProjects', () => {
+  it('names the project a command line checks', () => {
+    expect(
+      typecheckedProjects('tsc --noEmit -p tsconfig.backend.json')
+    ).toEqual(['tsconfig.backend.json'])
+  })
+
+  it('names every project in a chain', () => {
+    expect(
+      typecheckedProjects(
+        'tsc --noEmit -p tsconfig.backend.json && tsc --noEmit -p tsconfig.renderer.json'
+      )
+    ).toEqual(['tsconfig.backend.json', 'tsconfig.renderer.json'])
+  })
+
+  it('reads the long spelling of the project option', () => {
+    expect(typecheckedProjects('tsc --project tsconfig.tooling.json')).toEqual([
+      'tsconfig.tooling.json'
+    ])
+  })
+
+  // `tsconfig.json`'s references write the same paths with a `./` on the front,
+  // and a command line may too — `tsc -p ./tsconfig.backend.json` typechecks
+  // exactly the same project. Read literally, the guard below would call that a
+  // disagreement about which projects exist and say so in those words.
+  it('reads a project named with a leading prefix as the same project', () => {
+    expect(
+      typecheckedProjects('tsc --noEmit -p ./tsconfig.backend.json')
+    ).toEqual(['tsconfig.backend.json'])
+  })
+
+  it('reads the joined spelling of the project option', () => {
+    expect(typecheckedProjects('tsc --project=tsconfig.tooling.json')).toEqual([
+      'tsconfig.tooling.json'
+    ])
+  })
+
+  it('finds nothing in a command line that checks no project', () => {
+    expect(typecheckedProjects('tsc --noEmit')).toEqual([])
+  })
+})
+
+// `yarn typecheck` is only as wide as the projects it runs, and a file in none
+// of them is not checked by anything: it compiles when someone runs it and not
+// before. That is how `scripts/seed.ts` went unchecked for the life of the
+// repository.
+//
+// The projects are read out of `tsconfig.json`'s references rather than listed
+// here, so the references block is what the guard and the editor both go by. A
+// fourth project has to be referenced for this to see it, which is the same
+// step that makes it real.
+describe('the typecheck projects', () => {
+  const references = (
+    JSON.parse(
+      readFileSync(join(repositoryRoot, 'tsconfig.json'), 'utf-8')
+    ) as { references: { path: string }[] }
+  ).references.map((reference) => reference.path)
+
+  // `--showConfig` resolves the include globs and prints the result without
+  // typechecking anything, so this is the compiler's own answer to "which files
+  // is this project" rather than a reimplementation of its glob rules.
+  const projects = references.map((path) => {
+    const configuration = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(repositoryRoot, 'node_modules', 'typescript', 'bin', 'tsc'),
+          '--showConfig',
+          '-p',
+          path
+        ],
+        { cwd: repositoryRoot, encoding: 'utf-8', timeout: 15_000 }
+      )
+    ) as {
+      compilerOptions: {
+        lib?: string[]
+        noEmit?: boolean
+        strict?: boolean
+      }
+      files?: string[]
+    }
+
+    return {
+      compilerOptions: configuration.compilerOptions,
+      files: configuration.files ?? [],
+      name: path
+    }
+  })
+
+  const repositoryFiles = execFileSync('git', ['ls-files', '*.ts', '*.tsx'], {
+    cwd: repositoryRoot,
+    encoding: 'utf-8',
+    timeout: 15_000
+  })
+    .split('\n')
+    .filter((line) => line.length > 0)
+
+  it('covers every TypeScript file in the repository', () => {
+    expect(
+      uncoveredFiles(repositoryFiles, projects),
+      'These files are in no tsconfig project, so `yarn typecheck` never sees them. Add them to the include list of whichever project fits — `tsconfig.tooling.json` for build scripts and root configs — or, if a file is genuinely not meant to compile, say so where it lives rather than by leaving it out.'
+    ).toEqual([])
+  })
+
+  // An empty result above is what a passing repository looks like and also what
+  // a guard reading nothing looks like. These are what tell them apart: three
+  // projects that each really resolved the files they exist for.
+  it('reads the files each project resolved', () => {
+    expect({
+      backend: projects
+        .find((project) => project.name.includes('backend'))
+        ?.files.includes('./src/server/runtime.ts'),
+      renderer: projects
+        .find((project) => project.name.includes('renderer'))
+        ?.files.includes('./src/app/App.tsx'),
+      tooling: projects
+        .find((project) => project.name.includes('tooling'))
+        ?.files.includes('./scripts/seed.ts')
+    }).toEqual({ backend: true, renderer: true, tooling: true })
+  })
+
+  // The tooling project overrides three things from the base config, and
+  // nothing else in the repository notices when one of them goes. Without
+  // `strict` a build script can dereference an undefined value; without the
+  // narrowed `lib` it can reference `document` and compile against a DOM that
+  // is not there at runtime; without `noEmit` a bare
+  // `tsc -p tsconfig.tooling.json` writes into `dist`. Every one of those
+  // survives all three typechecks and every other case in this file, so the
+  // overrides are read back from the config the compiler resolved.
+  //
+  // Only the tooling project, deliberately. `tsconfig.backend.json` inherits
+  // the base `dom` too and has the same problem, but changing what the backend
+  // compiles against is a separate change with its own failures to work
+  // through.
+  it('checks the tooling project the way it says it does', () => {
+    const tooling = projects.find((project) => project.name.includes('tooling'))
+
+    invariant(tooling, 'tsconfig.json references no tooling project.')
+
+    expect(tooling.compilerOptions).toMatchObject({
+      noEmit: true,
+      strict: true
+    })
+    expect(tooling.compilerOptions.lib).toEqual(['esnext'])
+  })
+
+  it('reads the repository file list', () => {
+    expect(repositoryFiles).toContain('scripts/seed.ts')
+  })
+
+  // Being referenced is not being checked. The references block is what the
+  // editor and the guard above read, and `yarn typecheck` is a separate command
+  // line that has to name each project again — a fourth project added to one
+  // and not the other looks covered here while CI never compiles it.
+  it('are the projects the typecheck script runs', () => {
+    const manifest = JSON.parse(
+      readFileSync(join(repositoryRoot, 'package.json'), 'utf-8')
+    ) as { scripts: Record<string, string> }
+
+    expect(
+      typecheckedProjects(manifest.scripts.typecheck).sort(),
+      "The `typecheck` script and `tsconfig.json`'s references disagree about which projects exist. Every referenced project needs its own `tsc --noEmit -p` in the script, or CI never compiles it."
+    ).toEqual(references.map(normalize).sort())
+  })
+})

--- a/scripts/tsconfig-coverage.ts
+++ b/scripts/tsconfig-coverage.ts
@@ -1,0 +1,55 @@
+/**
+ * Which of the repository's TypeScript files no tsconfig project resolves, so a
+ * guard test can check that `yarn typecheck` is as wide as the repository.
+ */
+
+export interface TypeScriptProject {
+  /** The files `tsc --showConfig` resolved for it. */
+  readonly files: readonly string[]
+  /** The tsconfig they came from, so a caller can tell the projects apart. */
+  readonly name: string
+}
+
+/**
+ * A path as the comparisons here see it. The same file and the same project get
+ * spelled more than one way: `tsc --showConfig` prints what it resolved with a
+ * `./` on the front and separators already normalised, `git ls-files` prints
+ * neither, and a command line may use either. Left alone, two spellings of one
+ * path never match, and the guards answer that every file in the repository is
+ * unchecked and that the projects disagree about which projects exist.
+ */
+export function normalize(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\.\//, '')
+}
+
+/**
+ * The tsconfig projects a command line checks, in the order it names them.
+ *
+ * Separate from the references block on purpose: that block is what the editor
+ * and the coverage guard read, and it constrains nothing about what CI runs.
+ * `yarn typecheck` names each project again on its own command line, and the
+ * two drifting apart is the failure this exists to catch — a project that is
+ * referenced, resolves files, and is compiled by nothing.
+ */
+export function typecheckedProjects(script: string): string[] {
+  const matches = script.matchAll(/(?:-p|--project)[\s=]+(\S+)/g)
+
+  return [...matches].map((match) => normalize(match[1]))
+}
+
+/**
+ * The files in `repositoryFiles` that appear in no project, sorted.
+ *
+ * One pass over the repository rather than one pass per project, so a file
+ * missing from all three is named once and there is no set to dedupe after.
+ */
+export function uncoveredFiles(
+  repositoryFiles: readonly string[],
+  projects: readonly TypeScriptProject[]
+): string[] {
+  const covered = new Set(
+    projects.flatMap((project) => project.files.map(normalize))
+  )
+
+  return repositoryFiles.filter((file) => !covered.has(normalize(file))).sort()
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.backend.json" },
-    { "path": "./tsconfig.renderer.json" }
+    { "path": "./tsconfig.renderer.json" },
+    { "path": "./tsconfig.tooling.json" }
   ]
 }

--- a/tsconfig.tooling.json
+++ b/tsconfig.tooling.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": [
+    "drizzle.config.ts",
+    "forge.config.ts",
+    "forge.env.d.ts",
+    "scripts/**/*",
+    "vite.main.config.ts",
+    "vite.preload.config.ts",
+    "vitest.config.ts"
+  ]
+}


### PR DESCRIPTION
Closes #161.

`yarn typecheck` ran `tsconfig.backend.json` and `tsconfig.renderer.json`, and both are scoped to `src`. Fifteen files sat outside every project — `scripts/` (nine files), `forge.config.ts`, `forge.env.d.ts`, `vite.main.config.ts`, `vite.preload.config.ts`, `vitest.config.ts`, `drizzle.config.ts` — several of which run in CI and in the release pipeline, where a type error shows up as a release that half-happened rather than as a red check.

`tsconfig.tooling.json` is the third project. Node types, no DOM lib, `noEmit`, strict like the other two; referenced from `tsconfig.json` and named on the `typecheck` command line.

## What turning it on found

```
scripts/generate-icons.ts(35,9): error TS2868: Cannot find name 'Bun'.
scripts/mysql-seed.test.ts(192,21): error TS2339: Property 'cause' does not
  exist on type 'void | Error'.
```

`await Bun.write(...)` in a script that already imports `fs` and uses it three times — the global was reachable only because nothing typechecked the file. It still runs under `bun`, which implements `node:fs`, so `writeFileSync` is the same write without a type dependency on the runtime.

The second is a `.catch` widening the awaited value to `void | Error`. Reading `.cause` off it was a `TypeError` waiting for the day the pipe stopped rejecting — and the case would then have failed for the wrong reason, reporting a missing property rather than a command that stopped failing. An `invariant` names what the case actually assumes.

## The guard

A third project catches those two and goes on catching them. What it cannot catch is a *fourth* file, or a fourth project, quietly falling outside it. `scripts/tsconfig-coverage.ts` and its test hold that down on three properties:

- **Every `*.ts`/`*.tsx` file `git ls-files` names is resolved by some referenced project.** File lists come from `tsc --showConfig`, which resolves the include globs and prints the answer without compiling — the compiler's own answer rather than a reimplementation of its glob rules.
- **The referenced projects are the projects `yarn typecheck` runs.** Being referenced is not being checked; CI runs a separate command line that has to name each project again.
- **The tooling project still checks the way it claims to.** Each of its three overrides is invisible to everything else: without `strict` a script can dereference an undefined value, without the narrowed `lib` it can reference `document` and compile, and without `noEmit` a bare `tsc -p tsconfig.tooling.json` writes into `dist`.

An empty "uncovered" list is what a healthy repository looks like and also what a guard that has stopped reading anything looks like, so separate cases assert each project really resolved the file it exists for and that the repository list is non-empty.

## Review

A fresh-context review verified every claim in the commit message independently — reproduced both type errors at the same line and column, ran the real `generateIco` body under `bun` to confirm the `writeFileSync` swap is byte-identical, and re-ran all ten mutants. It raised two should-fixes, both taken:

- **`typecheckedProjects` did not normalize the `./` prefix.** Writing the script as `tsc -p ./tsconfig.backend.json` — the same spelling the references block uses, and a command line that typechecks fine — turned the guard red with an assertion message that was simply wrong. `normalize` already existed one function up for exactly this on file paths; it is exported now and both comparisons go through it.
- **None of `tsconfig.tooling.json`'s compiler options were guarded, and three are load-bearing.** Deleting `strict`, `lib`, or `noEmit` survived `tsc` and all fifteen tests. They are now read back from the resolved config, and all three mutants die.

Mutation testing: **14 defects, no survivors.**

## Follow-up, deliberately not here

`tsconfig.backend.json` inherits `dom` from the base config too, so backend code can reference `document` and compile. Same shape of problem, but changing what the backend compiles against is a separate change with its own failures to work through.

## Gates

| Gate | Result |
|---|---|
| `tsc -p tsconfig.backend.json` | exit 0 |
| `tsc -p tsconfig.renderer.json` | exit 0 |
| `tsc -p tsconfig.tooling.json` | exit 0 |
| prettier `--check` | clean |
| eslint | 0 errors, 1 pre-existing warning (`DatabaseExplorer.tsx:19`) |
| vitest | 1430 passed, 1 failed — `sqlite-adapter.test.ts` Windows path, pre-existing on `main` |
