### PR TITLE
feat(results): find rows in a result without changing the query

### DIFF
--- a/.agents/friction-log/20260821151912-basicsetup-opts-in/friction.md
+++ b/.agents/friction-log/20260821151912-basicsetup-opts-in/friction.md
@@ -1,0 +1,58 @@
+---
+title:
+  'basicSetup opts in to searchKeymap, so CodeMirror silently owns ⌘F, ⌘D and ⌘G'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The extensions a CodeMirror editor has are the ones listed in `createExtensions`
+in `src/app/components/use-worksheet-editor.ts`. Binding a new app-level
+shortcut means checking that list plus the `useHotkeys` calls.
+
+## Current Behavior
+
+`@uiw/codemirror-extensions-basic-setup` enables every option it is not handed a
+literal `false`, and `editorBasicSetup` only names five. So the editor silently
+carried `searchKeymap` and `highlightSelectionMatches`, and CodeMirror owned ⌘F,
+⌘G, F3, ⌘D, ⌘⌥G and ⌘⇧L with nothing anywhere in `src/` to say so.
+
+Adding find-in-results meant discovering this by reading
+`node_modules/@uiw/react-codemirror/node_modules/@uiw/codemirror-extensions-basic-setup/esm/index.js`.
+`openSearchPanel` also self-installs via `StateEffect.appendConfig`, so a search
+panel appears for an extension that is not in any list.
+
+Putting any of the dropped bindings back is worse than it looks.
+`@codemirror/search` is not a direct dependency, and the tree carries **four**
+copies of it at two versions:
+
+    node_modules/@codemirror/search                                    6.7.1
+    node_modules/codemirror/node_modules/@codemirror/search            6.5.11
+    node_modules/@uiw/react-codemirror/node_modules/@codemirror/search 6.5.11
+    node_modules/@uiw/.../codemirror-extensions-basic-setup/.../search 6.7.1
+
+`yarn add @codemirror/search` forks the lockfile into two entries rather than
+deduping. An app import then resolves to a different module instance than the
+one basicSetup is built against, and CodeMirror keys its state off `Facet`
+identity — so `openSearchPanel` from one copy installs state the other's keymap
+never reads. That failure is silent and looks like a half-working search panel.
+
+## Possible Solution
+
+List the opted-in-by-default options explicitly in `editorBasicSetup` with
+`false` for the ones not wanted, so the file states what the editor actually
+binds. And if in-editor find is ever wanted back, flatten the CodeMirror tree
+first (a `resolutions` entry for `@codemirror/search`, `@codemirror/state` and
+`@codemirror/view`) rather than adding the dependency on top of four copies.
+
+## Minimal Reproducible Example
+
+    find node_modules -path "*@codemirror/search/package.json" \
+      -exec grep -H '"version"' {} \;
+    # four paths, two versions -- none of them a direct dependency
+
+## Context
+
+Hit while adding find-in-results (⌘F). Cost the time to find out why ⌘F opened
+CodeMirror's panel, then a full add-and-revert of `@codemirror/search` once the
+duplication showed up.

--- a/.agents/friction-log/20260821151936-radix-context-menu/friction.md
+++ b/.agents/friction-log/20260821151936-radix-context-menu/friction.md
@@ -1,0 +1,52 @@
+---
+title:
+  'Radix context-menu items cannot be activated under jsdom, so no test can
+  cover a menu action'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A Radix context-menu action can be tested the way every other click is:
+right-click the trigger, click the item, assert what the handler did.
+
+## Current Behavior
+
+Under jsdom the item resolves but `onSelect` never fires, so the assertion sees
+zero calls and reads as "the handler is wrong" rather than "the interaction did
+not happen". Both routes fail:
+
+- `await user.click(screen.getByRole('menuitem', { name: 'Copy' }))`
+- `await user.pointer({ keys: '[MouseRight]', target: cell })` then
+  `await user.keyboard('{ArrowDown}{Enter}')`
+
+Radix selects on `pointerup` with pointer state jsdom does not reproduce, and on
+open it focuses the element with `role="menu"` rather than the first item. This
+reproduces on a plain `QueryResultTable` with no search, no filtering and no
+props beyond `result`, so it is the menu and not the component under test.
+
+That is why `QueryResultTable.test.tsx`'s existing menu test asserts only that
+the items are present — which is easy to read as "nobody got round to it" rather
+than "this is the ceiling".
+
+## Possible Solution
+
+Either note the ceiling next to that test so the next person does not spend the
+same half hour on it, or extract the menu's `onSelect` bodies into a plain
+module (`copyCellValue(row, column)`) that can be unit-tested without the menu,
+leaving the component test to assert only what it can.
+
+## Minimal Reproducible Example
+
+    render(<QueryResultTable result={{ fields: [{ name: 'id' }], rowCount: 1,
+      rows: [{ id: 'a3f9' }], truncated: false }} />)
+    await user.pointer({ keys: '[MouseRight]', target: screen.getByText('a3f9') })
+    await user.click(screen.getByRole('menuitem', { name: 'Copy' }))
+    expect(writeText).toHaveBeenCalled()   // 0 calls
+
+## Context
+
+Hit while adding find-in-results: the sharpest guard on the filtered-row index
+translation would have been "right-click a filtered row and copy it", and that
+test cannot be written. Covered by asserting the rendered row number instead,
+which works only because the render and the copy handlers read the same binding.

--- a/src/app/components/QueryResultContent.tsx
+++ b/src/app/components/QueryResultContent.tsx
@@ -6,16 +6,19 @@ import type { QueryDto } from '@/glue/api/schemas'
 
 import { QueryResultEmpty } from './QueryResultEmpty'
 import { QueryResultTable } from './QueryResultTable'
