### PR TITLE
feat(databases): pick the SSL certificate with a file dialog, and settle the connection form in its modal

### DIFF
--- a/.agents/friction-log/20260824185420-vitest-s-project/friction.md
+++ b/.agents/friction-log/20260824185420-vitest-s-project/friction.md
@@ -1,0 +1,53 @@
+---
+title:
+  "vitest's project split puts src/main.test.ts in the renderer project, so
+  --project backend cannot run it"
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Running a main-process test file names the project its environment implies:
+`src/main.test.ts` declares `// @vitest-environment node`, so
+`npx vitest run --project backend src/main.test.ts` runs it.
+
+## Current Behavior
+
+It answers `No test files found, exiting with code 1`. The projects in
+`vitest.config.ts` are split by path glob, not by environment, and
+`backendTestPatterns` names `scripts/**`, `src/build/**`, `src/glue/**` and
+`src/server/**`. `src/main.test.ts` and `src/main/**/*.test.ts` match none of
+them, so they fall into the `renderer` project's exclude-everything-else branch
+and run there — under `jsdom`, except that each file overrides the environment
+back to node with a pragma.
+
+So the main process, which is the least renderer-like code in the repo, is
+tested by the project called `renderer`, and the project called `backend` cannot
+see it. The failure mode is the misleading part: exit code 1 with
+`No test files found` reads as "your filter has a typo", not as "right file,
+wrong project", and the filter it prints back is correct.
+
+## Possible Solution
+
+Add `src/main.test.ts` and `src/main/**/*.test.ts` to `backendTestPatterns` and
+drop the `// @vitest-environment node` pragmas they carry, or name the projects
+after the glob they actually hold rather than after a process.
+
+## Minimal Reproducible Example
+
+```
+$ npx vitest run --project backend src/main.test.ts
+No test files found, exiting with code 1
+filter: src/main.test.ts
+projects: backend
+
+$ npx vitest run --project renderer src/main.test.ts
+Test Files  1 passed (1)
+```
+
+## Context
+
+Hit while adding cases to `src/main.test.ts` for a new `ipcMain.handle` channel.
+The first run looked like the new cases had broken the file's discovery, so the
+next move was to go and re-read what had just been written rather than to try
+the other project.

--- a/.agents/friction-log/20260824193851-a-popover-inside/friction.md
+++ b/.agents/friction-log/20260824193851-a-popover-inside/friction.md
@@ -1,0 +1,45 @@
+---
+title:
+  'A Popover inside the editor screen renders behind the card, because portaled
+  content keeps z-50 under a z-100 overlay'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Putting a `Popover` inside the editor screen's card shows the popover over the
+card, the way `Select` already does from the same place.
+
+## Current Behavior
+
+It renders _behind_ the card. `PopoverContent` in
+`src/app/components/ui/popover.tsx` carries `z-50` and portals to the body,
+while the editor screen's overlay is `z-100`
+(`src/app/components/EditorScreen.tsx`) — so the popover lands under it. What is
+visible is a sliver of the popover poking out past the card's left edge, which
+reads as a layout bug in the popover rather than a stacking one.
+
+`SelectContent` does not have the problem because it carries `z-[200]`
+(`src/app/components/ui/select.tsx:67`) — but nothing at that line says why, so
+the number looks arbitrary and the constraint it encodes is invisible until the
+next portaled surface hits it. `ContextMenuContent` and `TooltipContent` are
+both still `z-50`, so they will hit it too.
+
+## Possible Solution
+
+Comment the `z-[200]` in `select.tsx` with the overlay it has to clear, or raise
+all four portaled primitives to a shared token above `z-100` so the question
+does not come up per component.
+
+## Minimal Reproducible Example
+
+Render any `Popover` inside the `EditorScreen` card — for example the
+connection-string control in `src/app/components/DatabaseForm.tsx` — and open
+it. The content is in the DOM and has a non-zero bounding box, so an assertion
+on `popoverOpen` passes while nothing is readable on screen.
+
+## Context
+
+Hit while moving the "paste a connection string" control out of the field flow
+and into a popover. The test asserted the popover opened and passed; only a
+screenshot showed it was behind the modal.