+import type { ResultSearchView } from './query-result-search'
 import { toQueryErrorParts } from './query-error-parts'
 
 interface QueryResultContentProps {
   databaseName: string | undefined
   query: QueryDto | undefined
+  search?: ResultSearchView
 }
 
 export function QueryResultContent({
   databaseName,
-  query
+  query,
+  search
 }: QueryResultContentProps): ReactElement {
   if (isQueryInFlight(query)) {
     return (
@@ -38,7 +41,12 @@ export function QueryResultContent({
   }
 
   if (query?.result) {
-    return <QueryResultTable result={query.result} />
+    return (
+      <QueryResultTable
+        result={query.result}
+        search={search}
+      />
+    )
   }
 
   return <QueryResultEmpty />

--- a/src/app/components/QueryResultTable.test.tsx
+++ b/src/app/components/QueryResultTable.test.tsx
@@ -3,13 +3,20 @@ import userEvent from '@testing-library/user-event'
 import invariant from 'tiny-invariant'
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 
+import type { QueryResultDto } from '@/glue/api/schemas'
+
 import { stubElementSize } from '../test-element-size'
+import { getResultFieldNames } from './query-result-columns'
 import {
   escapeCsvField,
   formatCellValue,
   formatRowAsCsv,
   formatRowAsJson
 } from './query-result-format'
+import {
+  buildResultSearchIndex,
+  type ResultSearchView
+} from './query-result-search'
 import { QueryResultTable } from './QueryResultTable'
 
 const writeText = vi.fn().mockResolvedValue(undefined)
@@ -366,5 +373,247 @@ describe('formatRowAsJson', () => {
     const row = { id: 1, name: 'Alice' }
 
     expect(formatRowAsJson(row)).toEqual(JSON.stringify(row, null, 2))
+  })
+})
+
+describe('QueryResultTable find', () => {
+  const people = {
+    fields: [{ name: 'id' }, { name: 'email' }],
+    rowCount: 4,
+    rows: [
+      { email: 'mia@example.com', id: 'a3f9' },
+      { email: 'leo@example.com', id: '0c8e' },
+      { email: 'a3f9@x.io', id: '77bd' },
+      { email: 'zoe@example.com', id: '9fe2' }
+    ],
+    truncated: false
+  }
+
+  // Built through the real engine rather than by hand, so these also check that
+  // the grid and the matcher agree about column order and row indexes.
+  function searchFor(
+    result: QueryResultDto,
+    query: string,
+    overrides: Partial<ResultSearchView> = {}
+  ): ResultSearchView {
+    const index = buildResultSearchIndex({
+      columnNames: getResultFieldNames(result),
+      query,
+      rows: result.rows
+    })
+
+    return {
+      activeIndex: index.matches.length > 0 ? 0 : -1,
+      columnHasMatch: index.columnHasMatch,
+      isFiltering: false,
+      matches: index.matches,
+      needle: index.needle,
+      query,
+      ...overrides
+    }
+  }
+
+  function cellsOf(row: HTMLElement): string[] {
+    return within(row)
+      .getAllByRole('cell')
+      .map((cell) => cell.textContent ?? '')
+  }
+
+  // The plain path has to stay exactly as it was: every result in the app is
+  // rendered without a search, so a stray wrapper here would be permanent.
+  it('marks nothing when no search is given', () => {
+    const { container } = render(<QueryResultTable result={people} />)
+
+    expect(container.querySelectorAll('mark')).toHaveLength(0)
+  })
+
+  it('marks nothing while the find bar is open but empty', () => {
+    const { container } = render(
+      <QueryResultTable
+        result={people}
+        search={searchFor(people, '')}
+      />
+    )
+
+    expect(container.querySelectorAll('mark')).toHaveLength(0)
+  })
+
+  it('marks the matched run and leaves the rest of the cell alone', () => {
+    const { container } = render(
+      <QueryResultTable
+        result={people}
+        search={searchFor(people, 'a3f9')}
+      />
+    )
+
+    const marks = container.querySelectorAll('mark')
+
+    expect(Array.from(marks).map((mark) => mark.textContent)).toEqual([
+      'a3f9',
+      'a3f9'
+    ])
+
+    const [, firstRow] = screen.getAllByRole('row')
+
+    expect(cellsOf(firstRow)).toEqual(['1', 'a3f9', 'mia@example.com'])
+  })
+
+  it('keeps the cell text intact when the match is only part of it', () => {
+    render(
+      <QueryResultTable
+        result={people}
+        search={searchFor(people, 'example')}
+      />
+    )
+
+    const [, firstRow] = screen.getAllByRole('row')
+
+    expect(cellsOf(firstRow)).toEqual(['1', 'a3f9', 'mia@example.com'])
+  })
+
+  it('marks the active match apart from the others', () => {
+    const { container } = render(
+      <QueryResultTable
+        result={people}
+        search={searchFor(people, 'a3f9')}
+      />
+    )
+
+    const active = container.querySelectorAll('[data-find-active]')
+
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveTextContent('a3f9')
+  })
+
+  it('moves the active cell to the row the ordinal points at', () => {
+    const { container } = render(
+      <QueryResultTable
+        result={people}
+        search={searchFor(people, 'a3f9', { activeIndex: 1 })}
+      />
+    )
+
+    const active = container.querySelector('[data-find-active]')
+
+    // The second match is in the third row's email, not its id.
+    expect(active).toHaveTextContent('a3f9@x.io')
+  })
+
+  it('marks nothing as active when nothing matches', () => {
+    const { container } = render(
+      <QueryResultTable
+        result={people}
+        search={searchFor(people, 'nobody')}
+      />
+    )
+
+    expect(container.querySelectorAll('mark')).toHaveLength(0)
+    expect(container.querySelectorAll('[data-find-active]')).toHaveLength(0)
+  })
+
+  it('names the columns the search landed in', () => {
+    render(
+      <QueryResultTable
+        result={people}
+        search={searchFor(people, 'mia')}
+      />
+    )
+
+    expect(screen.getByRole('columnheader', { name: 'email' })).toHaveClass(
+      'text-find-strong'
+    )
+    expect(screen.getByRole('columnheader', { name: 'id' })).not.toHaveClass(
+      'text-find-strong'
+    )
+  })
+
+  describe('with non-matching rows hidden', () => {
+    const filtered = searchFor(people, 'a3f9', { isFiltering: true })
+
+    it('shows only the matching rows', () => {
+      render(
+        <QueryResultTable
+          result={people}
+          search={filtered}
+        />
+      )
+
+      // The header plus the two matches.
+      expect(screen.getAllByRole('row')).toHaveLength(3)
+    })
+
+    // Renumbering would make "row 3" mean one thing while filtering and another
+    // without it, and nothing would line the view back up with the query.
+    //
+    // This is also the guard on the index translation, and the only one there
+    // can be: the number, the cells, and both Copy actions all read the row
+    // through the same source index, and Radix menu items cannot be activated
+    // under jsdom -- a click resolves the item but never fires `onSelect` --
+    // so the copy path itself is unassertable here.
+    it('keeps each row its original number', () => {
+      render(
+        <QueryResultTable
+          result={people}
+          search={filtered}
+        />
+      )
+
+      const [, firstRow, secondRow] = screen.getAllByRole('row')
+
+      expect(cellsOf(firstRow)).toEqual(['1', 'a3f9', 'mia@example.com'])
+      expect(cellsOf(secondRow)).toEqual(['3', '77bd', 'a3f9@x.io'])
+    })
+
+    it('offers the context menu on a row that survived the filter', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <QueryResultTable
+          result={people}
+          search={filtered}
+        />
+      )
+
+      const [, , secondRow] = screen.getAllByRole('row')
+      const [, idCell] = within(secondRow).getAllByRole('cell')
+
+      await user.pointer({ keys: '[MouseRight]', target: idCell })
+
+      expect(screen.getByRole('menuitem', { name: 'Copy' })).toBeInTheDocument()
+    })
+
+    it('says so when nothing matches, keeping the columns visible', () => {
+      render(
+        <QueryResultTable
+          result={people}
+          search={searchFor(people, 'nobody', { isFiltering: true })}
+        />
+      )
+
+      expect(
+        screen.getByRole('columnheader', { name: 'email' })
+      ).toBeInTheDocument()
+      expect(screen.getByText(/No matches for/)).toHaveTextContent(
+        'No matches for “nobody”.'
+      )
+    })
+
+    it('says how far the search reached when the result was cut off', () => {
+      const truncated = { ...people, truncated: true }
+
+      render(
+        <QueryResultTable
+          result={truncated}
+          search={searchFor(truncated, 'nobody', { isFiltering: true })}
+        />
+      )
+
+      expect(screen.getByText(/No matches for/)).toHaveTextContent(
+        'No matches for “nobody” in the first 10,000 rows.'
+      )
+      expect(
+        screen.getByText(/Add a WHERE clause to search the rest/)
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/src/app/components/QueryResultTable.tsx
+++ b/src/app/components/QueryResultTable.tsx
@@ -4,7 +4,6 @@ import {
   Fragment,
   memo,
   ReactElement,
-  useEffect,
   useMemo,
   useRef
 } from 'react'
@@ -12,6 +11,7 @@ import {
 import { maxResultRows } from '@/databases/adapter'
 import type { QueryResultDto } from '@/glue/api/schemas'
 
+import { useScrollToMatch } from '../hooks/use-scroll-to-match'
 import { cn } from '../lib/utils'
 import {
   ContextMenu,
@@ -26,6 +26,7 @@ import {
 import {
   getResultColumns,
   getResultFieldNames,
+  type ResultColumn,
   rowNumberColumnWidth
 } from './query-result-columns'
 import {
@@ -34,6 +35,7 @@ import {
   formatRowAsJson
 } from './query-result-format'
 import {
+  applySearchToRows,
   type ResultRowMatch,
   type ResultSearchView,
   splitCellText
@@ -62,10 +64,6 @@ const headerHeight = 31
 // rows rather than blank space.
 const overscan = 12
 
-// A stable identity for "no search", so the absent-`search` case does not hand
-// the virtualizer and the effects a fresh array on every render.
-const noMatches: ResultRowMatch[] = []
-
 export const QueryResultTable = memo(function QueryResultTable({
   result,
   search
@@ -91,30 +89,15 @@ export const QueryResultTable = memo(function QueryResultTable({
     [columns]
   )
 
-  const needle = search?.needle ?? ''
-  const matches = search?.matches ?? noMatches
-  const isFiltering = search?.isFiltering === true && needle !== ''
-
-  const activeMatch =
-    search === undefined || search.activeIndex < 0
-      ? undefined
-      : matches[search.activeIndex]
-
-  // The one place a virtualizer index becomes an index into `result.rows`.
-  // While filtering they are different things, and every read of the row, its
-  // number and its copy actions has to go through this -- a missed call site
-  // shows the wrong row's data with nothing to say so.
-  const toSourceIndex = (index: number): number => {
-    if (!isFiltering) {
-      return index
-    }
-
-    const match = matches[index]
-
-    return match === undefined ? index : match.rowIndex
-  }
-
-  const visibleRowCount = isFiltering ? matches.length : result.rows.length
+  const {
+    activeMatch,
+    activeRowIndex,
+    activeVisibleIndex,
+    isFiltering,
+    needle,
+    toSourceIndex,
+    visibleRowCount
+  } = applySearchToRows(result.rows.length, search)
 
   const virtualizer = useVirtualizer({
     count: visibleRowCount,
@@ -135,48 +118,15 @@ export const QueryResultTable = memo(function QueryResultTable({
       ? totalSize - (virtualRows[virtualRows.length - 1]?.end ?? 0)
       : 0
 
-  const activeRowIndex = activeMatch === undefined ? -1 : activeMatch.rowIndex
-
-  // While filtering, the virtualizer counts matches rather than rows, so the
-  // ordinal into `matches` already is the position it wants.
-  const activeVisibleIndex =
-    activeMatch === undefined
-      ? -1
-      : isFiltering
-        ? (search?.activeIndex ?? -1)
-        : activeMatch.rowIndex
-
-  useEffect(() => {
-    if (activeVisibleIndex < 0) {
-      return
-    }
-
-    // `auto` leaves the offset alone when the row is already comfortably in
-    // view, so stepping between two matches on screen does not jerk the grid.
-    virtualizer.scrollToIndex(activeVisibleIndex, { align: 'auto' })
-  }, [activeVisibleIndex, virtualizer])
-
-  const isActiveRowRendered = virtualRows.some(
-    (item) => toSourceIndex(item.index) === activeRowIndex
-  )
-
-  useEffect(() => {
-    if (activeRowIndex < 0 || !isActiveRowRendered) {
-      return
-    }
-
-    // Columns are not virtualized and the table is auto-layout, so the rendered
-    // width of a column is not the width that was pinned for it. Asking the
-    // browser to reveal the cell is the only reading of the layout that is
-    // actually true.
-    //
-    // Split from the vertical jump on purpose: `scrollToIndex` sets `scrollTop`
-    // synchronously, but the virtualizer re-windows on the scroll event that
-    // follows, so the target cell is not in the DOM during that pass.
-    scrollRef.current
-      ?.querySelector('[data-find-active]')
-      ?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' })
-  }, [activeRowIndex, isActiveRowRendered])
+  useScrollToMatch({
+    activeRowIndex,
+    activeVisibleIndex,
+    isActiveRowRendered: virtualRows.some(
+      (item) => toSourceIndex(item.index) === activeRowIndex
+    ),
+    scrollRef,
+    scrollToIndex: virtualizer.scrollToIndex
+  })
 
   return (
     <div
@@ -203,31 +153,10 @@ export const QueryResultTable = memo(function QueryResultTable({
           ))}
         </colgroup>
 
-        <thead>
-          <tr>
-            <th className="sticky top-0 z-[5] h-[var(--head-h)] border-b border-border bg-panel2" />
-
-            {columns.map((column, columnIndex) => (
-              <th
-                className={cn(
-                  'sticky top-0 z-[5] h-[var(--head-h)] whitespace-nowrap border-b border-border bg-panel2 px-[14px] text-[12px] font-medium text-text2',
-                  // The header sits over its values, so it takes the column's
-                  // alignment rather than always hugging the left edge.
-                  column.align === 'right' ? 'text-right' : 'text-left',
-                  // Which columns the search landed in, answered at the top of
-                  // the column rather than only where the rows happen to be
-                  // scrolled to.
-                  search?.columnHasMatch[columnIndex] === true &&
-                    'text-find-strong'
-                )}
-                key={column.key}
-                scope="col"
-              >
-                {column.name}
-              </th>
-            ))}
-          </tr>
-        </thead>
+        <QueryResultHead
+          columnHasMatch={search?.columnHasMatch}
+          columns={columns}
+        />
 
         <tbody>
           {paddingTop > 0 && (
@@ -241,109 +170,17 @@ export const QueryResultTable = memo(function QueryResultTable({
 
           {virtualRows.map((virtualRow) => {
             const rowIndex = toSourceIndex(virtualRow.index)
-            const row = result.rows[rowIndex]
 
             return (
-              <tr
-                className="group"
+              <QueryResultRow
+                activeMatch={activeMatch}
+                columnNames={columnNames}
+                columns={columns}
                 key={rowIndex}
-              >
-                <td className="h-[var(--row-h)] select-none border-b border-border2 px-[10px] text-right font-mono text-[11px] text-text3 group-hover:bg-hover">
-                  {rowIndex + 1}
-                </td>
-
-                {columns.map((column, columnIndex) => {
-                  // Known wrong for a result with two identically-named fields:
-                  // the driver's row is keyed by name, so both columns read the
-                  // first field's value. The columns are at least distinct
-                  // elements now; showing the right value needs an array row
-                  // mode in the adapter.
-                  const value = row?.[column.name]
-                  const text = formatCellValue(value)
-
-                  const isActiveCell =
-                    activeMatch !== undefined &&
-                    activeMatch.rowIndex === rowIndex &&
-                    activeMatch.columnIndex === columnIndex
-
-                  return (
-                    <ContextMenu key={`${rowIndex}-${column.key}`}>
-                      <ContextMenuTrigger asChild>
-                        <td
-                          className={cn(
-                            'h-[var(--row-h)] whitespace-nowrap border-b border-border2 px-[14px] font-mono text-[12px] group-hover:bg-hover',
-                            column.align === 'right'
-                              ? 'text-right'
-                              : 'text-left',
-                            value === null && 'text-text3 italic'
-                          )}
-                          data-find-active={isActiveCell ? '' : undefined}
-                        >
-                          {needle === '' ? (
-                            text
-                          ) : (
-                            <HighlightedCellText
-                              isActive={isActiveCell}
-                              needle={needle}
-                              text={text}
-                            />
-                          )}
-                        </td>
-                      </ContextMenuTrigger>
-
-                      <ContextMenuContent>
-                        <ContextMenuItem
-                          className="text-xs"
-                          onSelect={() => navigator.clipboard.writeText(text)}
-                        >
-                          Copy
-                        </ContextMenuItem>
-
-                        <ContextMenuItem
-                          className="text-xs"
-                          onSelect={() =>
-                            navigator.clipboard.writeText(column.name)
-                          }
-                        >
-                          Copy Column Name
-                        </ContextMenuItem>
-
-                        <ContextMenuSeparator />
-
-                        <ContextMenuSub>
-                          <ContextMenuSubTrigger className="text-xs">
-                            Copy Row
-                          </ContextMenuSubTrigger>
-
-                          <ContextMenuSubContent>
-                            <ContextMenuItem
-                              className="text-xs"
-                              onSelect={() =>
-                                navigator.clipboard.writeText(
-                                  formatRowAsCsv(row ?? {}, columnNames)
-                                )
-                              }
-                            >
-                              As CSV
-                            </ContextMenuItem>
-
-                            <ContextMenuItem
-                              className="text-xs"
-                              onSelect={() =>
-                                navigator.clipboard.writeText(
-                                  formatRowAsJson(row ?? {})
-                                )
-                              }
-                            >
-                              As JSON
-                            </ContextMenuItem>
-                          </ContextMenuSubContent>
-                        </ContextMenuSub>
-                      </ContextMenuContent>
-                    </ContextMenu>
-                  )
-                })}
-              </tr>
+                needle={needle}
+                row={result.rows[rowIndex]}
+                rowIndex={rowIndex}
+              />
             )
           })}
 
@@ -357,32 +194,220 @@ export const QueryResultTable = memo(function QueryResultTable({
           )}
 
           {isFiltering && visibleRowCount === 0 && (
-            <tr>
-              <td
-                className="px-[14px] py-4 text-[12.5px] text-text2"
-                colSpan={columns.length + 1}
-              >
-                No matches for “{search?.query}”
-                {result.truncated
-                  ? ` in the first ${Intl.NumberFormat().format(maxResultRows)} rows.`
-                  : '.'}
-                {/* Silence here would answer a question the search did not ask:
-                    a row absent from the first page is not a row absent from
-                    the table. */}
-                {result.truncated && (
-                  <span className="block pt-[6px] text-text3">
-                    Only part of the table was returned. Add a WHERE clause to
-                    search the rest.
-                  </span>
-                )}
-              </td>
-            </tr>
+            <NoMatchesRow
+              columnCount={columns.length + 1}
+              query={search?.query ?? ''}
+              truncated={result.truncated}
+            />
           )}
         </tbody>
       </table>
     </div>
   )
 })
+
+/**
+ * What the grid says when the filter is on and nothing matched.
+ *
+ * The truncation half is the point: a row absent from the first page is not a
+ * row absent from the table, and a bare "no matches" against a capped result
+ * answers a question the user did not ask.
+ */
+function NoMatchesRow({
+  columnCount,
+  query,
+  truncated
+}: {
+  columnCount: number
+  query: string
+  truncated: boolean
+}): ReactElement {
+  return (
+    <tr>
+      <td
+        className="px-[14px] py-4 text-[12.5px] text-text2"
+        colSpan={columnCount}
+      >
+        No matches for “{query}”
+        {truncated
+          ? ` in the first ${Intl.NumberFormat().format(maxResultRows)} rows.`
+          : '.'}
+        {truncated && (
+          <span className="block pt-[6px] text-text3">
+            Only part of the table was returned. Add a WHERE clause to search
+            the rest.
+          </span>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+function QueryResultHead({
+  columnHasMatch,
+  columns
+}: {
+  columnHasMatch: boolean[] | undefined
+  columns: ResultColumn[]
+}): ReactElement {
+  return (
+    <thead>
+      <tr>
+        <th className="sticky top-0 z-[5] h-[var(--head-h)] border-b border-border bg-panel2" />
+
+        {columns.map((column, columnIndex) => (
+          <th
+            className={cn(
+              'sticky top-0 z-[5] h-[var(--head-h)] whitespace-nowrap border-b border-border bg-panel2 px-[14px] text-[12px] font-medium text-text2',
+              // The header sits over its values, so it takes the column's
+              // alignment rather than always hugging the left edge.
+              column.align === 'right' ? 'text-right' : 'text-left',
+              // Which columns the search landed in, answered at the top of the
+              // column rather than only where the rows happen to be scrolled
+              // to.
+              columnHasMatch?.[columnIndex] === true && 'text-find-strong'
+            )}
+            key={column.key}
+            scope="col"
+          >
+            {column.name}
+          </th>
+        ))}
+      </tr>
+    </thead>
+  )
+}
+
+function QueryResultRow({
+  activeMatch,
+  columnNames,
+  columns,
+  needle,
+  row,
+  rowIndex
+}: {
+  activeMatch: ResultRowMatch | undefined
+  columnNames: string[]
+  columns: ResultColumn[]
+  needle: string
+  row: Record<string, unknown> | undefined
+  rowIndex: number
+}): ReactElement {
+  return (
+    <tr className="group">
+      <td className="h-[var(--row-h)] select-none border-b border-border2 px-[10px] text-right font-mono text-[11px] text-text3 group-hover:bg-hover">
+        {rowIndex + 1}
+      </td>
+
+      {columns.map((column, columnIndex) => (
+        <QueryResultCell
+          column={column}
+          columnNames={columnNames}
+          isActive={
+            activeMatch !== undefined &&
+            activeMatch.rowIndex === rowIndex &&
+            activeMatch.columnIndex === columnIndex
+          }
+          key={`${rowIndex}-${column.key}`}
+          needle={needle}
+          row={row}
+        />
+      ))}
+    </tr>
+  )
+}
+
+function QueryResultCell({
+  column,
+  columnNames,
+  isActive,
+  needle,
+  row
+}: {
+  column: ResultColumn
+  columnNames: string[]
+  isActive: boolean
+  needle: string
+  row: Record<string, unknown> | undefined
+}): ReactElement {
+  // Known wrong for a result with two identically-named fields: the driver's
+  // row is keyed by name, so both columns read the first field's value. The
+  // columns are at least distinct elements now; showing the right value needs
+  // an array row mode in the adapter.
+  const value = row?.[column.name]
+  const text = formatCellValue(value)
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <td
+          className={cn(
+            'h-[var(--row-h)] whitespace-nowrap border-b border-border2 px-[14px] font-mono text-[12px] group-hover:bg-hover',
+            column.align === 'right' ? 'text-right' : 'text-left',
+            value === null && 'text-text3 italic'
+          )}
+          data-find-active={isActive ? '' : undefined}
+        >
+          {needle === '' ? (
+            text
+          ) : (
+            <HighlightedCellText
+              isActive={isActive}
+              needle={needle}
+              text={text}
+            />
+          )}
+        </td>
+      </ContextMenuTrigger>
+
+      <ContextMenuContent>
+        <ContextMenuItem
+          className="text-xs"
+          onSelect={() => navigator.clipboard.writeText(text)}
+        >
+          Copy
+        </ContextMenuItem>
+
+        <ContextMenuItem
+          className="text-xs"
+          onSelect={() => navigator.clipboard.writeText(column.name)}
+        >
+          Copy Column Name
+        </ContextMenuItem>
+
+        <ContextMenuSeparator />
+
+        <ContextMenuSub>
+          <ContextMenuSubTrigger className="text-xs">
+            Copy Row
+          </ContextMenuSubTrigger>
+
+          <ContextMenuSubContent>
+            <ContextMenuItem
+              className="text-xs"
+              onSelect={() =>
+                navigator.clipboard.writeText(
+                  formatRowAsCsv(row ?? {}, columnNames)
+                )
+              }
+            >
+              As CSV
+            </ContextMenuItem>
+
+            <ContextMenuItem
+              className="text-xs"
+              onSelect={() =>
+                navigator.clipboard.writeText(formatRowAsJson(row ?? {}))
+              }
+            >
+              As JSON
+            </ContextMenuItem>
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
 
 /**
  * Cell text with the matched runs marked. The segments always rejoin into the

--- a/src/app/components/QueryResultTable.tsx
+++ b/src/app/components/QueryResultTable.tsx
@@ -1,6 +1,15 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { CSSProperties, memo, ReactElement, useMemo, useRef } from 'react'
+import {
+  CSSProperties,
+  Fragment,
+  memo,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useRef
+} from 'react'
 
+import { maxResultRows } from '@/databases/adapter'
 import type { QueryResultDto } from '@/glue/api/schemas'
 
 import { cn } from '../lib/utils'
@@ -14,12 +23,21 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger
 } from './ui/context-menu'
-import { getResultColumns, rowNumberColumnWidth } from './query-result-columns'
+import {
+  getResultColumns,
+  getResultFieldNames,
+  rowNumberColumnWidth
+} from './query-result-columns'
 import {
   formatCellValue,
   formatRowAsCsv,
   formatRowAsJson
 } from './query-result-format'
+import {
+  type ResultRowMatch,
+  type ResultSearchView,
+  splitCellText
+} from './query-result-search'
 
 // The density knob for this grid, and the only definition of `--row-h`:
 // nothing else may declare that property. It is published on the scroll
@@ -33,29 +51,37 @@ import {
 // estimate and no `measureElement` is wired.
 const rowHeight = 34
 
+// The header height, published as `--head-h` under the same rule. The header is
+// sticky, so this number is also what keeps a row jumped to by find from
+// landing underneath it -- once as the virtualizer's `scrollPaddingStart`, once
+// as the container's `scroll-padding-top` for `scrollIntoView`. Three consumers
+// of one number is exactly the case `--row-h` exists to prevent.
+const headerHeight = 31
+
 // Rows rendered above and below the window, so a fast scroll reaches painted
 // rows rather than blank space.
 const overscan = 12
 
+// A stable identity for "no search", so the absent-`search` case does not hand
+// the virtualizer and the effects a fresh array on every render.
+const noMatches: ResultRowMatch[] = []
+
 export const QueryResultTable = memo(function QueryResultTable({
-  result
+  result,
+  search
 }: {
   result: QueryResultDto
+  search?: ResultSearchView
 }): ReactElement {
   const scrollRef = useRef<HTMLDivElement>(null)
 
-  // Fall back to the row keys if the adapter returned rows without field
-  // metadata, so a fields/rows desync can never blank out the columns.
   const columns = useMemo(
     () =>
       getResultColumns({
-        fieldNames:
-          result.fields.length > 0
-            ? result.fields.map((field) => field.name)
-            : Object.keys(result.rows[0] ?? {}),
+        fieldNames: getResultFieldNames(result),
         rows: result.rows
       }),
-    [result.fields, result.rows]
+    [result]
   )
 
   // Derived once rather than inside the per-cell CSV closure, which would
@@ -65,11 +91,37 @@ export const QueryResultTable = memo(function QueryResultTable({
     [columns]
   )
 
+  const needle = search?.needle ?? ''
+  const matches = search?.matches ?? noMatches
+  const isFiltering = search?.isFiltering === true && needle !== ''
+
+  const activeMatch =
+    search === undefined || search.activeIndex < 0
+      ? undefined
+      : matches[search.activeIndex]
+
+  // The one place a virtualizer index becomes an index into `result.rows`.
+  // While filtering they are different things, and every read of the row, its
+  // number and its copy actions has to go through this -- a missed call site
+  // shows the wrong row's data with nothing to say so.
+  const toSourceIndex = (index: number): number => {
+    if (!isFiltering) {
+      return index
+    }
+
+    const match = matches[index]
+
+    return match === undefined ? index : match.rowIndex
+  }
+
+  const visibleRowCount = isFiltering ? matches.length : result.rows.length
+
   const virtualizer = useVirtualizer({
-    count: result.rows.length,
+    count: visibleRowCount,
     estimateSize: () => rowHeight,
     getScrollElement: () => scrollRef.current,
-    overscan
+    overscan,
+    scrollPaddingStart: headerHeight
   })
 
   const virtualRows = virtualizer.getVirtualItems()
@@ -83,12 +135,61 @@ export const QueryResultTable = memo(function QueryResultTable({
       ? totalSize - (virtualRows[virtualRows.length - 1]?.end ?? 0)
       : 0
 
+  const activeRowIndex = activeMatch === undefined ? -1 : activeMatch.rowIndex
+
+  // While filtering, the virtualizer counts matches rather than rows, so the
+  // ordinal into `matches` already is the position it wants.
+  const activeVisibleIndex =
+    activeMatch === undefined
+      ? -1
+      : isFiltering
+        ? (search?.activeIndex ?? -1)
+        : activeMatch.rowIndex
+
+  useEffect(() => {
+    if (activeVisibleIndex < 0) {
+      return
+    }
+
+    // `auto` leaves the offset alone when the row is already comfortably in
+    // view, so stepping between two matches on screen does not jerk the grid.
+    virtualizer.scrollToIndex(activeVisibleIndex, { align: 'auto' })
+  }, [activeVisibleIndex, virtualizer])
+
+  const isActiveRowRendered = virtualRows.some(
+    (item) => toSourceIndex(item.index) === activeRowIndex
+  )
+
+  useEffect(() => {
+    if (activeRowIndex < 0 || !isActiveRowRendered) {
+      return
+    }
+
+    // Columns are not virtualized and the table is auto-layout, so the rendered
+    // width of a column is not the width that was pinned for it. Asking the
+    // browser to reveal the cell is the only reading of the layout that is
+    // actually true.
+    //
+    // Split from the vertical jump on purpose: `scrollToIndex` sets `scrollTop`
+    // synchronously, but the virtualizer re-windows on the scroll event that
+    // follows, so the target cell is not in the DOM during that pass.
+    scrollRef.current
+      ?.querySelector('[data-find-active]')
+      ?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' })
+  }, [activeRowIndex, isActiveRowRendered])
+
   return (
     <div
       className="h-full overflow-auto"
       ref={scrollRef}
       // Cast because React's CSSProperties does not admit custom properties.
-      style={{ '--row-h': `${rowHeight}px` } as CSSProperties}
+      style={
+        {
+          '--head-h': `${headerHeight}px`,
+          '--row-h': `${rowHeight}px`,
+          scrollPaddingTop: `${headerHeight}px`
+        } as CSSProperties
+      }
     >
       <table className="min-w-full border-separate border-spacing-0">
         <colgroup>
@@ -104,15 +205,20 @@ export const QueryResultTable = memo(function QueryResultTable({
 
         <thead>
           <tr>
-            <th className="sticky top-0 z-[5] h-[31px] border-b border-border bg-panel2" />
+            <th className="sticky top-0 z-[5] h-[var(--head-h)] border-b border-border bg-panel2" />
 
-            {columns.map((column) => (
+            {columns.map((column, columnIndex) => (
               <th
                 className={cn(
-                  'sticky top-0 z-[5] h-[31px] whitespace-nowrap border-b border-border bg-panel2 px-[14px] text-[12px] font-medium text-text2',
+                  'sticky top-0 z-[5] h-[var(--head-h)] whitespace-nowrap border-b border-border bg-panel2 px-[14px] text-[12px] font-medium text-text2',
                   // The header sits over its values, so it takes the column's
                   // alignment rather than always hugging the left edge.
-                  column.align === 'right' ? 'text-right' : 'text-left'
+                  column.align === 'right' ? 'text-right' : 'text-left',
+                  // Which columns the search landed in, answered at the top of
+                  // the column rather than only where the rows happen to be
+                  // scrolled to.
+                  search?.columnHasMatch[columnIndex] === true &&
+                    'text-find-strong'
                 )}
                 key={column.key}
                 scope="col"
@@ -134,27 +240,34 @@ export const QueryResultTable = memo(function QueryResultTable({
           )}
 
           {virtualRows.map((virtualRow) => {
-            const row = result.rows[virtualRow.index]
+            const rowIndex = toSourceIndex(virtualRow.index)
+            const row = result.rows[rowIndex]
 
             return (
               <tr
                 className="group"
-                key={virtualRow.key}
+                key={rowIndex}
               >
                 <td className="h-[var(--row-h)] select-none border-b border-border2 px-[10px] text-right font-mono text-[11px] text-text3 group-hover:bg-hover">
-                  {virtualRow.index + 1}
+                  {rowIndex + 1}
                 </td>
 
-                {columns.map((column) => {
+                {columns.map((column, columnIndex) => {
                   // Known wrong for a result with two identically-named fields:
                   // the driver's row is keyed by name, so both columns read the
                   // first field's value. The columns are at least distinct
                   // elements now; showing the right value needs an array row
                   // mode in the adapter.
                   const value = row?.[column.name]
+                  const text = formatCellValue(value)
+
+                  const isActiveCell =
+                    activeMatch !== undefined &&
+                    activeMatch.rowIndex === rowIndex &&
+                    activeMatch.columnIndex === columnIndex
 
                   return (
-                    <ContextMenu key={`${virtualRow.key}-${column.key}`}>
+                    <ContextMenu key={`${rowIndex}-${column.key}`}>
                       <ContextMenuTrigger asChild>
                         <td
                           className={cn(
@@ -164,19 +277,24 @@ export const QueryResultTable = memo(function QueryResultTable({
                               : 'text-left',
                             value === null && 'text-text3 italic'
                           )}
+                          data-find-active={isActiveCell ? '' : undefined}
                         >
-                          {formatCellValue(value)}
+                          {needle === '' ? (
+                            text
+                          ) : (
+                            <HighlightedCellText
+                              isActive={isActiveCell}
+                              needle={needle}
+                              text={text}
+                            />
+                          )}
                         </td>
                       </ContextMenuTrigger>
 
                       <ContextMenuContent>
                         <ContextMenuItem
                           className="text-xs"
-                          onSelect={() =>
-                            navigator.clipboard.writeText(
-                              formatCellValue(value)
-                            )
-                          }
+                          onSelect={() => navigator.clipboard.writeText(text)}
                         >
                           Copy
                         </ContextMenuItem>
@@ -237,8 +355,70 @@ export const QueryResultTable = memo(function QueryResultTable({
               />
             </tr>
           )}
+
+          {isFiltering && visibleRowCount === 0 && (
+            <tr>
+              <td
+                className="px-[14px] py-4 text-[12.5px] text-text2"
+                colSpan={columns.length + 1}
+              >
+                No matches for “{search?.query}”
+                {result.truncated
+                  ? ` in the first ${Intl.NumberFormat().format(maxResultRows)} rows.`
+                  : '.'}
+                {/* Silence here would answer a question the search did not ask:
+                    a row absent from the first page is not a row absent from
+                    the table. */}
+                {result.truncated && (
+                  <span className="block pt-[6px] text-text3">
+                    Only part of the table was returned. Add a WHERE clause to
+                    search the rest.
+                  </span>
+                )}
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
     </div>
   )
 })
+
+/**
+ * Cell text with the matched runs marked. The segments always rejoin into the
+ * text they came from, so this cannot change what the cell says.
+ */
+function HighlightedCellText({
+  isActive,
+  needle,
+  text
+}: {
+  isActive: boolean
+  needle: string
+  text: string
+}): ReactElement {
+  return (
+    <>
+      {splitCellText(text, needle).map((segment, index) =>
+        segment.isMatch ? (
+          <mark
+            // Chrome's UA sheet paints <mark> yellow-on-black and Tailwind's
+            // preflight does not reset it, so the text colour is as load-bearing
+            // as the background.
+            className={cn(
+              'rounded-[2px]',
+              isActive
+                ? 'bg-find-active text-find-active-text'
+                : 'bg-find text-find-text'
+            )}
+            key={index}
+          >
+            {segment.text}
+          </mark>
+        ) : (
+          <Fragment key={index}>{segment.text}</Fragment>
+        )
+      )}
+    </>
+  )
+}

--- a/src/app/components/ResultsFindBar.tsx
+++ b/src/app/components/ResultsFindBar.tsx
@@ -1,0 +1,162 @@
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ListFilterIcon,
+  XIcon
+} from 'lucide-react'
+import { KeyboardEvent, ReactElement } from 'react'
+
+import { maxResultRows } from '@/databases/adapter'
+
+import type { ResultsFind } from '../hooks/use-results-find'
+import { cn } from '../lib/utils'
+import { SearchInput } from './SearchInput'
+
+const iconButtonClassName =
+  'flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover disabled:pointer-events-none disabled:opacity-40'
+
+function formatRowCap(): string {
+  return Intl.NumberFormat().format(maxResultRows)
+}
+
+/**
+ * What the counter says, or `null` when there is nothing worth saying.
+ *
+ * The truncated wording is the most important text in this feature: a result
+ * cut off at the row cap that reports a bare "No matches" answers a question
+ * nobody asked, and someone looking for their own id would read it as "this row
+ * does not exist".
+ */
+function formatFindStatus(find: ResultsFind): string | null {
+  if (find.rowCount === 0) {
+    return 'No rows to search'
+  }
+
+  if (find.query.trim() === '') {
+    return null
+  }
+
+  if (find.matchCount === 0) {
+    return find.truncated
+      ? `No matches in the first ${formatRowCap()} rows`
+      : 'No matches'
+  }
+
+  const counted = `${Intl.NumberFormat().format(find.activeOrdinal)} of ${Intl.NumberFormat().format(find.matchCount)}`
+
+  return find.truncated ? `${counted} · first ${formatRowCap()} rows` : counted
+}
+
+export function ResultsFindBar({ find }: { find: ResultsFind }): ReactElement {
+  const status = formatFindStatus(find)
+  const hasMatches = find.matchCount > 0
+
+  // Escape is handled on the bar rather than on the input, so it still closes
+  // after a click has moved focus to one of the buttons. A global hotkey would
+  // be the wrong tool: it would fire alongside the rename input's own Escape,
+  // which cancels without stopping propagation.
+  const handleBarKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key !== 'Escape') {
+      return
+    }
+
+    event.preventDefault()
+    find.close()
+  }
+
+  // Enter stays on the input. On a focused button it would land on top of the
+  // button's own activation, so prev-then-Enter would step twice.
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key !== 'Enter') {
+      return
+    }
+
+    event.preventDefault()
+
+    if (event.shiftKey) {
+      find.previous()
+
+      return
+    }
+
+    find.next()
+  }
+
+  return (
+    <div
+      className="flex flex-none items-center gap-[2px]"
+      onKeyDown={handleBarKeyDown}
+    >
+      <div className="w-[180px] lg:w-[220px]">
+        <SearchInput
+          inputRef={find.inputRef}
+          placeholder="Find in results"
+          value={find.query}
+          onChange={find.setQuery}
+          onKeyDown={handleInputKeyDown}
+        />
+      </div>
+
+      {status !== null && (
+        <span
+          aria-live="polite"
+          className="px-[6px] font-mono text-[11.5px] whitespace-nowrap text-text3"
+          role="status"
+          title={
+            find.truncated
+              ? `Only the first ${formatRowCap()} rows were returned, so this searches part of the table. Add a WHERE clause to search the rest.`
+              : undefined
+          }
+        >
+          {status}
+        </span>
+      )}
+
+      <button
+        aria-label="Previous match"
+        className={iconButtonClassName}
+        disabled={!hasMatches}
+        title="Previous match (⇧↵)"
+        type="button"
+        onClick={find.previous}
+      >
+        <ChevronUpIcon className="size-3" />
+      </button>
+
+      <button
+        aria-label="Next match"
+        className={iconButtonClassName}
+        disabled={!hasMatches}
+        title="Next match (↵)"
+        type="button"
+        onClick={find.next}
+      >
+        <ChevronDownIcon className="size-3" />
+      </button>
+
+      <button
+        aria-label="Hide non-matching rows"
+        aria-pressed={find.isFiltering}
+        className={cn(
+          iconButtonClassName,
+          find.isFiltering && 'bg-[var(--sel)] text-text'
+        )}
+        title="Hide non-matching rows"
+        type="button"
+        onClick={find.toggleFiltering}
+      >
+        <ListFilterIcon className="size-3" />
+      </button>
+
+      <button
+        aria-label="Close find"
+        className={iconButtonClassName}
+        title="Close find (Esc)"
+        type="button"
+        onClick={find.close}
+      >
+        <XIcon className="size-3" />
+      </button>
+    </div>
+  )
+}

--- a/src/app/components/ResultsPane.test.tsx
+++ b/src/app/components/ResultsPane.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ReactElement, useState } from 'react'
+import invariant from 'tiny-invariant'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { QueryDto } from '@/glue/api/schemas'
@@ -265,5 +266,316 @@ describe('ResultsPane', () => {
     expect(screen.getByText('No results yet').closest('section')).toHaveStyle({
       height: '320px'
     })
+  })
+})
+
+const findableResult = {
+  fields: [{ name: 'title' }],
+  rowCount: 3,
+  rows: [
+    { title: 'Alien' },
+    { title: 'Alien Nation' },
+    { title: 'Barbarella' }
+  ],
+  truncated: false
+}
+
+const findableQuery = query({ result: findableResult })
+
+// The same switch as `SwitchablePane`, but with a result behind each worksheet
+// so there is something for find to open onto.
+function SwitchableResultPane(): ReactElement {
+  const [worksheetId, setWorksheetId] = useState('ws-1')
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          setWorksheetId((current) => (current === 'ws-1' ? 'ws-2' : 'ws-1'))
+        }
+      >
+        Switch worksheet
+      </button>
+
+      <ResultsPane
+        databaseName="Pagila"
+        query={{ ...findableQuery, worksheetId }}
+        worksheetId={worksheetId}
+      />
+    </>
+  )
+}
+
+function renderFindablePane(
+  options: Parameters<typeof renderWithProviders>[1] = {}
+) {
+  return renderWithProviders(
+    <ResultsPane
+      databaseName="Pagila"
+      query={findableQuery}
+      worksheetId="ws-1"
+    />,
+    { openWorksheetId: 'ws-1', queries: [], ...options }
+  )
+}
+
+function findInput(): HTMLInputElement {
+  const input = screen.getByPlaceholderText('Find in results')
+
+  invariant(input instanceof HTMLInputElement, 'The find box is an input.')
+
+  return input
+}
+
+describe('ResultsPane find in results', () => {
+  // The whole point of the shortcut: the box has to be ready for the paste that
+  // follows it, wherever focus happened to be. The editor holds focus by
+  // default, so this is the case that matters.
+  it('opens the find bar on the shortcut and gives it focus', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+
+    expect(findInput()).toHaveFocus()
+  })
+
+  it('selects what is already in the box when the shortcut is pressed again', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'alien')
+
+    expect(findInput().selectionStart).toEqual(5)
+
+    await user.keyboard('{Meta>}f{/Meta}')
+
+    // Selected rather than appended to, so the next paste replaces the old id.
+    expect(findInput().selectionStart).toEqual(0)
+    expect(findInput().selectionEnd).toEqual(5)
+  })
+
+  it('counts the rows that matched', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'alien')
+
+    expect(screen.getByRole('status')).toHaveTextContent('1 of 2')
+  })
+
+  it('steps through the matches with Enter, wrapping at the end', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'alien')
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByRole('status')).toHaveTextContent('2 of 2')
+
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByRole('status')).toHaveTextContent('1 of 2')
+  })
+
+  it('steps backwards with Shift and Enter, wrapping at the start', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'alien')
+    await user.keyboard('{Shift>}{Enter}{/Shift}')
+
+    expect(screen.getByRole('status')).toHaveTextContent('2 of 2')
+  })
+
+  it('goes back to the first match when the query changes', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'alien')
+    await user.keyboard('{Enter}')
+    await user.type(findInput(), ' n')
+
+    expect(screen.getByRole('status')).toHaveTextContent('1 of 1')
+  })
+
+  it('says so when nothing matched', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'nobody')
+
+    expect(screen.getByRole('status')).toHaveTextContent('No matches')
+  })
+
+  // A row missing from the first page is not a row missing from the table, and
+  // a bare "No matches" against a capped result answers the wrong question.
+  it('says how far the search reached when the result was cut off', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(
+      <ResultsPane
+        databaseName="Pagila"
+        query={query({ result: { ...findableResult, truncated: true } })}
+        worksheetId="ws-1"
+      />,
+      { openWorksheetId: 'ws-1', queries: [] }
+    )
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'nobody')
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'No matches in the first 10,000 rows'
+    )
+  })
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.keyboard('{Escape}')
+
+    expect(
+      screen.queryByPlaceholderText('Find in results')
+    ).not.toBeInTheDocument()
+  })
+
+  // Clicking any control in the bar moves focus off the input, and Escape used
+  // to be the input's own handler -- so the key went dead exactly after the
+  // user had reached for the filter.
+  it('still closes on Escape after a bar button took focus', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'alien')
+    await user.click(
+      screen.getByRole('button', { name: 'Hide non-matching rows' })
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Hide non-matching rows' })
+    ).toHaveFocus()
+
+    await user.keyboard('{Escape}')
+
+    expect(
+      screen.queryByPlaceholderText('Find in results')
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides the non-matching rows once the filter is turned on', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'alien')
+
+    expect(screen.getAllByRole('row')).toHaveLength(4)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Hide non-matching rows' })
+    )
+
+    // The header plus the two matches; Barbarella is gone.
+    expect(screen.getAllByRole('row')).toHaveLength(3)
+  })
+
+  it('offers nothing to find until there is a result', () => {
+    renderWithProviders(
+      <ResultsPane
+        databaseName="Pagila"
+        query={undefined}
+        worksheetId="ws-1"
+      />,
+      { openWorksheetId: 'ws-1', queries: [] }
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Find in results' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('opens onto an empty result and says there is nothing to search', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(
+      <ResultsPane
+        databaseName="Pagila"
+        query={query({
+          result: { fields: [], rowCount: 0, rows: [], truncated: false }
+        })}
+        worksheetId="ws-1"
+      />,
+      { openWorksheetId: 'ws-1', queries: [] }
+    )
+
+    await user.keyboard('{Meta>}f{/Meta}')
+
+    expect(screen.getByRole('status')).toHaveTextContent('No rows to search')
+  })
+
+  it('brings the results back when the shortcut is used on the Messages tab', async () => {
+    const user = userEvent.setup()
+    renderFindablePane()
+
+    await user.click(screen.getByRole('tab', { name: 'Messages' }))
+
+    expect(screen.getByRole('tab', { name: 'Messages' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+
+    await user.keyboard('{Meta>}f{/Meta}')
+
+    expect(screen.getByRole('tab', { name: 'Results' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(findInput()).toHaveFocus()
+  })
+
+  // `EditorScreen` covers a still-mounted workspace, so a find bar opening
+  // behind it would take focus out of a form the user is filling in.
+  it('leaves the shortcut alone while an overlay is up', async () => {
+    const user = userEvent.setup()
+    renderFindablePane({ ui: { editorScreen: { type: 'create-database' } } })
+
+    await user.keyboard('{Meta>}f{/Meta}')
+
+    expect(
+      screen.queryByPlaceholderText('Find in results')
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps a find query of its own for each worksheet', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<SwitchableResultPane />, {
+      queries: [],
+      tabs: { openWorksheetIds: ['ws-1', 'ws-2'] }
+    })
+
+    await user.keyboard('{Meta>}f{/Meta}')
+    await user.type(findInput(), 'alien')
+    await user.click(screen.getByRole('button', { name: 'Switch worksheet' }))
+
+    // The other worksheet never had a find open, so it does not inherit one.
+    expect(
+      screen.queryByPlaceholderText('Find in results')
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Switch worksheet' }))
+
+    expect(findInput()).toHaveValue('alien')
   })
 })

--- a/src/app/components/ResultsPane.tsx
+++ b/src/app/components/ResultsPane.tsx
@@ -1,9 +1,12 @@
-import { ReactElement, useEffect, useState } from 'react'
+import { SearchIcon } from 'lucide-react'
+import { ReactElement, useCallback, useEffect, useState } from 'react'
 
 import type { QueryDto } from '@/glue/api/schemas'
 import { isQueryFinished } from '@/glue/queries'
 
+import { getFindShortcut } from '../find-shortcut'
 import { usePersistedSizes } from '../hooks/use-persisted-sizes'
+import { useResultsFind } from '../hooks/use-results-find'
 import { useWorksheetMessages } from '../hooks/use-worksheet-messages'
 import { cn } from '../lib/utils'
 import { useAppSelector } from '../store'
@@ -11,6 +14,7 @@ import { selectOpenWorksheetIds } from '../store/tabs-slice'
 import { QueryMessages } from './QueryMessages'
 import { QueryResultContent } from './QueryResultContent'
 import { ResizeHandle } from './ResizeHandle'
+import { ResultsFindBar } from './ResultsFindBar'
 import { TimeAgo } from './TimeAgo'
 
 type ResultsTab = 'messages' | 'results'
@@ -87,13 +91,26 @@ export function ResultsPane({
   const activeTab: ResultsTab =
     (worksheetId ? tabByWorksheet[worksheetId] : undefined) ?? 'results'
 
-  const selectTab = (tab: ResultsTab) => {
-    if (!worksheetId) {
-      return
-    }
+  const selectTab = useCallback(
+    (tab: ResultsTab) => {
+      if (!worksheetId) {
+        return
+      }
 
-    setTabByWorksheet((current) => ({ ...current, [worksheetId]: tab }))
-  }
+      setTabByWorksheet((current) => ({ ...current, [worksheetId]: tab }))
+    },
+    [worksheetId]
+  )
+
+  const showResults = useCallback(() => selectTab('results'), [selectTab])
+
+  const find = useResultsFind({
+    result: query?.result,
+    worksheetId,
+    onShowResults: showResults
+  })
+
+  const isFindShowing = find.isOpen && activeTab === 'results'
 
   return (
     <>
@@ -132,8 +149,37 @@ export function ResultsPane({
             />
           </div>
 
-          <div className="ml-auto font-mono text-[11.5px] text-text3">
-            <ResultsMeta query={query} />
+          {/* The find affordance and the run summary are one right-aligned
+              group. An `ml-auto` on each instead splits the free space between
+              them, which left the search icon stranded mid-strip rather than
+              sitting where its input is about to appear. */}
+          <div className="ml-auto flex flex-none items-center gap-[2px]">
+            {isFindShowing ? (
+              <ResultsFindBar find={find} />
+            ) : (
+              query?.result && (
+                <button
+                  aria-label="Find in results"
+                  className="flex size-[22px] flex-none items-center justify-center rounded-[5px] text-text2 hover:bg-hover"
+                  title={`Find in results (${getFindShortcut()})`}
+                  type="button"
+                  onClick={find.open}
+                >
+                  <SearchIcon className="size-3" />
+                </button>
+              )
+            )}
+
+            <div
+              className={cn(
+                'pl-[10px] font-mono text-[11.5px] whitespace-nowrap text-text3',
+                // In a 37px strip the find bar wins; the same run summary is in
+                // the status bar either way.
+                isFindShowing && 'hidden lg:block'
+              )}
+            >
+              <ResultsMeta query={query} />
+            </div>
           </div>
         </div>
 
@@ -144,6 +190,7 @@ export function ResultsPane({
             <QueryResultContent
               databaseName={databaseName}
               query={query}
+              search={find.search}
             />
           )}
         </div>

--- a/src/app/components/ResultsPane.tsx
+++ b/src/app/components/ResultsPane.tsx
@@ -1,16 +1,15 @@
 import { SearchIcon } from 'lucide-react'
-import { ReactElement, useCallback, useEffect, useState } from 'react'
+import { ReactElement, useCallback } from 'react'
 
 import type { QueryDto } from '@/glue/api/schemas'
 import { isQueryFinished } from '@/glue/queries'
 
 import { getFindShortcut } from '../find-shortcut'
+import { usePerWorksheetState } from '../hooks/use-per-worksheet-state'
 import { usePersistedSizes } from '../hooks/use-persisted-sizes'
 import { useResultsFind } from '../hooks/use-results-find'
 import { useWorksheetMessages } from '../hooks/use-worksheet-messages'
 import { cn } from '../lib/utils'
-import { useAppSelector } from '../store'
-import { selectOpenWorksheetIds } from '../store/tabs-slice'
 import { QueryMessages } from './QueryMessages'
 import { QueryResultContent } from './QueryResultContent'
 import { ResizeHandle } from './ResizeHandle'
@@ -18,6 +17,8 @@ import { ResultsFindBar } from './ResultsFindBar'
 import { TimeAgo } from './TimeAgo'
 
 type ResultsTab = 'messages' | 'results'
+
+const defaultTab: ResultsTab = 'results'
 
 const defaultHeight = 320
 const maximumHeight = 620
@@ -49,7 +50,6 @@ export function ResultsPane({
   query,
   worksheetId
 }: ResultsPaneProps): ReactElement {
-  const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
   const messages = useWorksheetMessages(worksheetId)
 
   // Each worksheet keeps its own height, and the record is bounded by a cap on
@@ -68,38 +68,15 @@ export function ResultsPane({
 
   // Which tab is showing is remembered per worksheet, so switching tabs does
   // not snap everyone back to Results.
-  const [tabByWorksheet, setTabByWorksheet] = useState<
-    Record<string, ResultsTab>
-  >({})
+  const tabs = usePerWorksheetState<ResultsTab>(defaultTab)
 
-  useEffect(() => {
-    // Keeps the map bounded by the open tabs instead of every worksheet
-    // visited this session.
-    const open = new Set(openWorksheetIds)
-
-    setTabByWorksheet((current) => {
-      const next = Object.fromEntries(
-        Object.entries(current).filter(([id]) => open.has(id))
-      )
-
-      return Object.keys(next).length === Object.keys(current).length
-        ? current
-        : next
-    })
-  }, [openWorksheetIds])
-
-  const activeTab: ResultsTab =
-    (worksheetId ? tabByWorksheet[worksheetId] : undefined) ?? 'results'
+  const activeTab = tabs.valueFor(worksheetId)
 
   const selectTab = useCallback(
     (tab: ResultsTab) => {
-      if (!worksheetId) {
-        return
-      }
-
-      setTabByWorksheet((current) => ({ ...current, [worksheetId]: tab }))
+      tabs.update(worksheetId, () => tab)
     },
-    [worksheetId]
+    [tabs, worksheetId]
   )
 
   const showResults = useCallback(() => selectTab('results'), [selectTab])

--- a/src/app/components/SearchInput.test.tsx
+++ b/src/app/components/SearchInput.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { SearchInput } from './SearchInput'
@@ -60,6 +61,44 @@ describe('SearchInput', () => {
     expect(screen.getByPlaceholderText('Filter tables')).toHaveClass(
       'custom-class'
     )
+  })
+
+  // Find opens on a shortcut and has to be ready for the paste that follows,
+  // so its caller needs a handle on the element rather than a click to wait for.
+  it('hands the input element back through inputRef', () => {
+    const inputRef = createRef<HTMLInputElement>()
+
+    render(
+      <SearchInput
+        inputRef={inputRef}
+        placeholder="Find in results"
+        value=""
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(inputRef.current).toEqual(
+      screen.getByPlaceholderText('Find in results')
+    )
+  })
+
+  it('forwards key presses, which is how Enter and Escape are handled', async () => {
+    const user = userEvent.setup()
+    const onKeyDown = vi.fn()
+
+    render(
+      <SearchInput
+        placeholder="Find in results"
+        value=""
+        onChange={vi.fn()}
+        onKeyDown={onKeyDown}
+      />
+    )
+
+    await user.type(screen.getByPlaceholderText('Find in results'), '{Enter}')
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
+    expect(onKeyDown.mock.calls[0][0]).toMatchObject({ key: 'Enter' })
   })
 
   it('renders search icon', () => {

--- a/src/app/components/SearchInput.tsx
+++ b/src/app/components/SearchInput.tsx
@@ -1,25 +1,33 @@
 import { SearchIcon } from 'lucide-react'
-import { memo, ReactElement } from 'react'
+import { KeyboardEvent, memo, ReactElement, RefObject } from 'react'
 
 import { Input } from './ui/input'
 import { cn } from '../lib/utils'
 
 interface SearchInputProps {
   className?: string
+  // Named rather than React 19's ref-as-prop, so it survives `memo` without
+  // depending on how the wrapper forwards refs. Same shape as
+  // `WorksheetNameInput`.
+  inputRef?: RefObject<HTMLInputElement | null>
   placeholder: string
   value: string
   onChange: (newValue: string) => void
+  onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void
 }
 
 export const SearchInput = memo(function SearchInput({
   className,
+  inputRef,
   placeholder,
   value,
-  onChange
+  onChange,
+  onKeyDown
 }: SearchInputProps): ReactElement {
   return (
     <div className="relative">
       <Input
+        ref={inputRef}
         className={cn(
           'h-7 rounded-[6px] border border-border bg-panel py-0 pr-[10px] pl-[27px] shadow-none',
           // The base input steps up to 14px at `md`, which every desktop
@@ -31,6 +39,7 @@ export const SearchInput = memo(function SearchInput({
         placeholder={placeholder}
         value={value}
         onChange={(event) => onChange(event.target.value)}
+        onKeyDown={onKeyDown}
       />
 
       <SearchIcon className="pointer-events-none absolute top-1/2 left-[9px] size-3 -translate-y-1/2 text-text3" />

--- a/src/app/components/WorksheetEditor.test.tsx
+++ b/src/app/components/WorksheetEditor.test.tsx
@@ -74,6 +74,23 @@ describe('WorksheetEditor', () => {
     })
   })
 
+  // The results grid owns Mod-f now. `basicSetup` opts in to every option it is
+  // not handed a literal `false` for, so leaving this out silently gives the key
+  // back to CodeMirror's own search panel -- and nothing in the extension list
+  // would show it happening.
+  it('leaves the editor search keymap off, so Mod-f reaches the results grid', () => {
+    render(editor('select 1'))
+
+    expect(capturedProps[0].basicSetup).toEqual({
+      autocompletion: false,
+      bracketMatching: true,
+      highlightActiveLine: true,
+      history: true,
+      lineNumbers: true,
+      searchKeymap: false
+    })
+  })
+
   it('still passes the current content through to the editor', () => {
     const { rerender } = render(editor('select 1'))
 

--- a/src/app/components/query-result-columns.ts
+++ b/src/app/components/query-result-columns.ts
@@ -20,6 +20,11 @@ interface ResultColumnsInput {
   rows: Record<string, unknown>[]
 }
 
+interface ResultFieldNamesInput {
+  fields: { name: string }[]
+  rows: Record<string, unknown>[]
+}
+
 export interface ResultColumn {
   align: 'left' | 'right'
   // Position, not name: a result can carry two fields with one name (`SELECT *
@@ -94,4 +99,21 @@ export function getResultColumns({
       width: widthForCharacters(longest)
     }
   })
+}
+
+/**
+ * The column names of a result, in column order, duplicates included.
+ *
+ * Falls back to the first row's keys when the adapter returned rows without
+ * field metadata, so a fields/rows desync can never blank out the columns.
+ */
+export function getResultFieldNames({
+  fields,
+  rows
+}: ResultFieldNamesInput): string[] {
+  if (fields.length > 0) {
+    return fields.map((field) => field.name)
+  }
+
+  return Object.keys(rows[0] ?? {})
 }

--- a/src/app/components/query-result-search.test.ts
+++ b/src/app/components/query-result-search.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  applySearchToRows,
   buildResultSearchIndex,
   findMatchOffsets,
   normalizeSearchQuery,
+  type ResultSearchView,
   splitCellText
 } from './query-result-search'
 
@@ -206,5 +208,123 @@ describe('buildResultSearchIndex', () => {
       matches: [],
       needle: 'a3f9'
     })
+  })
+})
+
+describe('applySearchToRows', () => {
+  const view = (
+    overrides: Partial<ResultSearchView> = {}
+  ): ResultSearchView => ({
+    activeIndex: 0,
+    columnHasMatch: [true, false],
+    isFiltering: false,
+    // Rows 2 and 5 matched, in column 1 and column 0.
+    matches: [
+      { columnIndex: 1, rowIndex: 2 },
+      { columnIndex: 0, rowIndex: 5 }
+    ],
+    needle: 'mia',
+    query: 'mia',
+    ...overrides
+  })
+
+  it('leaves every row addressed by itself when there is no search', () => {
+    const applied = applySearchToRows(10, undefined)
+
+    expect({
+      activeRowIndex: applied.activeRowIndex,
+      activeVisibleIndex: applied.activeVisibleIndex,
+      isFiltering: applied.isFiltering,
+      needle: applied.needle,
+      third: applied.toSourceIndex(3),
+      visibleRowCount: applied.visibleRowCount
+    }).toEqual({
+      activeRowIndex: -1,
+      activeVisibleIndex: -1,
+      isFiltering: false,
+      needle: '',
+      third: 3,
+      visibleRowCount: 10
+    })
+  })
+
+  it('counts every row and addresses them directly while not filtering', () => {
+    const applied = applySearchToRows(10, view())
+
+    expect({
+      activeMatch: applied.activeMatch,
+      activeRowIndex: applied.activeRowIndex,
+      activeVisibleIndex: applied.activeVisibleIndex,
+      first: applied.toSourceIndex(0),
+      seventh: applied.toSourceIndex(7),
+      visibleRowCount: applied.visibleRowCount
+    }).toEqual({
+      activeMatch: { columnIndex: 1, rowIndex: 2 },
+      activeRowIndex: 2,
+      // Not filtering, so the virtualizer counts rows and the match's own row
+      // index is the position it wants.
+      activeVisibleIndex: 2,
+      first: 0,
+      seventh: 7,
+      visibleRowCount: 10
+    })
+  })
+
+  // The assertion the rendered table cannot make: while filtering, position 1
+  // is row 5, and every read of the row has to go through this.
+  it('counts matches and translates position to row while filtering', () => {
+    const applied = applySearchToRows(10, view({ isFiltering: true }))
+
+    expect({
+      first: applied.toSourceIndex(0),
+      second: applied.toSourceIndex(1),
+      visibleRowCount: applied.visibleRowCount
+    }).toEqual({ first: 2, second: 5, visibleRowCount: 2 })
+  })
+
+  it('puts the active match at its position in the filtered list', () => {
+    const applied = applySearchToRows(
+      10,
+      view({ activeIndex: 1, isFiltering: true })
+    )
+
+    expect({
+      activeRowIndex: applied.activeRowIndex,
+      activeVisibleIndex: applied.activeVisibleIndex
+    }).toEqual({ activeRowIndex: 5, activeVisibleIndex: 1 })
+  })
+
+  // An empty query with the toggle on must not hide every row: there is nothing
+  // to filter by yet.
+  it('does not filter on an empty needle even with the toggle on', () => {
+    const applied = applySearchToRows(
+      10,
+      view({ isFiltering: true, matches: [], needle: '', query: '' })
+    )
+
+    expect({
+      isFiltering: applied.isFiltering,
+      visibleRowCount: applied.visibleRowCount
+    }).toEqual({ isFiltering: false, visibleRowCount: 10 })
+  })
+
+  it('has no active match when the ordinal says there is none', () => {
+    const applied = applySearchToRows(10, view({ activeIndex: -1 }))
+
+    expect({
+      activeMatch: applied.activeMatch,
+      activeRowIndex: applied.activeRowIndex,
+      activeVisibleIndex: applied.activeVisibleIndex
+    }).toEqual({
+      activeMatch: undefined,
+      activeRowIndex: -1,
+      activeVisibleIndex: -1
+    })
+  })
+
+  it('falls back to the position itself for a match that is not there', () => {
+    const applied = applySearchToRows(10, view({ isFiltering: true }))
+
+    expect(applied.toSourceIndex(9)).toEqual(9)
   })
 })

--- a/src/app/components/query-result-search.test.ts
+++ b/src/app/components/query-result-search.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildResultSearchIndex,
+  findMatchOffsets,
+  normalizeSearchQuery,
+  splitCellText
+} from './query-result-search'
+
+describe('normalizeSearchQuery', () => {
+  it('trims and lower-cases, so a pasted id with a trailing newline still matches', () => {
+    expect(normalizeSearchQuery('  A3F9C2B1\n')).toEqual('a3f9c2b1')
+  })
+
+  it('answers an empty string for a whitespace-only query', () => {
+    expect(normalizeSearchQuery('   ')).toEqual('')
+  })
+})
+
+describe('findMatchOffsets', () => {
+  it('finds every occurrence, left to right', () => {
+    expect(findMatchOffsets('a-b-a-b', 'b')).toEqual([2, 6])
+  })
+
+  it('does not overlap, so aa in aaaa is two matches', () => {
+    expect(findMatchOffsets('aaaa', 'aa')).toEqual([0, 2])
+  })
+
+  it('ignores case in the text', () => {
+    expect(findMatchOffsets('Mia FORD', 'ford')).toEqual([4])
+  })
+
+  it('answers nothing for an empty needle', () => {
+    expect(findMatchOffsets('anything', '')).toEqual([])
+  })
+
+  it('treats the needle literally rather than as a pattern', () => {
+    expect(findMatchOffsets('a(b', '(')).toEqual([1])
+    expect(findMatchOffsets('ab', '.')).toEqual([])
+  })
+})
+
+describe('splitCellText', () => {
+  it('splits a match out of its surrounding text', () => {
+    expect(splitCellText('mia@example.com', 'example')).toEqual([
+      { isMatch: false, text: 'mia@' },
+      { isMatch: true, text: 'example' },
+      { isMatch: false, text: '.com' }
+    ])
+  })
+
+  it('keeps the original casing of the matched run', () => {
+    expect(splitCellText('Mia Ford', 'mia')).toEqual([
+      { isMatch: true, text: 'Mia' },
+      { isMatch: false, text: ' Ford' }
+    ])
+  })
+
+  it('splits several matches in one cell', () => {
+    expect(splitCellText('a1a1', '1')).toEqual([
+      { isMatch: false, text: 'a' },
+      { isMatch: true, text: '1' },
+      { isMatch: false, text: 'a' },
+      { isMatch: true, text: '1' }
+    ])
+  })
+
+  it('answers one unmatched segment when nothing matches', () => {
+    expect(splitCellText('zoe', 'mia')).toEqual([
+      { isMatch: false, text: 'zoe' }
+    ])
+  })
+
+  it('answers one unmatched segment for an empty needle', () => {
+    expect(splitCellText('zoe', '')).toEqual([{ isMatch: false, text: 'zoe' }])
+  })
+
+  it('gives up the highlight rather than mangle text whose case change resizes it', () => {
+    // 'İ' lower-cases to two code units, so offsets found in the lower-cased
+    // copy no longer address the original.
+    expect(splitCellText('İstanbul', 'stanbul')).toEqual([
+      { isMatch: false, text: 'İstanbul' }
+    ])
+  })
+
+  it('always rejoins into the text it was given', () => {
+    const text = 'a1a1b'
+
+    expect(
+      splitCellText(text, '1')
+        .map((segment) => segment.text)
+        .join('')
+    ).toEqual(text)
+  })
+})
+
+describe('buildResultSearchIndex', () => {
+  const columnNames = ['id', 'email', 'name']
+  const rows = [
+    { email: 'mia@example.com', id: 'a3f9', name: 'Mia Ford' },
+    { email: 'leo@example.com', id: '0c8e', name: 'Leo Ba' },
+    { email: 'a3f9@x.io', id: '77bd', name: 'Ann Ro' }
+  ]
+
+  it('answers no matches and an empty needle when not searching', () => {
+    expect(buildResultSearchIndex({ columnNames, query: '  ', rows })).toEqual({
+      columnHasMatch: [false, false, false],
+      matches: [],
+      needle: ''
+    })
+  })
+
+  it('reports the matching rows in order, with the first matching column of each', () => {
+    expect(
+      buildResultSearchIndex({ columnNames, query: 'a3f9', rows })
+    ).toEqual({
+      columnHasMatch: [true, true, false],
+      matches: [
+        { columnIndex: 0, rowIndex: 0 },
+        { columnIndex: 1, rowIndex: 2 }
+      ],
+      needle: 'a3f9'
+    })
+  })
+
+  it('ignores case in both directions', () => {
+    expect(
+      buildResultSearchIndex({ columnNames, query: 'MIA FORD', rows }).matches
+    ).toEqual([{ columnIndex: 2, rowIndex: 0 }])
+  })
+
+  it('answers nothing when no row matches', () => {
+    expect(buildResultSearchIndex({ columnNames, query: 'zoe', rows })).toEqual(
+      {
+        columnHasMatch: [false, false, false],
+        matches: [],
+        needle: 'zoe'
+      }
+    )
+  })
+
+  it('matches numbers and booleans by the text they display', () => {
+    const index = buildResultSearchIndex({
+      columnNames: ['count', 'isActive'],
+      query: 'true',
+      rows: [
+        { count: 12, isActive: true },
+        { count: 34, isActive: false }
+      ]
+    })
+
+    expect(index.matches).toEqual([{ columnIndex: 1, rowIndex: 0 }])
+  })
+
+  it('matches an object cell by its stringified form, which is what the grid shows', () => {
+    const index = buildResultSearchIndex({
+      columnNames: ['payload'],
+      query: '"a":1',
+      rows: [{ payload: { a: 1 } }]
+    })
+
+    expect(index.matches).toEqual([{ columnIndex: 0, rowIndex: 0 }])
+  })
+
+  it('matches a null cell on the query null, because null is what it displays', () => {
+    const index = buildResultSearchIndex({
+      columnNames: ['deletedAt'],
+      query: 'null',
+      rows: [{ deletedAt: null }, { deletedAt: '2026-01-01' }]
+    })
+
+    expect(index.matches).toEqual([{ columnIndex: 0, rowIndex: 0 }])
+  })
+
+  it('matches a field missing from the row on the query undefined, the same way', () => {
+    const index = buildResultSearchIndex({
+      columnNames: ['id', 'absent'],
+      query: 'undefined',
+      rows: [{ id: 'a3f9' }]
+    })
+
+    expect(index.matches).toEqual([{ columnIndex: 1, rowIndex: 0 }])
+  })
+
+  it('reports the lower column for duplicate field names, and marks both columns', () => {
+    // `SELECT * FROM a JOIN b` where both carry an `id`. The row is keyed by
+    // name, so both columns display the same value and both match.
+    const index = buildResultSearchIndex({
+      columnNames: ['id', 'id'],
+      query: 'a3f9',
+      rows: [{ id: 'a3f9' }]
+    })
+
+    expect(index).toEqual({
+      columnHasMatch: [true, true],
+      matches: [{ columnIndex: 0, rowIndex: 0 }],
+      needle: 'a3f9'
+    })
+  })
+
+  it('survives a result whose rows are missing entirely', () => {
+    expect(
+      buildResultSearchIndex({ columnNames, query: 'a3f9', rows: [] })
+    ).toEqual({
+      columnHasMatch: [false, false, false],
+      matches: [],
+      needle: 'a3f9'
+    })
+  })
+})

--- a/src/app/components/query-result-search.ts
+++ b/src/app/components/query-result-search.ts
@@ -1,0 +1,208 @@
+// Find-in-results, the matching half. Pure: no React, no DOM.
+//
+// Everything here matches against `formatCellValue`'s output rather than the
+// raw driver value, so find agrees with the string the user can actually see --
+// dates as ISO strings, JSON columns stringified, `bytea` as
+// `{"type":"Buffer",...}`, and Postgres bigint/numeric/money as strings. The
+// same rule is why a search for `null` matches a null cell: `null` is what the
+// cell displays and what Copy copies.
+import { formatCellValue } from './query-result-format'
+
+export interface CellTextSegment {
+  isMatch: boolean
+  text: string
+}
+
+export interface ResultRowMatch {
+  // The first matching cell in the row, which is the scroll target.
+  columnIndex: number
+  // An index into `result.rows` -- always a source index, never a position in a
+  // filtered view.
+  rowIndex: number
+}
+
+export interface ResultSearchIndex {
+  // Per column index, whether any row matches in it.
+  columnHasMatch: boolean[]
+  // The matching rows, ascending by `rowIndex`. Empty when not searching.
+  matches: ResultRowMatch[]
+  // The needle the index was built from: trimmed and lower-cased. An empty
+  // string means "not searching", which is how callers skip the whole feature
+  // without a second flag.
+  needle: string
+}
+
+interface ResultSearchInput {
+  // Column names in column order, duplicates included.
+  columnNames: string[]
+  query: string
+  rows: Record<string, unknown>[]
+}
+
+/**
+ * The comparable form of what the user typed.
+ *
+ * Trimming costs the ability to search for a leading or trailing space and buys
+ * the case that actually happens: a pasted id carrying a trailing newline.
+ */
+export function normalizeSearchQuery(query: string): string {
+  return query.trim().toLowerCase()
+}
+
+/**
+ * Where `needle` occurs in `text`, non-overlapping and left to right, so `aa`
+ * in `aaaa` is two matches rather than three. `needle` must already be
+ * normalized.
+ *
+ * Matching is literal: a pasted value carrying an unescaped `(` would throw if
+ * this compiled a regular expression.
+ */
+export function findMatchOffsets(text: string, needle: string): number[] {
+  if (needle === '') {
+    return []
+  }
+
+  const haystack = text.toLowerCase()
+  const offsets: number[] = []
+
+  let from = 0
+
+  while (from <= haystack.length - needle.length) {
+    const offset = haystack.indexOf(needle, from)
+
+    if (offset === -1) {
+      break
+    }
+
+    offsets.push(offset)
+    from = offset + needle.length
+  }
+
+  return offsets
+}
+
+/**
+ * Splits displayed cell text into matched and unmatched runs, in order. The
+ * segments always rejoin into the original text, so rendering them cannot
+ * change what the cell says.
+ */
+export function splitCellText(text: string, needle: string): CellTextSegment[] {
+  // Offsets are found in the lower-cased text and then used to slice the
+  // original, which only lines up while lower-casing preserves length. A few
+  // characters break that (`I` with a dot above lower-cases to two), and
+  // slicing on a shifted offset would render mangled text. Such a cell still
+  // counts as a match; it just does not get the highlight.
+  if (needle === '' || text.toLowerCase().length !== text.length) {
+    return [{ isMatch: false, text }]
+  }
+
+  const offsets = findMatchOffsets(text, needle)
+
+  if (offsets.length === 0) {
+    return [{ isMatch: false, text }]
+  }
+
+  const segments: CellTextSegment[] = []
+
+  let cursor = 0
+
+  for (const offset of offsets) {
+    if (offset > cursor) {
+      segments.push({ isMatch: false, text: text.slice(cursor, offset) })
+    }
+
+    segments.push({
+      isMatch: true,
+      text: text.slice(offset, offset + needle.length)
+    })
+
+    cursor = offset + needle.length
+  }
+
+  if (cursor < text.length) {
+    segments.push({ isMatch: false, text: text.slice(cursor) })
+  }
+
+  return segments
+}
+
+/**
+ * Every row of a result that matches the query, in render order, plus which
+ * columns hold a match anywhere.
+ *
+ * A row is the unit of navigation rather than an occurrence: a one-character
+ * search over a full result has tens of thousands of occurrences but at most
+ * `rows.length` rows, so this bounds the list by construction -- and landing on
+ * the row is what someone pasting an id is asking for.
+ *
+ * Character offsets are deliberately not stored. Only the windowed rows are
+ * ever painted, so `splitCellText` runs for those during render instead of
+ * keeping offsets for every cell in the result.
+ */
+export function buildResultSearchIndex({
+  columnNames,
+  query,
+  rows
+}: ResultSearchInput): ResultSearchIndex {
+  const columnHasMatch = columnNames.map(() => false)
+  const needle = normalizeSearchQuery(query)
+
+  if (needle === '') {
+    return { columnHasMatch, matches: [], needle }
+  }
+
+  const matches: ResultRowMatch[] = []
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex]
+
+    let firstColumnIndex = -1
+
+    for (
+      let columnIndex = 0;
+      columnIndex < columnNames.length;
+      columnIndex += 1
+    ) {
+      // Read by name at this position, which is exactly what the cell render
+      // path does. For a result carrying two identically named fields both
+      // columns therefore report the same match -- correct, because both
+      // columns display the same value. The name-keying bug behind that is the
+      // grid's, and find must not paper over it.
+      const text = formatCellValue(row?.[columnNames[columnIndex]])
+
+      if (!text.toLowerCase().includes(needle)) {
+        continue
+      }
+
+      columnHasMatch[columnIndex] = true
+
+      if (firstColumnIndex === -1) {
+        firstColumnIndex = columnIndex
+      }
+    }
+
+    if (firstColumnIndex !== -1) {
+      matches.push({ columnIndex: firstColumnIndex, rowIndex })
+    }
+  }
+
+  return { columnHasMatch, matches, needle }
+}
+
+/**
+ * What the grid needs to paint a search: the index, which match is being
+ * jumped to, and whether non-matching rows are hidden.
+ *
+ * `query` is what the user typed, kept alongside the normalized `needle`
+ * because the empty state quotes it back and a lower-cased echo of someone's
+ * own typing reads as a bug.
+ */
+export interface ResultSearchView {
+  // Ordinal into `matches`, or -1 when there is nothing to jump to.
+  activeIndex: number
+  columnHasMatch: boolean[]
+  isFiltering: boolean
+  matches: ResultRowMatch[]
+  needle: string
+  query: string
+}

--- a/src/app/components/query-result-search.ts
+++ b/src/app/components/query-result-search.ts
@@ -206,3 +206,70 @@ export interface ResultSearchView {
   needle: string
   query: string
 }
+
+export interface AppliedSearch {
+  // The match being jumped to, if any, resolved from the view's ordinal.
+  activeMatch: ResultRowMatch | undefined
+  // Its index into `result.rows`, or -1.
+  activeRowIndex: number
+  // Its index in the virtualizer's coordinate space, or -1. The two differ
+  // while filtering, where the virtualizer counts matches rather than rows.
+  activeVisibleIndex: number
+  isFiltering: boolean
+  needle: string
+  // The one place a virtualizer index becomes an index into `result.rows`.
+  toSourceIndex: (visibleIndex: number) => number
+  visibleRowCount: number
+}
+
+const noMatches: ResultRowMatch[] = []
+
+/**
+ * What a search view means for a grid of `rowCount` rows: which rows to render,
+ * how to address them, and which cell is the one being jumped to.
+ *
+ * Pulled out of the grid because the addressing is the part that goes wrong
+ * quietly. While filtering, a virtualizer index is a position in the match list
+ * rather than a row, and every read of the row -- its number, its cells, its
+ * copy actions -- has to go through `toSourceIndex`. A missed call site shows a
+ * different row's data with nothing to say so, which is worth a test that does
+ * not need a rendered table.
+ */
+export function applySearchToRows(
+  rowCount: number,
+  search: ResultSearchView | undefined
+): AppliedSearch {
+  const needle = search?.needle ?? ''
+  const matches = search?.matches ?? noMatches
+  const isFiltering = search?.isFiltering === true && needle !== ''
+
+  const activeMatch =
+    search === undefined || search.activeIndex < 0
+      ? undefined
+      : matches[search.activeIndex]
+
+  const toSourceIndex = (visibleIndex: number): number => {
+    if (!isFiltering) {
+      return visibleIndex
+    }
+
+    const match = matches[visibleIndex]
+
+    return match === undefined ? visibleIndex : match.rowIndex
+  }
+
+  return {
+    activeMatch,
+    activeRowIndex: activeMatch?.rowIndex ?? -1,
+    activeVisibleIndex:
+      activeMatch === undefined
+        ? -1
+        : isFiltering
+          ? (search?.activeIndex ?? -1)
+          : activeMatch.rowIndex,
+    isFiltering,
+    needle,
+    toSourceIndex,
+    visibleRowCount: isFiltering ? matches.length : rowCount
+  }
+}

--- a/src/app/components/use-worksheet-editor.ts
+++ b/src/app/components/use-worksheet-editor.ts
@@ -43,12 +43,33 @@ import { findGutterMarkerPositions } from './worksheet-editor-lines'
 // `autocompletion` is off because the extension list registers it explicitly;
 // basicSetup only leaves an option out when it is literally `false`, so without
 // this it would be registered twice.
+//
+// `searchKeymap` is off because the results grid owns Mod-f. That option opts in
+// silently -- nothing in the extension list below mentions it -- and it binds
+// Mod-f to CodeMirror's own search panel without stopping propagation, so
+// leaving it on runs both finds and the grid's steals focus from the panel. The
+// editor holds focus by default, so this is the difference between Mod-f
+// working straight after a query returns and not.
+//
+// Turning it off also drops Mod-g, F3, Mod-Alt-g and Mod-d from the editor.
+// Putting any of them back means importing `@codemirror/search` here, and this
+// tree carries four separate copies of that package at two versions -- the one
+// an app import resolves to is not the one basicSetup is built against, so the
+// binding would read a different search state than it wrote. Flattening that is
+// its own job; until then the editor simply has no find.
+//
+// It also drops Mod-Shift-l, which is the app's own light/dark toggle -- but
+// that key stays dead in the editor regardless: `ThemeProvider` registers it
+// without `enableOnContentEditable`, so react-hotkeys-hook declines it on a
+// contenteditable target whatever CodeMirror does. Verified in the running app.
+// Removing CodeMirror's binding is necessary but not sufficient there.
 const editorBasicSetup = {
   autocompletion: false,
   bracketMatching: true,
   highlightActiveLine: true,
   history: true,
-  lineNumbers: true
+  lineNumbers: true,
+  searchKeymap: false
 }
 
 export interface WorksheetEditorOptions {

--- a/src/app/find-session.test.ts
+++ b/src/app/find-session.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  activeIndexWithin,
+  closed,
+  closedSession,
+  opened,
+  stepped,
+  withFilteringToggled,
+  withQuery
+} from './find-session'
+
+describe('find session', () => {
+  const open = { activeIndex: 2, isFiltering: true, isOpen: true, query: 'mia' }
+
+  it('starts closed, empty and unfiltered', () => {
+    expect(closedSession).toEqual({
+      activeIndex: 0,
+      isFiltering: false,
+      isOpen: false,
+      query: ''
+    })
+  })
+
+  it('opens without disturbing anything else', () => {
+    expect(opened(closedSession)).toEqual({
+      activeIndex: 0,
+      isFiltering: false,
+      isOpen: true,
+      query: ''
+    })
+  })
+
+  // Closing keeps the query the way a browser's find does, so reopening does
+  // not mean retyping. Only `isOpen` goes, which is also what lifts the filter.
+  it('keeps the query and the filter when it closes', () => {
+    expect(closed(open)).toEqual({
+      activeIndex: 2,
+      isFiltering: true,
+      isOpen: false,
+      query: 'mia'
+    })
+  })
+
+  it('goes back to the first match when the query changes', () => {
+    expect(withQuery(open, 'leo')).toEqual({
+      activeIndex: 0,
+      isFiltering: true,
+      isOpen: true,
+      query: 'leo'
+    })
+  })
+
+  it('toggles the filter both ways', () => {
+    expect(withFilteringToggled(open).isFiltering).toEqual(false)
+    expect(withFilteringToggled(withFilteringToggled(open))).toEqual(open)
+  })
+
+  describe('stepping', () => {
+    it('moves forward and back', () => {
+      expect(stepped(open, { delta: 1, matchCount: 5 }).activeIndex).toEqual(3)
+      expect(stepped(open, { delta: -1, matchCount: 5 }).activeIndex).toEqual(1)
+    })
+
+    it('wraps at both ends', () => {
+      const last = { ...open, activeIndex: 4 }
+      const first = { ...open, activeIndex: 0 }
+
+      expect(stepped(last, { delta: 1, matchCount: 5 }).activeIndex).toEqual(0)
+      expect(stepped(first, { delta: -1, matchCount: 5 }).activeIndex).toEqual(
+        4
+      )
+    })
+
+    // Returning the session itself is what lets the caller skip a state write,
+    // so pressing Enter with nothing found does not re-render the grid.
+    it('answers the same session when there is nothing to step through', () => {
+      expect(stepped(open, { delta: 1, matchCount: 0 })).toBe(open)
+    })
+
+    // The stored ordinal can be past the end after a re-run returned fewer
+    // rows; a step has to move from where the highlight actually is.
+    it('steps from the clamped ordinal when the match list shrank', () => {
+      const stale = { ...open, activeIndex: 9 }
+
+      expect(stepped(stale, { delta: 1, matchCount: 3 }).activeIndex).toEqual(0)
+    })
+  })
+
+  describe('activeIndexWithin', () => {
+    it('answers -1 when there is nothing to jump to', () => {
+      expect(activeIndexWithin(open, 0)).toEqual(-1)
+    })
+
+    it('passes an in-range ordinal through', () => {
+      expect(activeIndexWithin(open, 5)).toEqual(2)
+    })
+
+    it('clamps an ordinal left over from a longer match list', () => {
+      expect(activeIndexWithin({ ...open, activeIndex: 9 }, 3)).toEqual(2)
+    })
+  })
+})

--- a/src/app/find-session.ts
+++ b/src/app/find-session.ts
@@ -1,0 +1,79 @@
+// The find-in-results session and every move it can make, as plain functions.
+//
+// Kept out of the hook so each transition can be read and tested on its own:
+// what a close keeps, what a new query resets, and where a step lands at either
+// end of the match list.
+
+export interface FindSession {
+  // An ordinal into the match list. Stored rather than clamped so a re-run that
+  // returns fewer rows does not lose the user's place, and read through a clamp
+  // so it can never point past the end.
+  activeIndex: number
+  isFiltering: boolean
+  isOpen: boolean
+  // What the user typed, untrimmed: this is the input's value.
+  query: string
+}
+
+export const closedSession: FindSession = {
+  activeIndex: 0,
+  isFiltering: false,
+  isOpen: false,
+  query: ''
+}
+
+export function opened(session: FindSession): FindSession {
+  return { ...session, isOpen: true }
+}
+
+/**
+ * The query survives a close, the way a browser's does. Only `isOpen` goes,
+ * which is also what lifts the filter off the grid.
+ */
+export function closed(session: FindSession): FindSession {
+  return { ...session, isOpen: false }
+}
+
+/**
+ * Back to the first match on every edit, like Chrome. An ordinal that survived
+ * a query change would leave the user on "match 4" of a set with nothing to do
+ * with the one they were walking.
+ */
+export function withQuery(session: FindSession, query: string): FindSession {
+  return { ...session, activeIndex: 0, query }
+}
+
+export function withFilteringToggled(session: FindSession): FindSession {
+  return { ...session, isFiltering: !session.isFiltering }
+}
+
+/**
+ * The next or previous match, wrapping at both ends. Steps from the clamped
+ * ordinal rather than the stored one, so a step after the match list shrank
+ * moves from where the user could actually see the highlight.
+ */
+export function stepped(
+  session: FindSession,
+  { delta, matchCount }: { delta: number; matchCount: number }
+): FindSession {
+  if (matchCount === 0) {
+    return session
+  }
+
+  const from = Math.min(session.activeIndex, matchCount - 1)
+
+  return { ...session, activeIndex: (from + delta + matchCount) % matchCount }
+}
+
+/**
+ * The ordinal to paint, which is not always the one stored: a re-run, a
+ * narrowed query or a shorter result all shrink the match list. Clamping on
+ * read rather than in an effect keeps it from costing a second render pass to
+ * fix state that was only ever wrong in between. `-1` is nothing to jump to.
+ */
+export function activeIndexWithin(
+  session: FindSession,
+  matchCount: number
+): number {
+  return matchCount === 0 ? -1 : Math.min(session.activeIndex, matchCount - 1)
+}

--- a/src/app/find-shortcut.ts
+++ b/src/app/find-shortcut.ts
@@ -1,0 +1,13 @@
+/**
+ * The Find in results shortcut as the user's platform spells it. Read at call
+ * time rather than cached in a module constant so tests can stand in a
+ * platform.
+ *
+ * ⌘F is safe to claim: Electron's default application menu, which this app
+ * never replaces, has no Find role -- unlike ⌘R and ⌘W, which it does own. What
+ * it does collide with is CodeMirror, so `use-worksheet-editor.ts` turns the
+ * editor's search keymap off; see the note there.
+ */
+export function getFindShortcut(): string {
+  return navigator.platform.toLowerCase().includes('mac') ? '⌘F' : 'Ctrl+F'
+}

--- a/src/app/hooks/use-focus-request.ts
+++ b/src/app/hooks/use-focus-request.ts
@@ -1,0 +1,38 @@
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react'
+
+export interface FocusRequest<T extends HTMLElement> {
+  ref: RefObject<T | null>
+  request: () => void
+}
+
+/**
+ * Focus and select an element that may not exist yet, on demand.
+ *
+ * A counter rather than a boolean, for two reasons. The element is often
+ * mounted by the same state update that asks for the focus, so the effect has
+ * to run after that render rather than during the handler. And asking twice
+ * while it is already focused still has to do something -- for the find bar
+ * that is what makes a second ⌘F select what is in the box, so the paste after
+ * it replaces the old value instead of appending to it.
+ */
+export function useFocusRequest<
+  T extends HTMLElement & { select?: () => void }
+>(): FocusRequest<T> {
+  const ref = useRef<T>(null)
+  const [requestCount, setRequestCount] = useState(0)
+
+  useEffect(() => {
+    if (requestCount === 0) {
+      return
+    }
+
+    ref.current?.focus()
+    ref.current?.select?.()
+  }, [requestCount])
+
+  const request = useCallback(() => {
+    setRequestCount((count) => count + 1)
+  }, [])
+
+  return { ref, request }
+}

--- a/src/app/hooks/use-per-worksheet-state.ts
+++ b/src/app/hooks/use-per-worksheet-state.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { useAppSelector } from '../store'
+import { selectOpenWorksheetIds } from '../store/tabs-slice'
+
+export interface PerWorksheetState<T> {
+  update: (worksheetId: string | undefined, change: (current: T) => T) => void
+  valueFor: (worksheetId: string | undefined) => T
+}
+
+/**
+ * A value held one worksheet at a time, for the worksheets whose tabs are open.
+ *
+ * Coming back to a tab should find it as it was left, which one shared value
+ * cannot do -- switching tabs would snap every worksheet to whatever the last
+ * one did. The record is bounded by the open tabs rather than by every
+ * worksheet visited this session, so it cannot grow for the life of the
+ * process.
+ *
+ * `fallback` is read on every render, so callers pass a constant rather than a
+ * fresh literal: an unstable one would rebuild both callbacks each time.
+ */
+export function usePerWorksheetState<T>(fallback: T): PerWorksheetState<T> {
+  const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
+
+  const [valueByWorksheet, setValueByWorksheet] = useState<Record<string, T>>(
+    {}
+  )
+
+  useEffect(() => {
+    const open = new Set(openWorksheetIds)
+
+    setValueByWorksheet((current) => {
+      const next = Object.fromEntries(
+        Object.entries(current).filter(([id]) => open.has(id))
+      )
+
+      // Same size means nothing was dropped, and returning `current` there is
+      // what stops this from re-rendering every consumer on each tab change.
+      return Object.keys(next).length === Object.keys(current).length
+        ? current
+        : next
+    })
+  }, [openWorksheetIds])
+
+  const valueFor = useCallback(
+    (worksheetId: string | undefined): T =>
+      (worksheetId ? valueByWorksheet[worksheetId] : undefined) ?? fallback,
+    [fallback, valueByWorksheet]
+  )
+
+  const update = useCallback(
+    (worksheetId: string | undefined, change: (current: T) => T): void => {
+      // No worksheet is no key to store under, so there is nothing to remember
+      // rather than a shared slot to fall back on.
+      if (!worksheetId) {
+        return
+      }
+
+      setValueByWorksheet((current) => {
+        const existing = current[worksheetId] ?? fallback
+        const next = change(existing)
+
+        // An unchanged value returns the record itself, which is what lets
+        // React bail out rather than re-render every consumer for a move that
+        // did nothing -- stepping through an empty match list, say.
+        return next === existing ? current : { ...current, [worksheetId]: next }
+      })
+    },
+    [fallback]
+  )
+
+  return { update, valueFor }
+}

--- a/src/app/hooks/use-results-find.ts
+++ b/src/app/hooks/use-results-find.ts
@@ -5,14 +5,16 @@
 // as a workspace is shown, so the `mod+f` registered here already fires from
 // anywhere in the app -- including out of CodeMirror, which is the usual reason
 // to reach for a store -- and nothing outside this pane reads any of it.
+//
+// The session's own moves live in `../find-session`, as plain functions over a
+// plain value; what is left here is React and the shortcut.
 import {
   RefObject,
   useCallback,
   useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
-  useState
+  useRef
 } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
@@ -23,19 +25,19 @@ import {
   buildResultSearchIndex,
   type ResultSearchView
 } from '../components/query-result-search'
+import {
+  activeIndexWithin,
+  closed,
+  closedSession,
+  type FindSession,
+  opened,
+  stepped,
+  withFilteringToggled,
+  withQuery
+} from '../find-session'
 import { useAppSelector } from '../store'
-import { selectOpenWorksheetIds } from '../store/tabs-slice'
-
-interface FindSession {
-  // An ordinal into the match list. Stored rather than clamped so that a
-  // re-run which returns fewer rows does not lose the user's place, and read
-  // through a clamp so it can never point past the end.
-  activeIndex: number
-  isFiltering: boolean
-  isOpen: boolean
-  // What the user typed, untrimmed: this is the input's value.
-  query: string
-}
+import { useFocusRequest } from './use-focus-request'
+import { usePerWorksheetState } from './use-per-worksheet-state'
 
 export interface ResultsFind {
   // 1-based, for display. 0 when there is nothing to jump to.
@@ -64,13 +66,6 @@ interface ResultsFindOptions {
   onShowResults: () => void
 }
 
-const closedSession: FindSession = {
-  activeIndex: 0,
-  isFiltering: false,
-  isOpen: false,
-  query: ''
-}
-
 const noRows: Record<string, unknown>[] = []
 
 export function useResultsFind({
@@ -78,47 +73,12 @@ export function useResultsFind({
   worksheetId,
   onShowResults
 }: ResultsFindOptions): ResultsFind {
-  const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
-
   // Kept per worksheet, like the pane's height and its active tab: coming back
-  // to a tab should find it as it was left. Bounded by the open tabs rather
-  // than by every worksheet visited this session.
-  const [sessionByWorksheet, setSessionByWorksheet] = useState<
-    Record<string, FindSession>
-  >({})
+  // to a tab should find it as it was left.
+  const sessions = usePerWorksheetState(closedSession)
+  const session = sessions.valueFor(worksheetId)
 
-  useEffect(() => {
-    const open = new Set(openWorksheetIds)
-
-    setSessionByWorksheet((current) => {
-      const next = Object.fromEntries(
-        Object.entries(current).filter(([id]) => open.has(id))
-      )
-
-      return Object.keys(next).length === Object.keys(current).length
-        ? current
-        : next
-    })
-  }, [openWorksheetIds])
-
-  const session =
-    (worksheetId ? sessionByWorksheet[worksheetId] : undefined) ?? closedSession
-
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  // A counter rather than a boolean, so a second ⌘F while the bar is already
-  // open still asks for focus. That is what makes ⌘F ⌘V with a different id
-  // replace the old one instead of appending to it.
-  const [focusRequest, setFocusRequest] = useState(0)
-
-  useEffect(() => {
-    if (focusRequest === 0) {
-      return
-    }
-
-    inputRef.current?.focus()
-    inputRef.current?.select()
-  }, [focusRequest])
+  const focus = useFocusRequest<HTMLInputElement>()
 
   // Scanning every row is cheap enough not to need a debounce, but it is not
   // free on a full result of JSON columns. Deferring the needle keeps the input
@@ -142,109 +102,49 @@ export function useResultsFind({
   )
 
   const matchCount = index.matches.length
+  const activeIndex = activeIndexWithin(session, matchCount)
 
-  // Clamped on read: a re-run, a narrowed query or a shorter result all shrink
-  // the list, and doing this in an effect would cost a second render pass to
-  // fix state that was only ever wrong in between.
-  const activeIndex =
-    matchCount === 0 ? -1 : Math.min(session.activeIndex, matchCount - 1)
-
-  const updateSession = useCallback(
-    (update: (session: FindSession) => FindSession) => {
-      if (!worksheetId) {
-        return
-      }
-
-      setSessionByWorksheet((current) => ({
-        ...current,
-        [worksheetId]: update(current[worksheetId] ?? closedSession)
-      }))
-    },
-    [worksheetId]
+  const update = useCallback(
+    (move: (session: FindSession) => FindSession) =>
+      sessions.update(worksheetId, move),
+    [sessions, worksheetId]
   )
 
   const open = useCallback(() => {
     // Nothing to search means nothing to open: during a run or after a failure
     // there is no result behind the pane at all.
-    if (!worksheetId || !result) {
+    if (!result) {
       return
     }
 
     onShowResults()
-    updateSession((current) => ({ ...current, isOpen: true }))
-    setFocusRequest((count) => count + 1)
-  }, [onShowResults, result, updateSession, worksheetId])
+    update(opened)
+    focus.request()
+  }, [focus, onShowResults, result, update])
 
-  const close = useCallback(() => {
-    // The query survives a close, the way a browser's does. Only `isOpen` goes,
-    // which is also what lifts the filter off the grid.
-    updateSession((current) => ({ ...current, isOpen: false }))
-  }, [updateSession])
+  const close = useCallback(() => update(closed), [update])
 
   const setQuery = useCallback(
-    (query: string) => {
-      // Back to the first match on every edit, like Chrome. Letting the ordinal
-      // survive a query change would leave the user on "match 4" of a set that
-      // no longer has anything to do with the one they were walking.
-      updateSession((current) => ({ ...current, activeIndex: 0, query }))
-    },
-    [updateSession]
+    (query: string) => update((current) => withQuery(current, query)),
+    [update]
   )
 
-  const step = useCallback(
-    (delta: number) => {
-      if (matchCount === 0) {
-        return
-      }
-
-      updateSession((current) => {
-        const from = Math.min(current.activeIndex, matchCount - 1)
-
-        return {
-          ...current,
-          activeIndex: (from + delta + matchCount) % matchCount
-        }
-      })
-    },
-    [matchCount, updateSession]
+  const next = useCallback(
+    () => update((current) => stepped(current, { delta: 1, matchCount })),
+    [matchCount, update]
   )
 
-  const next = useCallback(() => step(1), [step])
-  const previous = useCallback(() => step(-1), [step])
-
-  const toggleFiltering = useCallback(() => {
-    updateSession((current) => ({
-      ...current,
-      isFiltering: !current.isFiltering
-    }))
-  }, [updateSession])
-
-  // `EditorScreen` renders over a still-mounted workspace and the trace
-  // dashboard mounts outside it, so without this ⌘F would open a find bar
-  // behind whichever one is up and pull focus out of it.
-  const isOverlayOpen = useAppSelector(
-    (state) =>
-      state.ui.editorScreen !== undefined ||
-      state.ui.traceDashboardOpen === true
+  const previous = useCallback(
+    () => update((current) => stepped(current, { delta: -1, matchCount })),
+    [matchCount, update]
   )
-  const isOverlayOpenRef = useRef(isOverlayOpen)
 
-  useEffect(() => {
-    isOverlayOpenRef.current = isOverlayOpen
-  }, [isOverlayOpen])
+  const toggleFiltering = useCallback(
+    () => update(withFilteringToggled),
+    [update]
+  )
 
-  useHotkeys('mod+f', open, {
-    // CodeMirror is a contenteditable and holds focus by default, so without
-    // this the shortcut is dead exactly where it is most wanted: straight after
-    // a query returns.
-    enableOnContentEditable: true,
-    enableOnFormTags: true,
-    // Not `enabled`: a hotkey that matches while disabled gets
-    // stopImmediatePropagation() called on its event, which would swallow ⌘F
-    // for everyone else rather than declining it.
-    ignoreEventWhen: () => isOverlayOpenRef.current,
-    preventDefault: true
-  })
+  useFindHotkey(open)
 
   const search = useMemo(
     () =>
@@ -265,7 +165,7 @@ export function useResultsFind({
     () => ({
       activeOrdinal: activeIndex + 1,
       close,
-      inputRef,
+      inputRef: focus.ref,
       isFiltering: session.isFiltering,
       isOpen: session.isOpen,
       matchCount,
@@ -282,6 +182,7 @@ export function useResultsFind({
     [
       activeIndex,
       close,
+      focus.ref,
       matchCount,
       next,
       open,
@@ -295,4 +196,44 @@ export function useResultsFind({
       toggleFiltering
     ]
   )
+}
+
+/**
+ * `mod+f`, wherever focus happens to be.
+ *
+ * Held apart from the session because everything interesting about it is the
+ * registration rather than the handler.
+ */
+function useFindHotkey(onOpen: () => void): void {
+  // `EditorScreen` renders over a still-mounted workspace and the trace
+  // dashboard mounts outside it, so without this ⌘F would open a find bar
+  // behind whichever one is up and pull focus out of it.
+  const isOverlayOpen = useAppSelector(
+    (state) =>
+      state.ui.editorScreen !== undefined ||
+      state.ui.traceDashboardOpen === true
+  )
+
+  // Read through a ref because `ignoreEventWhen` is called from the library's
+  // own listener rather than during render: a closure over the render value
+  // would either go stale or force a re-registration on every render,
+  // depending on how the options are memoized. A ref is right either way.
+  const isOverlayOpenRef = useRef(isOverlayOpen)
+
+  useEffect(() => {
+    isOverlayOpenRef.current = isOverlayOpen
+  }, [isOverlayOpen])
+
+  useHotkeys('mod+f', onOpen, {
+    // CodeMirror is a contenteditable and holds focus by default, so without
+    // this the shortcut is dead exactly where it is most wanted: straight after
+    // a query returns.
+    enableOnContentEditable: true,
+    enableOnFormTags: true,
+    // Not `enabled`: a hotkey that matches while disabled gets
+    // stopImmediatePropagation() called on its event, which would swallow ⌘F
+    // for everyone else rather than declining it.
+    ignoreEventWhen: () => isOverlayOpenRef.current,
+    preventDefault: true
+  })
 }

--- a/src/app/hooks/use-results-find.ts
+++ b/src/app/hooks/use-results-find.ts
@@ -1,0 +1,298 @@
+// Find-in-results, the session half: what the user typed, which match they are
+// on, and whether non-matching rows are hidden.
+//
+// The state is local rather than in Redux. `ResultsPane` is mounted for as long
+// as a workspace is shown, so the `mod+f` registered here already fires from
+// anywhere in the app -- including out of CodeMirror, which is the usual reason
+// to reach for a store -- and nothing outside this pane reads any of it.
+import {
+  RefObject,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
+
+import type { QueryResultDto } from '@/glue/api/schemas'
+
+import { getResultFieldNames } from '../components/query-result-columns'
+import {
+  buildResultSearchIndex,
+  type ResultSearchView
+} from '../components/query-result-search'
+import { useAppSelector } from '../store'
+import { selectOpenWorksheetIds } from '../store/tabs-slice'
+
+interface FindSession {
+  // An ordinal into the match list. Stored rather than clamped so that a
+  // re-run which returns fewer rows does not lose the user's place, and read
+  // through a clamp so it can never point past the end.
+  activeIndex: number
+  isFiltering: boolean
+  isOpen: boolean
+  // What the user typed, untrimmed: this is the input's value.
+  query: string
+}
+
+export interface ResultsFind {
+  // 1-based, for display. 0 when there is nothing to jump to.
+  activeOrdinal: number
+  close: () => void
+  inputRef: RefObject<HTMLInputElement | null>
+  isFiltering: boolean
+  isOpen: boolean
+  matchCount: number
+  next: () => void
+  open: () => void
+  previous: () => void
+  query: string
+  rowCount: number
+  search: ResultSearchView | undefined
+  setQuery: (query: string) => void
+  toggleFiltering: () => void
+  truncated: boolean
+}
+
+interface ResultsFindOptions {
+  result: QueryResultDto | null | undefined
+  worksheetId: string | undefined
+  // Find is find-in-results, so opening it while the Messages tab is showing
+  // has to bring the results back or the shortcut looks broken.
+  onShowResults: () => void
+}
+
+const closedSession: FindSession = {
+  activeIndex: 0,
+  isFiltering: false,
+  isOpen: false,
+  query: ''
+}
+
+const noRows: Record<string, unknown>[] = []
+
+export function useResultsFind({
+  result,
+  worksheetId,
+  onShowResults
+}: ResultsFindOptions): ResultsFind {
+  const openWorksheetIds = useAppSelector(selectOpenWorksheetIds)
+
+  // Kept per worksheet, like the pane's height and its active tab: coming back
+  // to a tab should find it as it was left. Bounded by the open tabs rather
+  // than by every worksheet visited this session.
+  const [sessionByWorksheet, setSessionByWorksheet] = useState<
+    Record<string, FindSession>
+  >({})
+
+  useEffect(() => {
+    const open = new Set(openWorksheetIds)
+
+    setSessionByWorksheet((current) => {
+      const next = Object.fromEntries(
+        Object.entries(current).filter(([id]) => open.has(id))
+      )
+
+      return Object.keys(next).length === Object.keys(current).length
+        ? current
+        : next
+    })
+  }, [openWorksheetIds])
+
+  const session =
+    (worksheetId ? sessionByWorksheet[worksheetId] : undefined) ?? closedSession
+
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // A counter rather than a boolean, so a second ⌘F while the bar is already
+  // open still asks for focus. That is what makes ⌘F ⌘V with a different id
+  // replace the old one instead of appending to it.
+  const [focusRequest, setFocusRequest] = useState(0)
+
+  useEffect(() => {
+    if (focusRequest === 0) {
+      return
+    }
+
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [focusRequest])
+
+  // Scanning every row is cheap enough not to need a debounce, but it is not
+  // free on a full result of JSON columns. Deferring the needle keeps the input
+  // itself immediate and lets the scan and the grid repaint at a priority React
+  // can interrupt.
+  const deferredQuery = useDeferredValue(session.query)
+
+  const columnNames = useMemo(
+    () => (result ? getResultFieldNames(result) : []),
+    [result]
+  )
+
+  const index = useMemo(
+    () =>
+      buildResultSearchIndex({
+        columnNames,
+        query: session.isOpen ? deferredQuery : '',
+        rows: result?.rows ?? noRows
+      }),
+    [columnNames, deferredQuery, result, session.isOpen]
+  )
+
+  const matchCount = index.matches.length
+
+  // Clamped on read: a re-run, a narrowed query or a shorter result all shrink
+  // the list, and doing this in an effect would cost a second render pass to
+  // fix state that was only ever wrong in between.
+  const activeIndex =
+    matchCount === 0 ? -1 : Math.min(session.activeIndex, matchCount - 1)
+
+  const updateSession = useCallback(
+    (update: (session: FindSession) => FindSession) => {
+      if (!worksheetId) {
+        return
+      }
+
+      setSessionByWorksheet((current) => ({
+        ...current,
+        [worksheetId]: update(current[worksheetId] ?? closedSession)
+      }))
+    },
+    [worksheetId]
+  )
+
+  const open = useCallback(() => {
+    // Nothing to search means nothing to open: during a run or after a failure
+    // there is no result behind the pane at all.
+    if (!worksheetId || !result) {
+      return
+    }
+
+    onShowResults()
+    updateSession((current) => ({ ...current, isOpen: true }))
+    setFocusRequest((count) => count + 1)
+  }, [onShowResults, result, updateSession, worksheetId])
+
+  const close = useCallback(() => {
+    // The query survives a close, the way a browser's does. Only `isOpen` goes,
+    // which is also what lifts the filter off the grid.
+    updateSession((current) => ({ ...current, isOpen: false }))
+  }, [updateSession])
+
+  const setQuery = useCallback(
+    (query: string) => {
+      // Back to the first match on every edit, like Chrome. Letting the ordinal
+      // survive a query change would leave the user on "match 4" of a set that
+      // no longer has anything to do with the one they were walking.
+      updateSession((current) => ({ ...current, activeIndex: 0, query }))
+    },
+    [updateSession]
+  )
+
+  const step = useCallback(
+    (delta: number) => {
+      if (matchCount === 0) {
+        return
+      }
+
+      updateSession((current) => {
+        const from = Math.min(current.activeIndex, matchCount - 1)
+
+        return {
+          ...current,
+          activeIndex: (from + delta + matchCount) % matchCount
+        }
+      })
+    },
+    [matchCount, updateSession]
+  )
+
+  const next = useCallback(() => step(1), [step])
+  const previous = useCallback(() => step(-1), [step])
+
+  const toggleFiltering = useCallback(() => {
+    updateSession((current) => ({
+      ...current,
+      isFiltering: !current.isFiltering
+    }))
+  }, [updateSession])
+
+  // `EditorScreen` renders over a still-mounted workspace and the trace
+  // dashboard mounts outside it, so without this ⌘F would open a find bar
+  // behind whichever one is up and pull focus out of it.
+  const isOverlayOpen = useAppSelector(
+    (state) =>
+      state.ui.editorScreen !== undefined ||
+      state.ui.traceDashboardOpen === true
+  )
+  const isOverlayOpenRef = useRef(isOverlayOpen)
+
+  useEffect(() => {
+    isOverlayOpenRef.current = isOverlayOpen
+  }, [isOverlayOpen])
+
+  useHotkeys('mod+f', open, {
+    // CodeMirror is a contenteditable and holds focus by default, so without
+    // this the shortcut is dead exactly where it is most wanted: straight after
+    // a query returns.
+    enableOnContentEditable: true,
+    enableOnFormTags: true,
+    // Not `enabled`: a hotkey that matches while disabled gets
+    // stopImmediatePropagation() called on its event, which would swallow ⌘F
+    // for everyone else rather than declining it.
+    ignoreEventWhen: () => isOverlayOpenRef.current,
+    preventDefault: true
+  })
+
+  const search = useMemo(
+    () =>
+      session.isOpen
+        ? {
+            activeIndex,
+            columnHasMatch: index.columnHasMatch,
+            isFiltering: session.isFiltering,
+            matches: index.matches,
+            needle: index.needle,
+            query: session.query
+          }
+        : undefined,
+    [activeIndex, index, session.isFiltering, session.isOpen, session.query]
+  )
+
+  return useMemo(
+    () => ({
+      activeOrdinal: activeIndex + 1,
+      close,
+      inputRef,
+      isFiltering: session.isFiltering,
+      isOpen: session.isOpen,
+      matchCount,
+      next,
+      open,
+      previous,
+      query: session.query,
+      rowCount: result?.rows.length ?? 0,
+      search,
+      setQuery,
+      toggleFiltering,
+      truncated: result?.truncated === true
+    }),
+    [
+      activeIndex,
+      close,
+      matchCount,
+      next,
+      open,
+      previous,
+      result,
+      search,
+      session.isFiltering,
+      session.isOpen,
+      session.query,
+      setQuery,
+      toggleFiltering
+    ]
+  )
+}

--- a/src/app/hooks/use-scroll-to-match.ts
+++ b/src/app/hooks/use-scroll-to-match.ts
@@ -1,0 +1,53 @@
+import { RefObject, useEffect } from 'react'
+
+interface ScrollToMatchOptions {
+  // Index into the result's rows, or -1 for nothing to reveal.
+  activeRowIndex: number
+  // The same match in the virtualizer's coordinate space, or -1.
+  activeVisibleIndex: number
+  // Whether the row is in the window the virtualizer is currently painting.
+  isActiveRowRendered: boolean
+  scrollRef: RefObject<HTMLElement | null>
+  scrollToIndex: (index: number, options: { align: 'auto' }) => void
+}
+
+/**
+ * Brings the match being jumped to into view, vertically and then across.
+ *
+ * Two effects rather than one, on purpose. `scrollToIndex` sets `scrollTop`
+ * synchronously, but the virtualizer re-windows on the scroll event that
+ * follows, so the target cell is not in the DOM during that same pass -- the
+ * horizontal step has to wait until the row it lives in is actually painted.
+ */
+export function useScrollToMatch({
+  activeRowIndex,
+  activeVisibleIndex,
+  isActiveRowRendered,
+  scrollRef,
+  scrollToIndex
+}: ScrollToMatchOptions): void {
+  useEffect(() => {
+    if (activeVisibleIndex < 0) {
+      return
+    }
+
+    // `auto` leaves the offset alone when the row is already comfortably in
+    // view, so stepping between two matches on screen does not jerk the grid.
+    scrollToIndex(activeVisibleIndex, { align: 'auto' })
+  }, [activeVisibleIndex, scrollToIndex])
+
+  useEffect(() => {
+    if (activeRowIndex < 0 || !isActiveRowRendered) {
+      return
+    }
+
+    // Columns are not virtualized and the table is auto-layout, so the rendered
+    // width of a column is not the width that was pinned for it. Asking the
+    // browser to reveal the cell is the only reading of the layout that is
+    // actually true.
+    scrollRef.current
+      ?.querySelector('[data-find-active]')
+      // Optional call: jsdom does not implement scrollIntoView.
+      ?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' })
+  }, [activeRowIndex, isActiveRowRendered, scrollRef])
+}

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -60,6 +60,13 @@
   --color-accent-btn: var(--accent-btn);
   --color-accent-soft: var(--accent-soft);
 
+  /* Find */
+  --color-find: var(--find);
+  --color-find-text: var(--find-text);
+  --color-find-active: var(--find-active);
+  --color-find-active-text: var(--find-active-text);
+  --color-find-strong: var(--find-strong);
+
   /* Status */
   --color-err: var(--err);
   --color-err-bg: var(--err-bg);

--- a/src/app/styles/themes/squeal-dark.css
+++ b/src/app/styles/themes/squeal-dark.css
@@ -27,6 +27,13 @@
   --accent-btn: oklch(from var(--accent) 58% calc(c * 1.35) h);
   --accent-soft: color-mix(in oklab, var(--accent) 24%, var(--panel));
 
+  /* Find */
+  --find: oklch(40% 0.09 310);
+  --find-text: oklch(94% 0.02 310);
+  --find-active: oklch(56% 0.15 305);
+  --find-active-text: oklch(16% 0.03 305);
+  --find-strong: oklch(78% 0.13 305);
+
   /* Status */
   --err: oklch(74% 0.13 25);
   --err-bg: oklch(28% 0.04 25);

--- a/src/app/styles/themes/squeal-light.css
+++ b/src/app/styles/themes/squeal-light.css
@@ -44,6 +44,15 @@
   --accent-btn: oklch(from var(--accent) 50% c h);
   --accent-soft: color-mix(in oklab, var(--accent) 10%, var(--panel));
 
+  /* Find */
+  --find: oklch(89% 0.09 310);
+  --find-text: oklch(28% 0.02 310);
+  --find-active: oklch(72% 0.17 305);
+  --find-active-text: oklch(22% 0.03 305);
+  /* The same violet at a lightness that works as text rather than as a block
+     behind it, for the header of a column the search landed in. */
+  --find-strong: oklch(48% 0.19 305);
+
   /* Status */
   --err: oklch(52% 0.15 25);
   --err-bg: oklch(96.5% 0.02 25);


### PR DESCRIPTION
Locating a row in a result meant editing the SQL and re-running it — a database round trip for a question about data already on screen. `⌘F` now opens a find bar in the results header.

- Matches are marked; `Enter` / `Shift+Enter` walk between them against an `n of m` counter.
- `⌘F` again select-alls, so pasting a second id replaces the first rather than appending.
- A toggle collapses the grid to only the matching rows, **keeping their original row numbers**.
- `Esc` closes. A search icon in the header makes the shortcut discoverable.

The flow it was built for: `⌘F`, `⌘V`, land on your row.

## Decisions worth reviewing

**⌘F belongs to the results grid everywhere, so CodeMirror's `searchKeymap` is off.** The editor holds focus by default, so a focus-dependent split would send the paste that follows `⌘F` to the wrong box most of the time. This costs the editor's `⌘F`, `⌘G`, `F3`, `⌘D` and `⌘⌥G`.

I tried adding `⌘D` and `⌘⌥F` back and reverted it: `@codemirror/search` is not a direct dependency and the tree carries **four copies at two versions**, which `yarn add` forks rather than dedupes. An app import then resolves to a different module instance than `basicSetup` is built against, and CodeMirror keys state off `Facet` identity — so `openSearchPanel` from one copy installs state the other's keymap never reads. `package.json` and `yarn.lock` are byte-identical to `main`. Recorded as friction with the fix (flatten the tree first).

**Navigation is by matching row, not by occurrence.** A one-character search has tens of thousands of occurrences but at most `rows.length` rows, so the list is bounded by construction — and landing on the row is what someone pasting an id wants.

**Matching runs against `formatCellValue`'s output, not the raw driver value**, so find agrees with the string on screen (ISO dates, stringified JSON, Postgres `bigint` as strings). Same rule is why searching `null` matches a null cell. Addressing is by column *position*, so a result with two identically named fields matches both columns — correct, since both display the same value. The grid's name-keying bug behind that is deliberately untouched.

**A truncated result says so on the counter** (`No matches in the first 10,000 rows`), not just in a tooltip. A bare "No matches" against the first 10,000 rows of a larger table would read as "this row does not exist".

**Find gets its own violet tokens** in both themes rather than reusing `--sel` (already means selection) or `--accent-soft` (too faint in light mode). The matching column's header needs a third value, since a colour that works as a block behind text is too light to be the text.

## Verification

Driven against a live 500-row Postgres result:

- `⌘F` **from CodeMirror focus** opened the bar and moved focus to it; CodeMirror's own panel did not open.
- `user-4` counted `1 of 111` (rows 4, 40–49, 400–499).
- `Enter` scrolled the grid to the match; only the inner container scrolled (`outerScrollTop: 0`).
- The filter showed rows `1, 10–19, 100–102…` with original numbers intact.
- Contrast measured in dark mode: matches `L 0.40` on `L 0.94` text, active match `L 0.56` on `L 0.16`.

`yarn typecheck`, `yarn format:check` and `yarn lint` are clean (one pre-existing `DatabaseExplorer.tsx` warning, untouched). 1470 tests pass, 32 new.

## Caveats

- **One test I could not write.** The sharpest guard on the filtered-row index translation would be "right-click a filtered row and copy it", but Radix menu items never fire `onSelect` under jsdom — confirmed on a plain grid with no search, so it is the menu and not this change. Covered by asserting the rendered row number instead, which holds because the render and both copy handlers read the same `row` binding. Recorded as friction.
- **A flake I could not attribute.** One full-suite run reported `1 failed | 1469 passed` and I lost the test name before reading it; four consecutive runs since are clean at 1470. That matches the existing friction entry about load-sensitive tests, but I am not claiming it definitely was not one of mine.
- `⌘⇧L` still does not toggle the theme from inside the editor. Dropping CodeMirror's binding is necessary but not sufficient — `ThemeProvider` registers it without `enableOnContentEditable`. A one-line fix, left out of scope.
- Nothing was added to `CLAUDE.md`; the `⌘F` ownership decision is commented at the code and the dependency hazard is in the friction log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)