--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -240,7 +240,9 @@ describe('DatabaseForm', () => {
 
       renderDatabaseForm()
 
-      await user.click(screen.getByRole('button', { name: /paste it/i }))
+      await user.click(
+        screen.getByRole('button', { name: 'Paste a connection string' })
+      )
       await user.type(
         screen.getByPlaceholderText(/postgresql:\/\//),
         'postgresql://alice:secret@db.example.com:6543/analytics'
@@ -252,6 +254,51 @@ describe('DatabaseForm', () => {
       expect(screen.getByLabelText('Database')).toHaveValue('analytics')
       expect(screen.getByLabelText('Username')).toHaveValue('alice')
       expect(screen.getByLabelText('Password')).toHaveValue('secret')
+    })
+
+    // The two halves of "does not interrupt the form": the trigger lives in
+    // the section header beside the type select, and the input it opens is
+    // outside the form entirely. Inline, the collapsed link sat between the
+    // separator and Name reading as a field of its own, and opening it pushed
+    // every field below it down.
+    it('keeps the trigger in the header and the input out of the form', async () => {
+      const user = userEvent.setup()
+
+      renderDatabaseForm()
+
+      const trigger = screen.getByRole('button', {
+        name: 'Paste a connection string'
+      })
+      const [typeSelect] = screen.getAllByRole('combobox')
+
+      // Same row as the type select, above the separator, not among the fields.
+      expect(trigger.closest('div')).toEqual(
+        typeSelect.closest('div[data-slot="form-item"]')?.parentElement
+      )
+
+      await user.click(trigger)
+
+      // Portaled, so no field can be displaced to make room for it.
+      expect(
+        screen.getByPlaceholderText(/postgresql:\/\//).closest('form')
+      ).toEqual(null)
+      expect(screen.getByLabelText('Name').closest('form')).not.toEqual(null)
+    })
+
+    // A file path has no connection string to paste.
+    it('offers no connection string for sqlite', async () => {
+      const user = userEvent.setup()
+
+      renderDatabaseForm()
+
+      const [typeSelect] = screen.getAllByRole('combobox')
+
+      await user.click(typeSelect)
+      await user.click(screen.getByRole('option', { name: 'SQLite' }))
+
+      expect(
+        screen.queryByRole('button', { name: 'Paste a connection string' })
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/src/app/components/DatabaseForm.test.tsx
+++ b/src/app/components/DatabaseForm.test.tsx
@@ -906,6 +906,64 @@ describe('DatabaseForm', () => {
       ).not.toBeInTheDocument()
     })
 
+    // The path is the field nobody remembers, so it is the one field in the
+    // form with a picker beside it. What matters here is that the picked path
+    // reaches the form state, not just the input's own value.
+    it('saves a certificate path picked from the file dialog', async () => {
+      const user = userEvent.setup()
+      const database: DatabaseDto = {
+        connectionInfo: {
+          database: 'testdb',
+          host: 'localhost',
+          port: 5432,
+          username: 'admin'
+        },
+        createdAt: Date.now(),
+        id: '123',
+        name: 'My Database',
+        sortOrder: null,
+        type: 'postgres'
+      }
+
+      vi.spyOn(window.electron, 'openFileDialog').mockResolvedValue(
+        '/etc/ssl/certs/pagila.pem'
+      )
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse({ database }, { status: 201 })
+      )
+
+      renderDatabaseForm()
+
+      await fillForm(user)
+      await user.click(screen.getByRole('button', { name: /advanced/i }))
+      await user.click(screen.getByRole('combobox', { name: /ssl mode/i }))
+      await user.click(screen.getByRole('option', { name: 'Verify Full' }))
+      await user.click(
+        screen.getByRole('button', { name: 'Browse for certificate file' })
+      )
+
+      expect(screen.getByLabelText('SSL Root Certificate')).toHaveValue(
+        '/etc/ssl/certs/pagila.pem'
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalled()
+      })
+
+      const body = (await capturedFetch()).body as {
+        connectionInfo: { sslRootCert: string }
+      }
+
+      expect(body.connectionInfo.sslRootCert).toEqual(
+        '/etc/ssl/certs/pagila.pem'
+      )
+      expect(vi.mocked(window.electron.openFileDialog).mock.calls).toEqual([
+        ['certificate']
+      ])
+    })
+
     it('includes ssl fields in the save payload', async () => {
       const user = userEvent.setup()
       const onSuccess = vi.fn()
@@ -948,6 +1006,36 @@ describe('DatabaseForm', () => {
       expect(body.connectionInfo.sslMode).toEqual('verify-full')
       expect(body.connectionInfo.sslRootCert).toEqual('system')
     })
+  })
+
+  // The SQLite path field's picker predates the certificate one and had no
+  // case of its own; both go through the same component now, so a break in one
+  // is a break in both.
+  it('fills the SQLite file path from the file dialog', async () => {
+    const user = userEvent.setup()
+
+    vi.spyOn(window.electron, 'openFileDialog').mockResolvedValue(
+      '/tmp/pagila.sqlite3'
+    )
+
+    renderDatabaseForm()
+
+    // The type select has no accessible name; it is the first combobox, and
+    // the SSL mode one below it is the second.
+    const [typeSelect] = screen.getAllByRole('combobox')
+
+    await user.click(typeSelect)
+    await user.click(screen.getByRole('option', { name: 'SQLite' }))
+    await user.click(
+      screen.getByRole('button', { name: 'Browse for database file' })
+    )
+
+    expect(screen.getByLabelText('File Path')).toHaveValue(
+      '/tmp/pagila.sqlite3'
+    )
+    expect(vi.mocked(window.electron.openFileDialog).mock.calls).toEqual([
+      ['sqliteDatabase']
+    ])
   })
 
   it('disables buttons while saving', async () => {

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -2,7 +2,6 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import {
   CheckCircle2Icon,
   ChevronRightIcon,
-  FolderOpenIcon,
   Loader2Icon,
   XCircleIcon
 } from 'lucide-react'
@@ -42,6 +41,7 @@ import {
 } from '../hooks/mutations'
 import { useSecretStorage } from '../hooks/queries'
 import { cn } from '../lib/utils'
+import { FilePathInput } from './FilePathInput'
 import { Button } from './ui/button'
 import {
   Form,
@@ -264,14 +264,6 @@ export function DatabaseForm({
     [form]
   )
 
-  const handleBrowseFile = useCallback(async () => {
-    const filePath = await window.electron.openFileDialog()
-
-    if (filePath) {
-      form.setValue('connectionInfo.path', filePath)
-    }
-  }, [form])
-
   const isLoading = isSaving || isTestingConnection
 
   return (
@@ -288,7 +280,6 @@ export function DatabaseForm({
         <ConnectionDetailsSection
           databaseType={databaseType}
           form={form}
-          onBrowseFile={handleBrowseFile}
           onSslModeApplied={() => setShowAdvanced(true)}
           onTypeChange={handleTypeChange}
         />
@@ -705,7 +696,6 @@ function ConnectionStringSection({
 interface ConnectionDetailsSectionProps {
   databaseType: DatabaseType
   form: DatabaseFormApi
-  onBrowseFile: () => void
   onSslModeApplied: () => void
   onTypeChange: (newType: string) => void
 }
@@ -713,7 +703,6 @@ interface ConnectionDetailsSectionProps {
 function ConnectionDetailsSection({
   databaseType,
   form,
-  onBrowseFile,
   onSslModeApplied,
   onTypeChange
 }: ConnectionDetailsSectionProps): ReactElement {
@@ -788,25 +777,14 @@ function ConnectionDetailsSection({
           render={({ field }) => (
             <FormItem>
               <FormLabel>File Path</FormLabel>
-              <div className="flex gap-2">
-                <FormControl>
-                  <Input
-                    className="flex-1"
-                    placeholder="/path/to/database.sqlite"
-                    type="text"
-                    {...field}
-                    value={field.value ?? ''}
-                  />
-                </FormControl>
-                <Button
-                  size="icon"
-                  type="button"
-                  variant="outline"
-                  onClick={onBrowseFile}
-                >
-                  <FolderOpenIcon className="h-4 w-4" />
-                </Button>
-              </div>
+              <FilePathInput
+                browseLabel="Browse for database file"
+                dialogKind="sqliteDatabase"
+                placeholder="/path/to/database.sqlite"
+                {...field}
+                value={field.value ?? ''}
+                onFileSelected={field.onChange}
+              />
               <FormMessage />
             </FormItem>
           )}
@@ -1002,14 +980,14 @@ function SslSection({ form }: { form: DatabaseFormApi }): ReactElement {
           render={({ field }) => (
             <FormItem>
               <FormLabel>SSL Root Certificate</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="system"
-                  type="text"
-                  {...field}
-                  value={field.value ?? ''}
-                />
-              </FormControl>
+              <FilePathInput
+                browseLabel="Browse for certificate file"
+                dialogKind="certificate"
+                placeholder="system"
+                {...field}
+                value={field.value ?? ''}
+                onFileSelected={field.onChange}
+              />
               <p className="text-xs text-muted-foreground">
                 Path to a CA certificate file, or <code>system</code> to use the
                 OS trust store.

--- a/src/app/components/DatabaseForm.tsx
+++ b/src/app/components/DatabaseForm.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import {
   CheckCircle2Icon,
   ChevronRightIcon,
+  ClipboardPasteIcon,
   Loader2Icon,
   XCircleIcon
 } from 'lucide-react'
@@ -52,6 +53,7 @@ import {
   FormMessage
 } from './ui/form'
 import { Input } from './ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import {
   Select,
   SelectContent,
@@ -81,6 +83,15 @@ export interface DatabaseFormProps {
   defaultValues?: Partial<FormInput>
   onCancel?: () => void
   onSuccess?: (result: DatabaseFormResult) => void
+
+  /**
+   * `dialog` scrolls the fields and pins the actions to a footer bar, for a
+   * host that caps the form's height. `page` lets the whole form flow, for the
+   * getting-started screen, where it sits on the background with no card
+   * around it and a link below it — a bleeding, tinted footer there would be a
+   * bar floating on the page, and there is no height to scroll within anyway.
+   */
+  variant?: 'dialog' | 'page'
 }
 
 function stringOrEmpty(value: unknown): string {
@@ -209,8 +220,10 @@ export function DatabaseForm({
   databaseId,
   defaultValues,
   onCancel,
-  onSuccess
+  onSuccess,
+  variant = 'page'
 }: DatabaseFormProps): ReactElement {
+  const isDialog = variant === 'dialog'
   const isEditMode = Boolean(databaseId)
   const defaultType = (defaultValues?.type as DatabaseType) ?? 'postgres'
 
@@ -266,49 +279,72 @@ export function DatabaseForm({
 
   const isLoading = isSaving || isTestingConnection
 
+  // `min-h-0` is what lets the scroller below actually scroll: a flex item's
+  // default `min-height: auto` refuses to shrink below its content, so without
+  // it the form grows to fit every field and pushes the buttons off the screen
+  // no matter what the card above caps itself at.
   return (
     <Form {...form}>
       <form
-        className="flex flex-col gap-8"
+        className={cn('flex flex-col', isDialog ? 'min-h-0 flex-1' : 'gap-8')}
         onSubmit={form.handleSubmit(handleSubmit)}
       >
-        <UnreadableConnectionNotice
-          defaultValues={defaultValues}
-          isEditMode={isEditMode}
-        />
-
-        <ConnectionDetailsSection
-          databaseType={databaseType}
-          form={form}
-          onSslModeApplied={() => setShowAdvanced(true)}
-          onTypeChange={handleTypeChange}
-        />
-
-        {databaseType !== 'sqlite' && (
-          <AuthenticationSection
-            form={form}
+        {/* Only the fields scroll. The actions stay put because Save is the
+            reason the screen is open, and a form long enough to need a
+            scrollbar is exactly the one where hunting for it costs the most —
+            an SSL connection with a certificate path is already past the
+            bottom of a laptop window. The negative margin pulls the scrollbar
+            out to the card's edge, past the padding it would otherwise sit
+            inside. */}
+        <div
+          className={cn(
+            'flex flex-col gap-8',
+            // `pb-4` because the footer bleeds over the card's bottom
+            // padding, so without it the last field's helper text sits on the
+            // bar's top border. It also leaves a little tail below the last
+            // field when the area does scroll.
+            isDialog && '-mr-6 min-h-0 flex-1 overflow-y-auto pr-6 pb-4'
+          )}
+        >
+          <UnreadableConnectionNotice
+            defaultValues={defaultValues}
             isEditMode={isEditMode}
           />
-        )}
 
-        {databaseType !== 'sqlite' &&
-          (showAdvanced ? (
-            <SslSection form={form} />
-          ) : (
-            <button
-              className="flex items-center gap-1 self-start text-xs text-text2 hover:text-text"
-              type="button"
-              onClick={() => setShowAdvanced(true)}
-            >
-              <ChevronRightIcon className="size-3" />
-              Advanced (SSL)
-            </button>
-          ))}
+          <ConnectionDetailsSection
+            databaseType={databaseType}
+            form={form}
+            onSslModeApplied={() => setShowAdvanced(true)}
+            onTypeChange={handleTypeChange}
+          />
+
+          {databaseType !== 'sqlite' && (
+            <AuthenticationSection
+              form={form}
+              isEditMode={isEditMode}
+            />
+          )}
+
+          {databaseType !== 'sqlite' &&
+            (showAdvanced ? (
+              <SslSection form={form} />
+            ) : (
+              <button
+                className="flex items-center gap-1 self-start text-xs text-text2 hover:text-text"
+                type="button"
+                onClick={() => setShowAdvanced(true)}
+              >
+                <ChevronRightIcon className="size-3" />
+                Advanced (SSL)
+              </button>
+            ))}
+        </div>
 
         <DatabaseFormActions
           connectionTestIcon={connectionTestIcon}
           isLoading={isLoading}
           isSaving={isSaving}
+          variant={variant}
           onCancel={onCancel}
           onTestConnection={handleTestConnection}
         />
@@ -594,15 +630,15 @@ function useConnectionTest({
   }
 }
 
-interface ConnectionStringSectionProps {
+interface ConnectionStringPopoverProps {
   form: DatabaseFormApi
   onSslModeApplied: () => void
 }
 
-function ConnectionStringSection({
+function ConnectionStringPopover({
   form,
   onSslModeApplied
-}: ConnectionStringSectionProps): ReactElement {
+}: ConnectionStringPopoverProps): ReactElement {
   const [connectionString, setConnectionString] = useState('')
   const [showConnectionString, setShowConnectionString] = useState(false)
 
@@ -647,49 +683,63 @@ function ConnectionStringSection({
     toast.success('Connection details filled in')
   }, [connectionString, form, onSslModeApplied])
 
-  if (!showConnectionString) {
-    return (
-      <button
-        className="self-start text-xs text-accent underline-offset-4 hover:underline"
-        type="button"
-        onClick={() => setShowConnectionString(true)}
-      >
-        Have a connection string? Paste it
-      </button>
-    )
-  }
-
   return (
-    <div className="flex flex-col gap-2">
-      <p className="text-xs text-text2">
-        Paste a connection string to fill in the fields below.
-      </p>
-
-      <div className="flex gap-2">
-        <Input
-          autoFocus
-          className="flex-1 font-mono text-xs"
-          placeholder="postgresql://user:password@host:5432/database"
-          value={connectionString}
-          onChange={(event) => setConnectionString(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault()
-              handleApplyConnectionString()
-            }
-          }}
-        />
-
+    <Popover
+      open={showConnectionString}
+      onOpenChange={setShowConnectionString}
+    >
+      <PopoverTrigger asChild>
         <Button
-          disabled={!connectionString.trim()}
-          size="sm"
+          aria-label="Paste a connection string"
+          size="icon"
+          title="Paste a connection string"
           type="button"
-          onClick={handleApplyConnectionString}
+          variant="ghost"
         >
-          Fill in
+          <ClipboardPasteIcon className="size-3.5" />
         </Button>
-      </div>
-    </div>
+      </PopoverTrigger>
+
+      {/* Wider than the default 20rem: a connection string is long, and a URL
+          the user cannot read back is one they cannot spot a typo in. Both
+          `w-` and `max-w-` because the base class caps the width at 20rem, so
+          widening one alone changes nothing.
+
+          `z-[200]` to clear the `z-100` editor-screen overlay, matching what
+          `SelectContent` already does for the same reason — a portaled surface
+          keeps the popover's default `z-50`, which lands it behind the card. */}
+      <PopoverContent className="z-[200] w-[min(26rem,calc(100vw-2rem))] max-w-[min(26rem,calc(100vw-2rem))]">
+        <div className="flex flex-col gap-2">
+          <p className="text-xs text-text2">
+            Paste a connection string to fill in the fields.
+          </p>
+
+          <div className="flex gap-2">
+            <Input
+              autoFocus
+              className="flex-1 font-mono text-xs"
+              placeholder="postgresql://user:password@host:5432/database"
+              value={connectionString}
+              onChange={(event) => setConnectionString(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  handleApplyConnectionString()
+                }
+              }}
+            />
+
+            <Button
+              disabled={!connectionString.trim()}
+              type="button"
+              onClick={handleApplyConnectionString}
+            >
+              Fill in
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }
 
@@ -712,6 +762,18 @@ function ConnectionDetailsSection({
         <FormSectionTitle text="Connection Details" />
 
         <FormSectionHeaderActions>
+          {/* Beside the type select rather than above the fields: it fills
+              those fields in, so it belongs to this section, and a control
+              that appears and disappears in the header costs the fields below
+              it nothing. As a link between the separator and Name it read as
+              an interruption, and expanding it pushed the whole form down. */}
+          {databaseType !== 'sqlite' && (
+            <ConnectionStringPopover
+              form={form}
+              onSslModeApplied={onSslModeApplied}
+            />
+          )}
+
           <FormField
             control={form.control}
             name="type"
@@ -740,16 +802,6 @@ function ConnectionDetailsSection({
       </FormSectionHeader>
 
       <Separator />
-
-      {/* Inside the section rather than above it: this fills in the fields
-          below, and on its own it read as a stray link floating in the gap
-          between sections. */}
-      {databaseType !== 'sqlite' && (
-        <ConnectionStringSection
-          form={form}
-          onSslModeApplied={onSslModeApplied}
-        />
-      )}
 
       <div className="flex items-start gap-4">
         <FormField
@@ -1005,6 +1057,7 @@ interface DatabaseFormActionsProps {
   connectionTestIcon: ReactNode
   isLoading: boolean
   isSaving: boolean
+  variant: 'dialog' | 'page'
   onCancel?: () => void
   onTestConnection: (event: React.FormEvent) => void
 }
@@ -1013,15 +1066,33 @@ function DatabaseFormActions({
   connectionTestIcon,
   isLoading,
   isSaving,
+  variant,
   onCancel,
   onTestConnection
 }: DatabaseFormActionsProps): ReactElement {
+  const isDialog = variant === 'dialog'
+
+  // In a dialog the bar carries its own ground and bleeds through the card's
+  // padding to its edges, so it reads as a piece of the window rather than the
+  // last row of the form — `panel2` is the same step down from `panel` the
+  // inputs use, so it recedes in both themes without naming a colour.
+  //
+  // `size="default"` rather than `sm`: it is the app's own button metric
+  // (29px, 12.5px text), which matches the fields above it, where `sm` stood a
+  // row of 32px buttons taller than anything else in the form.
   return (
-    <div className="flex justify-end gap-3 py-4">
+    <div
+      className={cn(
+        'flex justify-end',
+        isDialog
+          ? '-mx-6 -mb-6 gap-2 rounded-b-md border-t border-border2 bg-panel2 px-6 py-3'
+          : 'gap-3 py-4'
+      )}
+    >
       {onCancel && (
         <Button
           disabled={isLoading}
-          size="sm"
+          size={isDialog ? 'default' : 'sm'}
           type="button"
           variant="ghost"
           onClick={onCancel}
@@ -1032,7 +1103,7 @@ function DatabaseFormActions({
 
       <Button
         disabled={isLoading}
-        size="sm"
+        size={isDialog ? 'default' : 'sm'}
         type="button"
         variant="outline"
         onClick={onTestConnection}
@@ -1043,7 +1114,7 @@ function DatabaseFormActions({
 
       <Button
         disabled={isLoading}
-        size="sm"
+        size={isDialog ? 'default' : 'sm'}
         type="submit"
       >
         {isSaving && <Loader2Icon className="size-3 animate-spin" />}

--- a/src/app/components/EditorScreen.tsx
+++ b/src/app/components/EditorScreen.tsx
@@ -81,9 +81,15 @@ export function EditorScreen(props: EditorScreenProps): ReactElement {
   // because centering something taller than its scroller splits the overflow
   // across both edges, and `scrollTop` cannot go negative — the top of the form
   // is then unreachable on a short window.
+  //
+  // `max-h-full` caps the card at the slot minus the `py-6` above, and the
+  // form scrolls its own fields inside that. So the overlay's own
+  // `overflow-y-auto` is now a backstop rather than the mechanism — the card
+  // does not outgrow it, which is what keeps the title and the Save button on
+  // screen at every window height.
   return (
-    <div className="absolute inset-0 z-100 bg-bg/70 flex justify-center items-start overflow-y-auto py-10">
-      <div className="w-full max-w-md my-auto flex flex-col gap-6 rounded-md border border-border bg-panel p-6 shadow-[0_8px_24px_rgba(0,0,0,0.14)]">
+    <div className="absolute inset-0 z-100 bg-bg/70 flex justify-center items-start overflow-y-auto py-6">
+      <div className="w-full max-w-lg max-h-full my-auto flex flex-col gap-6 overflow-hidden rounded-md border border-border bg-panel p-6 shadow-[0_8px_24px_rgba(0,0,0,0.14)]">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">{title}</h1>
 
@@ -114,6 +120,7 @@ export function EditorScreen(props: EditorScreenProps): ReactElement {
           <DatabaseForm
             databaseId={databaseId}
             defaultValues={defaultValues}
+            variant="dialog"
             onCancel={handleClose}
             onSuccess={handleClose}
           />

--- a/src/app/components/FilePathInput.test.tsx
+++ b/src/app/components/FilePathInput.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+import { Toaster } from 'sonner'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FilePathInput } from './FilePathInput'
+import { Form, FormField, FormItem, FormLabel } from './ui/form'
+
+// `FilePathInput` renders `FormControl`, which reads the react-hook-form
+// context, so it cannot be rendered on its own. This is the smallest form that
+// gives it one — and it doubles as the assertion that the label reaches the
+// input, which is what every query below goes through.
+function FilePathInputHarness({
+  onFileSelected
+}: {
+  onFileSelected: (filePath: string) => void
+}) {
+  const form = useForm({ defaultValues: { certificate: '' } })
+
+  return (
+    <Form {...form}>
+      <FormField
+        control={form.control}
+        name="certificate"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>SSL Root Certificate</FormLabel>
+            <FilePathInput
+              browseLabel="Browse for certificate file"
+              dialogKind="certificate"
+              placeholder="system"
+              {...field}
+              onFileSelected={(filePath) => {
+                field.onChange(filePath)
+                onFileSelected(filePath)
+              }}
+            />
+          </FormItem>
+        )}
+      />
+    </Form>
+  )
+}
+
+function renderFilePathInput(onFileSelected = vi.fn()) {
+  render(
+    <>
+      <FilePathInputHarness onFileSelected={onFileSelected} />
+      <Toaster />
+    </>
+  )
+
+  return onFileSelected
+}
+
+describe('FilePathInput', () => {
+  beforeEach(() => {
+    // `vitest.setup.ts` gives every test a bridge whose picker cancels. The
+    // cases that pick a file replace it.
+    vi.spyOn(window.electron, 'openFileDialog').mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fills the field with the picked path', async () => {
+    const user = userEvent.setup()
+
+    vi.spyOn(window.electron, 'openFileDialog').mockResolvedValue(
+      '/etc/ssl/certs/pagila.pem'
+    )
+
+    const onFileSelected = renderFilePathInput()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Browse for certificate file' })
+    )
+
+    expect(screen.getByLabelText('SSL Root Certificate')).toHaveValue(
+      '/etc/ssl/certs/pagila.pem'
+    )
+    expect(onFileSelected.mock.calls).toEqual([['/etc/ssl/certs/pagila.pem']])
+  })
+
+  it('asks for the dialog its kind names', async () => {
+    const user = userEvent.setup()
+
+    renderFilePathInput()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Browse for certificate file' })
+    )
+
+    expect(vi.mocked(window.electron.openFileDialog).mock.calls).toEqual([
+      ['certificate']
+    ])
+  })
+
+  // Cancelling is an answer, not a failure: whatever was typed by hand has to
+  // survive it, or the picker becomes a way to lose a path.
+  it('leaves a typed path alone when the picker is cancelled', async () => {
+    const user = userEvent.setup()
+    const onFileSelected = renderFilePathInput()
+
+    const field = screen.getByLabelText('SSL Root Certificate')
+
+    await user.type(field, '/etc/ssl/certs/typed.pem')
+    await user.click(
+      screen.getByRole('button', { name: 'Browse for certificate file' })
+    )
+
+    expect(field).toHaveValue('/etc/ssl/certs/typed.pem')
+    expect(onFileSelected.mock.calls).toEqual([])
+  })
+
+  // The picker failing to open is the one case where the field is the only way
+  // through, so the toast has to say so rather than leaving a dead button.
+  it('says to type the path instead when the picker cannot open', async () => {
+    const user = userEvent.setup()
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    vi.spyOn(window.electron, 'openFileDialog').mockRejectedValue(
+      new Error(
+        'Invariant failed: A file dialog was requested with no window open.'
+      )
+    )
+
+    renderFilePathInput()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Browse for certificate file' })
+    )
+
+    expect(
+      await screen.findByText('Could not open the file picker')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Type the path into the field instead.')
+    ).toBeInTheDocument()
+    expect(consoleError.mock.calls.length).toEqual(1)
+  })
+})

--- a/src/app/components/FilePathInput.tsx
+++ b/src/app/components/FilePathInput.tsx
@@ -1,0 +1,77 @@
+import { type ComponentProps, type ReactElement, useCallback } from 'react'
+import { FolderOpenIcon } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { Button } from '@/app/components/ui/button'
+import { FormControl } from '@/app/components/ui/form'
+import { Input } from '@/app/components/ui/input'
+import type { FileDialogKind } from '@/glue/file-dialogs'
+
+interface FilePathInputProps extends ComponentProps<'input'> {
+  // The button carries only an icon, so without this it has no accessible name
+  // — unreachable by a screen reader and by `getByRole('button', { name })`.
+  browseLabel: string
+  dialogKind: FileDialogKind
+  onFileSelected: (filePath: string) => void
+}
+
+/**
+ * A path field with a native picker beside it.
+ *
+ * Typing stays the point — someone who already has the path should not have to
+ * go through a dialog for it — so the picker only ever fills the field in.
+ *
+ * `FormControl` is rendered here rather than by the caller because it is a
+ * Radix `Slot` and has to wrap exactly one child: the flex row holding the
+ * button has to sit outside it.
+ */
+export function FilePathInput({
+  browseLabel,
+  dialogKind,
+  onFileSelected,
+  ...inputProps
+}: FilePathInputProps): ReactElement {
+  const browse = useCallback(async () => {
+    try {
+      const filePath = await window.electron.openFileDialog(dialogKind)
+
+      // Null is the cancel: leave whatever is already typed alone.
+      if (filePath !== null) {
+        onFileSelected(filePath)
+      }
+    } catch (error) {
+      // The reason is never something the user can act on — it is an ipc or
+      // dialog failure — so the toast says what to do instead and the detail
+      // goes to the console, where the renderer's error tracing picks it up.
+      console.error('Open file dialog error:', error)
+
+      toast.error('Could not open the file picker', {
+        description: 'Type the path into the field instead.'
+      })
+    }
+  }, [dialogKind, onFileSelected])
+
+  return (
+    <div className="flex gap-2">
+      <FormControl>
+        <Input
+          className="flex-1"
+          type="text"
+          {...inputProps}
+        />
+      </FormControl>
+
+      <Button
+        aria-label={browseLabel}
+        size="icon"
+        type="button"
+        variant="outline"
+        onClick={() => {
+          void browse()
+        }}
+      >
+        <FolderOpenIcon className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/src/app/types/bootstrap.d.ts
+++ b/src/app/types/bootstrap.d.ts
@@ -1,8 +1,10 @@
+import type { FileDialogKind } from '@/glue/file-dialogs'
+
 declare global {
   interface Window {
     electron: {
       getApiToken: () => Promise<string>
-      openFileDialog: () => Promise<string | null>
+      openFileDialog: (kind: FileDialogKind) => Promise<string | null>
       windowClose: () => Promise<void>
       windowMaximize: () => Promise<void>
       windowMinimize: () => Promise<void>

--- a/src/glue/file-dialogs.ts
+++ b/src/glue/file-dialogs.ts
@@ -1,0 +1,33 @@
+// The catalogue of native file pickers the renderer can ask for. It names one
+// of these rather than passing dialog options across the bridge: an options
+// object the renderer controlled could ask for directories, hidden files or
+// `promptToCreate`, and nothing in the app wants any of those.
+//
+// Plain data, no `electron` import, so the main process and the renderer can
+// both read it.
+interface FileDialog {
+  filters: Array<{ extensions: string[]; name: string }>
+  title: string
+}
+
+export const fileDialogs = {
+  certificate: {
+    // The "All Files" escape hatch is not decoration: corporate CA bundles
+    // turn up as `ca-bundle`, as `.txt`, and with no extension at all.
+    filters: [
+      { extensions: ['pem', 'crt', 'cer', 'cert', 'ca'], name: 'Certificate' },
+      { extensions: ['*'], name: 'All Files' }
+    ],
+    title: 'Select CA Certificate'
+  },
+  sqliteDatabase: {
+    filters: [
+      { extensions: ['db', 'sqlite', 'sqlite3'], name: 'SQLite Database' }
+    ],
+    title: 'Select SQLite Database'
+  }
+  // Annotated through `satisfies` rather than a type annotation: the keys have
+  // to stay literal for `FileDialogKind` below to name them.
+} satisfies Record<string, FileDialog>
+
+export type FileDialogKind = keyof typeof fileDialogs

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -20,6 +20,13 @@ const electron = vi.hoisted(() => ({
   // app currently has, and the cases that matter are the ones where those two
   // differ — a dock click on an app whose last window is already closed.
   openWindows: [] as FakeWindow[],
+
+  // What `showOpenDialog` was handed and what it answers. Recorded rather than
+  // stubbed flat, because the options are the whole point of the file-dialog
+  // cases: which title and filters a kind resolves to, and that the dialog is
+  // parented to the window instead of floating free.
+  openDialogArguments: [] as unknown[][],
+  openDialogResult: { canceled: true, filePaths: [] as string[] },
   preventedQuits: 0,
   windows: 0
 }))
@@ -86,7 +93,11 @@ vi.mock('electron', () => ({
     showErrorBox: () => {
       electron.errorBoxes += 1
     },
-    showOpenDialog: () => Promise.resolve({ canceled: true, filePaths: [] })
+    showOpenDialog: (...args: unknown[]) => {
+      electron.openDialogArguments.push(args)
+
+      return Promise.resolve(electron.openDialogResult)
+    }
   },
   ipcMain: {
     handle: (channel: string, handler: (...args: never[]) => unknown) => {
@@ -221,6 +232,8 @@ beforeEach(() => {
   electron.hasSingleInstanceLock = true
   electron.ipcHandlers.clear()
   electron.listeners.clear()
+  electron.openDialogArguments = []
+  electron.openDialogResult = { canceled: true, filePaths: [] }
   electron.openWindows = []
   electron.preventedQuits = 0
   electron.windows = 0
@@ -526,6 +539,109 @@ describe('the app lifecycle', () => {
 // minimize wired to close is a data-losing bug that every test over there still
 // passes. The handlers are registered while the module body runs, so importing
 // `main.ts` is all these need; none of them waits for `ready`.
+// One channel serves both pickers, and the renderer names an intent rather
+// than passing dialog options across the bridge: an options object it
+// controlled could ask for directories or hidden files. So what needs holding
+// is that the intent it names is what decides the title and the filters — a
+// certificate picker cannot end up offering `.sqlite` files.
+describe('the file dialog', () => {
+  // One channel serves both pickers, and the renderer names an intent rather
+  // than passing dialog options: what these cases hold is that the intent it
+  // names is what decides the title and the filters, so a certificate picker
+  // cannot end up offering `.sqlite` files.
+  it('offers certificate filters when the renderer asks for a certificate', async () => {
+    const browserWindow = openWindow()
+
+    await importMain()
+
+    await ipc('open-file-dialog')(undefined, 'certificate')
+
+    expect(electron.openDialogArguments).toEqual([
+      [
+        browserWindow,
+        {
+          filters: [
+            {
+              extensions: ['pem', 'crt', 'cer', 'cert', 'ca'],
+              name: 'Certificate'
+            },
+            { extensions: ['*'], name: 'All Files' }
+          ],
+          properties: ['openFile'],
+          title: 'Select CA Certificate'
+        }
+      ]
+    ])
+  })
+
+  it('offers database filters when the renderer asks for a SQLite database', async () => {
+    const browserWindow = openWindow()
+
+    await importMain()
+
+    await ipc('open-file-dialog')(undefined, 'sqliteDatabase')
+
+    expect(electron.openDialogArguments).toEqual([
+      [
+        browserWindow,
+        {
+          filters: [
+            {
+              extensions: ['db', 'sqlite', 'sqlite3'],
+              name: 'SQLite Database'
+            }
+          ],
+          properties: ['openFile'],
+          title: 'Select SQLite Database'
+        }
+      ]
+    ])
+  })
+
+  it('answers the chosen path', async () => {
+    openWindow()
+
+    electron.openDialogResult = {
+      canceled: false,
+      filePaths: ['/etc/ssl/certs/pagila.pem']
+    }
+
+    await importMain()
+
+    expect(await ipc('open-file-dialog')(undefined, 'certificate')).toEqual(
+      '/etc/ssl/certs/pagila.pem'
+    )
+  })
+
+  // Null rather than an error or an empty string: cancelling is an answer, and
+  // the field the renderer would fill keeps whatever was already typed in it.
+  it('answers null when the file dialog is cancelled', async () => {
+    openWindow()
+
+    await importMain()
+
+    expect(await ipc('open-file-dialog')(undefined, 'certificate')).toEqual(
+      null
+    )
+  })
+
+  // A kind the catalogue does not have can only come from a renderer bug, and
+  // the guard has to be `Object.hasOwn` rather than a truthiness check on the
+  // lookup: indexing a plain object with 'constructor' answers a function, so a
+  // truthiness check would spread one into the dialog options.
+  it('opens no dialog for a file dialog kind it does not have', async () => {
+    openWindow()
+
+    await importMain()
+
+    await expect(
+      ipc('open-file-dialog')(undefined, 'constructor')
+    ).rejects.toThrow(/constructor/)
+
+    expect(electron.openDialogArguments).toEqual([])
+  })
+})
+
 describe('the title bar and the dock', () => {
   it('closes the window from the title bar', async () => {
     const browserWindow = openWindow()

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,10 @@ import { randomBytes } from 'node:crypto'
 import { writeFileSync } from 'node:fs'
 import path from 'node:path'
 import started from 'electron-squirrel-startup'
+import invariant from 'tiny-invariant'
 import { log } from 'tiny-typescript-logger'
 
+import { fileDialogs, type FileDialogKind } from './glue/file-dialogs'
 import {
   closeMainWindow,
   focusMainWindow,
@@ -35,13 +37,30 @@ ipcMain.handle('window-close', () => {
   closeMainWindow()
 })
 
-ipcMain.handle('open-file-dialog', async () => {
-  const result = await dialog.showOpenDialog({
-    filters: [
-      { extensions: ['db', 'sqlite', 'sqlite3'], name: 'SQLite Database' }
-    ],
+ipcMain.handle('open-file-dialog', async (_event, kind: unknown) => {
+  // `Object.hasOwn` before indexing, not a truthiness check on the result: a
+  // plain object literal indexed by an untrusted string answers for prototype
+  // keys too, so `'constructor'` would sail past `if (!fileDialog)` and get
+  // spread into the options.
+  invariant(
+    typeof kind === 'string' && Object.hasOwn(fileDialogs, kind),
+    `Unknown file dialog kind: ${String(kind)}.`
+  )
+
+  const fileDialog = fileDialogs[kind as FileDialogKind]
+
+  // The only thing that opens a picker is a button inside the window, so no
+  // window means something is wrong rather than something to work around. It
+  // is passed so the dialog is a sheet on the frameless window instead of a
+  // panel floating off on its own.
+  const parentWindow = getMainWindow()
+
+  invariant(parentWindow, 'A file dialog was requested with no window open.')
+
+  const result = await dialog.showOpenDialog(parentWindow, {
+    filters: fileDialog.filters,
     properties: ['openFile'],
-    title: 'Select SQLite Database'
+    title: fileDialog.title
   })
 
   if (result.canceled || result.filePaths.length === 0) {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,8 +1,14 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
+// Type-only, so it is erased and the preload bundle still imports nothing but
+// `electron` — which matters because it runs with `sandbox: true`. Relative
+// rather than `@/`: the preload build has no path alias.
+import type { FileDialogKind } from './glue/file-dialogs'
+
 contextBridge.exposeInMainWorld('electron', {
   getApiToken: () => ipcRenderer.invoke('get-api-token'),
-  openFileDialog: () => ipcRenderer.invoke('open-file-dialog'),
+  openFileDialog: (kind: FileDialogKind) =>
+    ipcRenderer.invoke('open-file-dialog', kind),
   windowClose: () => ipcRenderer.invoke('window-close'),
   windowMaximize: () => ipcRenderer.invoke('window-maximize'),
   windowMinimize: () => ipcRenderer.invoke('window-minimize')


### PR DESCRIPTION
The SSL Root Certificate field was a bare text input. The path to a CA bundle
had to be typed from memory, and a typo did not surface until connect time,
from the backend, as `Could not read CA certificate at …: the file does not
exist.`

Adding a picker made the SSL section taller, which is what exposed the second
half of this PR: the Edit database modal grew with its content until Save ran
off the bottom of the window.

## The file picker

The app already had one — the SQLite **File Path** field has had a folder
button since it was written. What it lacked was a second caller:
`open-file-dialog` took no arguments and hardcoded the SQLite title and
filters.

The renderer now names an intent (`certificate`, `sqliteDatabase`) and the main
process owns the title and filters for each. It is deliberately not handed a
dialog options object: one it controlled could ask for directories, hidden
files, or `promptToCreate`. The kind is checked with `Object.hasOwn` before the
catalogue is indexed — a plain object indexed by an untrusted string answers
for prototype keys, so `'constructor'` would sail past a truthiness check and
get spread into the options.

Both fields go through one `FilePathInput`, which closes three things the
SQLite button had wrong:

- no `aria-label`, so nothing could reach it and it had **no test at all**
- a floating promise behind a prop typed `() => void`, so a rejected dialog
  became an unhandled rejection visible only as a `renderer.error` trace
- an unparented dialog, which on macOS opens a detached panel rather than a
  sheet on the frameless window

## The modal

The card caps at `max-h-full` and the form scrolls its own fields, so the title
and the actions stay on screen at every window height. `min-h-0` on both flex
items is load-bearing: a flex item's default `min-height: auto` refuses to
shrink below its content, so without it the form grows to fit every field no
matter what the card caps at.

| | before | after |
| --- | --- | --- |
| Card width | 448px | 512px |
| Footer height | 113px | 54px |
| Buttons | 32px (`sm`) | 29px (`default`, the app's own metric) |
| Save at 880px window | off screen | pinned, visible |

The actions are a bar now rather than the form's last row wedged against a
cut-off field — bleeding through the card's padding to its edges, on `panel2`,
the step down from `panel` the inputs already use, so it recedes in both themes
without naming a colour.

"Have a connection string? Paste it" sat between the separator and Name,
reading as a field of its own, and expanding it pushed the whole form down. It
is a popover on a header action beside the type select now: it fills those
fields, so it belongs to that section, and being portaled it displaces nothing
whether open or closed.

`DatabaseForm` is still rendered bare on the getting-started screen, with no
card and a link below it — a bleeding tinted bar there would be a footer
floating on the page, and there is no height to scroll within. Hence the
`variant` prop: `dialog` opts into scroll-and-pin, `page` keeps what that
screen had.

