### PR TITLE
perf(startup): open the window before the backend boots

### DIFF
--- a/.agents/friction-log/20260830125059-the-logger-mock/friction.md
+++ b/.agents/friction-log/20260830125059-the-logger-mock/friction.md
@@ -1,0 +1,61 @@
+---
+title:
+  'The logger mock in src/main.test.ts omits log.info, so adding one log line
+  fails 12 unrelated cases'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Adding a `log.info(...)` call to `src/main.ts` should not break tests that have
+nothing to do with logging.
+
+## Current Behavior
+
+`src/main.test.ts` mocks `tiny-typescript-logger` with an object literal
+carrying only the methods `main.ts` happened to call at the time:
+
+```ts
+const logger = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn()
+}))
+
+vi.mock('tiny-typescript-logger', () => ({ log: logger }))
+```
+
+The first `log.info` in `main.ts` therefore failed 12 of the file's cases at
+once with `TypeError: log.info is not a function` — including every window,
+quit, dispose and dock-click case, none of which log anything. The message names
+the logger, but the stack points into `main.ts`, so it reads as a fault in the
+code under test rather than a gap in its mock.
+
+## Possible Solution
+
+Give the mock the whole logger surface rather than the subset currently in use,
+so adding a log line is not a test change:
+
+```ts
+const logger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn()
+}))
+```
+
+The same shape appears in other suites that mock this logger, so it is worth
+doing wherever the partial literal is repeated.
+
+## Minimal Reproducible Example
+
+1. Add `log.info('anything')` anywhere in `src/main.ts`.
+2. `yarn test src/main.test.ts`.
+3. 12 cases fail with `TypeError: log.info is not a function`.
+
+## Context
+
+Hit while adding one line of boot timing to `main.ts` to measure startup. The
+line was correct and the failures were unrelated to it, so the first read was
+that the timing change had broken the lifecycle — the actual fix was three words
+in the mock.

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm'
 import {
   index,
   integer,
@@ -42,7 +43,15 @@ export const queriesTable = sqliteTable(
     index('queries_worksheet_id_queried_at_index').on(
       table.worksheetId,
       table.queriedAt
-    )
+    ),
+    // Partial on purpose. Boot reconciliation asks for exactly the rows this
+    // covers — the ones left unfinished by the previous process — and it asks
+    // before the window can paint, so it was a full scan of a table whose rows
+    // each carry a whole query result. In steady state the index holds nothing
+    // at all, since a finished query leaves it.
+    index('queries_unfinished_index')
+      .on(table.finishedAt)
+      .where(sql`finishedAt IS NULL`)
   ]
 )
 

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -39,6 +39,15 @@ const statements: SQL[] = [
     ON queries (worksheetId, queriedAt)
   `,
 
+  // Partial on purpose — see the matching declaration in `schema.ts`. Boot
+  // reconciliation wants exactly the rows left unfinished by the previous
+  // process, and it runs before the window can paint.
+  sql`
+    CREATE INDEX IF NOT EXISTS queries_unfinished_index
+    ON queries (finishedAt)
+    WHERE finishedAt IS NULL
+  `,
+
   sql`
     CREATE TABLE IF NOT EXISTS settings (
       id TEXT PRIMARY KEY NOT NULL,

--- a/src/databases/create-adapter.ts
+++ b/src/databases/create-adapter.ts
@@ -1,21 +1,42 @@
 import type { DatabaseAdapter } from './adapter'
-import { MysqlAdapter } from './mysql-adapter'
-import { PostgresAdapter } from './postgres-adapter'
 import type { DatabaseConnection } from './schemas'
-import { SqliteAdapter } from './sqlite-adapter'
 
-// Takes the type and its connection info as one discriminated value rather than
-// two independent arguments, so `switch` narrows the shape and no cast is
-// needed: a SQLite connection can only arrive carrying a SQLite path.
-export function createAdapter(connection: DatabaseConnection): DatabaseAdapter {
+// Each driver is loaded when a connection of its kind is first made, rather
+// than when this module is evaluated. That evaluation happens in the main
+// process's import graph, before Electron's `ready` and so before any window
+// exists: `pg`, `pg-cursor` and `mysql2` together are around 90ms of `require`
+// that every launch paid for, whatever kinds of database the user actually had.
+//
+// A dynamic import is enough to defer it because all four packages are Vite
+// externals (see `src/build/native-packages.ts`) — the import stays a real
+// runtime resolution instead of being folded back into the bundle.
+//
+// It also narrows a failure that module-level imports widened, which is the
+// case `native-packages.ts` warns about: a package missing from a packaged
+// build now breaks connections of its own type, not every type.
+export async function createAdapter(
+  connection: DatabaseConnection
+): Promise<DatabaseAdapter> {
+  // Takes the type and its connection info as one discriminated value rather
+  // than two independent arguments, so `switch` narrows the shape and no cast
+  // is needed: a SQLite connection can only arrive carrying a SQLite path.
   switch (connection.type) {
-    case 'mysql':
+    case 'mysql': {
+      const { MysqlAdapter } = await import('./mysql-adapter')
+
       return new MysqlAdapter(connection.connectionInfo)
-    case 'postgres':
+    }
+    case 'postgres': {
+      const { PostgresAdapter } = await import('./postgres-adapter')
+
       return new PostgresAdapter(connection.connectionInfo)
-    case 'sqlite':
+    }
+    case 'sqlite': {
+      const { SqliteAdapter } = await import('./sqlite-adapter')
+
       return new SqliteAdapter(connection.connectionInfo)
-    default:
+    }
+    default: {
       // Unreachable for validated input. It still guards a stored row whose
       // `type` column holds something this build does not know about.
       throw new Error(
@@ -23,5 +44,6 @@ export function createAdapter(connection: DatabaseConnection): DatabaseAdapter {
           (connection as { type: unknown }).type
         )}`
       )
+    }
   }
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,6 @@
-import { Exit } from 'effect'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BootOutcome } from './main/backend'
 
 // `src/main.ts` is a script, not a module: importing it registers every ipc
 // handler and every `app` event listener as a side effect, and there is no
@@ -9,6 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // module-level lifecycle values.
 const electron = vi.hoisted(() => ({
   applicationMenus: 0,
+
+  // What `nativeTheme.shouldUseDarkColors` answers, which is how the window
+  // picks the background it paints before the renderer has rendered anything.
+  darkMode: false,
   errorBoxes: 0,
   exits: [] as number[],
   hasSingleInstanceLock: true,
@@ -28,6 +33,11 @@ const electron = vi.hoisted(() => ({
   openDialogArguments: [] as unknown[][],
   openDialogResult: { canceled: true, filePaths: [] as string[] },
   preventedQuits: 0,
+
+  // The options each `BrowserWindow` was built with, so the loading background
+  // can be asserted on. The window is shown before anything has painted in it
+  // now, so that colour is what the user actually sees first.
+  windowOptions: [] as Array<Record<string, unknown>>,
   windows: 0
 }))
 
@@ -37,14 +47,23 @@ const electron = vi.hoisted(() => ({
 // therefore stubs the case drives directly, so that "the backend is still
 // booting" and "shutdown is wedged" become states a test can hold open.
 const backend = vi.hoisted(() => ({
-  boot: undefined as (() => Promise<unknown>) | undefined,
+  boot: undefined as (() => Promise<BootOutcome>) | undefined,
   dispose: undefined as (() => Promise<void>) | undefined,
   disposeCalls: 0,
   runtimes: 0
 }))
 
+// The whole `Logger` surface, not the subset `main.ts` happens to call today.
+// A partial literal here turns the next added log line into a dozen failures in
+// cases that log nothing, reported against `main.ts` rather than against this
+// mock — see `.agents/friction-log/20260830125059-the-logger-mock`.
 const logger = vi.hoisted(() => ({
+  debug: vi.fn(),
   error: vi.fn(),
+  fatal: vi.fn(),
+  info: vi.fn(),
+  log: vi.fn(),
+  trace: vi.fn(),
   warn: vi.fn()
 }))
 
@@ -77,8 +96,9 @@ vi.mock('electron', () => ({
       setWindowOpenHandler: () => undefined
     }
 
-    constructor() {
+    constructor(options: Record<string, unknown>) {
       electron.windows += 1
+      electron.windowOptions.push(options)
     }
 
     loadFile() {
@@ -113,6 +133,11 @@ vi.mock('electron', () => ({
       electron.applicationMenus += 1
     }
   },
+  nativeTheme: {
+    get shouldUseDarkColors() {
+      return electron.darkMode
+    }
+  },
   shell: { openExternal: () => Promise.resolve() }
 }))
 
@@ -130,17 +155,21 @@ vi.mock('node:fs', async (importOriginal) => ({
 
 vi.mock('tiny-typescript-logger', () => ({ log: logger }))
 
-vi.mock('./server/runtime', () => ({
-  makeMainRuntime: () => {
+// `./main/backend` rather than `./server/runtime`: the boot path reaches the
+// backend through a dynamic import of that module, so that is the seam. It is
+// also where Effect stops — the outcomes below are plain values, which is the
+// whole point of the module existing.
+vi.mock('./main/backend', () => ({
+  makeBackend: () => {
     backend.runtimes += 1
 
     return {
+      boot: () => backend.boot?.() ?? Promise.resolve({ status: 'ready' }),
       dispose: () => {
         backend.disposeCalls += 1
 
         return backend.dispose?.() ?? Promise.resolve()
-      },
-      runPromiseExit: () => backend.boot?.() ?? Promise.resolve(Exit.void)
+      }
     }
   }
 }))
@@ -237,6 +266,7 @@ function quitEvent(): { preventDefault: () => void } {
 
 beforeEach(() => {
   electron.applicationMenus = 0
+  electron.darkMode = false
   electron.errorBoxes = 0
   electron.exits = []
   electron.hasSingleInstanceLock = true
@@ -246,15 +276,17 @@ beforeEach(() => {
   electron.openDialogResult = { canceled: true, filePaths: [] }
   electron.openWindows = []
   electron.preventedQuits = 0
+  electron.windowOptions = []
   electron.windows = 0
 
-  backend.boot = () => Promise.resolve(Exit.void)
+  backend.boot = () => Promise.resolve({ status: 'ready' })
   backend.dispose = () => Promise.resolve()
   backend.disposeCalls = 0
   backend.runtimes = 0
 
-  logger.error.mockClear()
-  logger.warn.mockClear()
+  for (const level of Object.values(logger)) {
+    level.mockClear()
+  }
 
   vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined)
   vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
@@ -277,27 +309,166 @@ describe('the app lifecycle', () => {
     expect(electron.windows).toEqual(1)
   })
 
-  // The window is the case above, so it is not that windows are never made; it
-  // is that this one would be made over a backend already mid-`dispose()` and a
-  // few seconds from `app.exit(0)` — a window whose every request 500s or
-  // vanishes, for the moment it survives.
-  //
-  // The quit lands in the gap between the boot promise resolving and the
-  // continuation that reads it, which is why the boot here is held open across
-  // the quit rather than resolved before it.
-  it('opens no window when a quit arrives while the backend is still booting', async () => {
+  // The change this file's window cases are all about: the window used to be
+  // built after the backend was up, so everything the layer graph does — open
+  // SQLite, run the DDL, reconcile the previous process's queries, bind the
+  // port — happened with nothing at all on screen. Holding the boot open and
+  // asserting *without* awaiting it is what pins the ordering down; awaiting
+  // first would pass either way.
+  it('opens the window before the backend has finished booting', async () => {
+    backend.boot = () => new Promise(() => undefined)
+
+    await importMain()
+
+    void fire('ready')
+
+    expect(electron.windows).toEqual(1)
+  })
+
+  // The gap the `starting` state exists for: the window is up and the backend
+  // module has not finished importing, so there is nothing acquired to dispose
+  // and no reason to hold the quit — but the ready handler is still going to
+  // wake up on the other side of that import, and it must not go on to open the
+  // database and bind the port for an app that is already leaving.
+  it('boots no backend when a quit arrives while the backend module is loading', async () => {
+    await importMain()
+
+    const ready = fire('ready')
+
+    // Deliberately not flushed first: this is the one case that wants the quit
+    // to land before the import resolves.
+    fire('before-quit', quitEvent())
+
+    await ready
+    await flush()
+
+    expect({
+      disposals: backend.disposeCalls,
+      prevented: electron.preventedQuits,
+      runtimes: backend.runtimes
+    }).toEqual({ disposals: 0, prevented: 0, runtimes: 0 })
+  })
+
+  // What makes opening the window early safe. The renderer awaits its token
+  // inside the request transform, before any fetch leaves, so a token withheld
+  // is a request not yet sent — which is the difference between a spinner and
+  // the client spending three retries and its backoff on an unbound port.
+  it('withholds the session token until the backend is listening', async () => {
     let finishBoot = (): void => undefined
 
     backend.boot = () =>
       new Promise((resolve) => {
         finishBoot = () => {
-          resolve(Exit.void)
+          resolve({ status: 'ready' })
         }
       })
 
     await importMain()
 
     const ready = fire('ready')
+    const token = ipc('get-api-token')() as Promise<string>
+
+    // Raced rather than asserted directly: a pending promise has no state to
+    // read, so the sentinel winning is the evidence that it is still pending.
+    expect(
+      await Promise.race([token, flush().then(() => 'still waiting')])
+    ).toEqual('still waiting')
+
+    finishBoot()
+
+    await ready
+
+    expect(await token).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  // The gate is released on the failure path too, and that is deliberate: the
+  // renderer is up and asking by the time a boot fails, so leaving it pending
+  // would hold it on the spinner behind the error dialog. Released, the request
+  // goes out, finds nothing listening, and says so the way it always has.
+  it('releases the session token when the boot fails', async () => {
+    backend.boot = () =>
+      Promise.resolve({ error: new Error('port in use'), status: 'failed' })
+
+    await importMain()
+
+    await fire('ready')
+
+    expect(await (ipc('get-api-token')() as Promise<string>)).toMatch(
+      /^[0-9a-f]{64}$/
+    )
+  })
+
+  // A dock click between the window opening and the backend coming up finds an
+  // app that is genuinely on its way in. Refusing it — which `!== 'running'`
+  // did — left a macOS user who closed the loading window with no way back
+  // until the boot finished, and the boot path no longer opens one at the end.
+  it('reopens a window closed while the backend is still booting', async () => {
+    backend.boot = () => new Promise(() => undefined)
+
+    await importMain()
+
+    void fire('ready')
+
+    fire('activate')
+
+    expect(electron.windows).toEqual(2)
+  })
+
+  // The window is on screen before the renderer has painted into it, so the
+  // colour it is built with is what the user actually sees first. Unset, that
+  // is white — a full-window flash on the theme where it is most obvious.
+  it('builds the window in the dark loading colour when the OS is dark', async () => {
+    electron.darkMode = true
+
+    await importMain()
+
+    await fire('ready')
+
+    expect(electron.windowOptions[0]?.backgroundColor).toEqual('#181c24')
+  })
+
+  it('builds the window in the light loading colour when the OS is light', async () => {
+    electron.darkMode = false
+
+    await importMain()
+
+    await fire('ready')
+
+    expect(electron.windowOptions[0]?.backgroundColor).toEqual('#f6f7f9')
+  })
+
+  // The window used to be withheld here, because the boot path only opened one
+  // after the backend was up: a quit landing mid-boot meant the window was
+  // never made. It is made first now, so the same guarantee — that no window is
+  // left over a backend already mid-`dispose()` and a few seconds from
+  // `app.exit(0)` — has to be kept by closing it instead.
+  //
+  // The quit lands in the gap between the boot promise resolving and the
+  // continuation that reads it, which is why the boot here is held open across
+  // the quit rather than resolved before it.
+  it('closes the window when a quit arrives while the backend is still booting', async () => {
+    let finishBoot = (): void => undefined
+
+    backend.boot = () =>
+      new Promise((resolve) => {
+        finishBoot = () => {
+          resolve({ status: 'ready' })
+        }
+      })
+
+    await importMain()
+
+    const ready = fire('ready')
+
+    // Lets the dynamic import of `./main/backend` resolve, so the quit below
+    // lands while the backend is booting rather than while its module is still
+    // loading. Those are different branches, and the other one has its own case.
+    await flush()
+
+    // Stands in for the window the boot path just built. The fake constructor
+    // deliberately does not add to `openWindows` — that list is what the app
+    // currently has — so `shutDown` needs one put there to find.
+    const window = openWindow()
 
     fire('before-quit', quitEvent())
     finishBoot()
@@ -306,10 +477,10 @@ describe('the app lifecycle', () => {
     await flush()
 
     expect({
+      closes: window.close.mock.calls.length,
       disposals: backend.disposeCalls,
-      exits: electron.exits,
-      windows: electron.windows
-    }).toEqual({ disposals: 1, exits: [0], windows: 0 })
+      exits: electron.exits
+    }).toEqual({ closes: 1, disposals: 1, exits: [0] })
   })
 
   // Both halves matter and they pull in opposite directions. Disposing twice
@@ -407,10 +578,12 @@ describe('the app lifecycle', () => {
   })
 
   // The other half of the same branch, and the reason it cannot simply be
-  // silenced: a backend that genuinely failed to start leaves an app with no
-  // window and no explanation, so this one says so and goes.
+  // silenced: a backend that genuinely failed to start leaves an app with a
+  // window that will never load anything, so this one says so and goes. The
+  // window is built either way now — `app.exit(1)` is what takes it away.
   it('reports a boot failure that is not a shutdown, and exits nonzero', async () => {
-    backend.boot = () => Promise.resolve(Exit.fail(new Error('port in use')))
+    backend.boot = () =>
+      Promise.resolve({ error: new Error('port in use'), status: 'failed' })
 
     await importMain()
 
@@ -420,7 +593,7 @@ describe('the app lifecycle', () => {
       dialogs: electron.errorBoxes,
       exits: electron.exits,
       windows: electron.windows
-    }).toEqual({ dialogs: 1, exits: [1], windows: 0 })
+    }).toEqual({ dialogs: 1, exits: [1], windows: 1 })
   })
 
   // A quit while the layer is still building interrupts the build, so the boot
@@ -433,13 +606,17 @@ describe('the app lifecycle', () => {
     backend.boot = () =>
       new Promise((resolve) => {
         failBoot = () => {
-          resolve(Exit.fail(new Error('interrupted')))
+          resolve({ status: 'interrupted' })
         }
       })
 
     await importMain()
 
     const ready = fire('ready')
+
+    // As above: past the backend module's import, so the quit interrupts the
+    // layer build rather than the load.
+    await flush()
 
     fire('before-quit', quitEvent())
     failBoot()

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -292,9 +292,21 @@ beforeEach(() => {
   vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window')
 })
 
-afterEach(() => {
-  vi.unstubAllGlobals()
+afterEach(async () => {
+  // Before the tick below, which is a real `setTimeout`.
   vi.useRealTimers()
+
+  // The ready handler spans an await now — the dynamic import of
+  // `./main/backend` — so a case that holds the boot open and asserts without
+  // awaiting it is still inside that handler when the case ends. Unstubbing
+  // first pulls `MAIN_WINDOW_VITE_DEV_SERVER_URL` out from under
+  // `corsAllowedOrigins()`, which the handler reads on the far side of that
+  // import: it rejects with a ReferenceError belonging to no test, and vitest
+  // fails the run on an unhandled error while reporting every case as passing.
+  // One tick is all it takes to get the handler as far as the boot it parks on.
+  await flush()
+
+  vi.unstubAllGlobals()
 })
 
 // The four things `main.ts` decides — open a window, hold a quit, dispose the

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,11 @@
-import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
-import { Cause, Effect, Exit } from 'effect'
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  nativeTheme,
+  shell
+} from 'electron'
 import { randomBytes } from 'node:crypto'
 import { writeFileSync } from 'node:fs'
 import path from 'node:path'
@@ -16,15 +22,48 @@ import {
   minimizeMainWindow,
   toggleMainWindowMaximized
 } from './main/window'
-import { makeMainRuntime, type MainRuntime } from './server/runtime'
+// Type-only, so it is erased and the backend module stays out of this file's
+// runtime import graph -- which is the entire point of `./main/backend`.
+import type { Backend } from './main/backend'
 
 if (!app.isPackaged) {
   app.commandLine.appendSwitch('remote-debugging-port', '9222')
 }
 
+// Milliseconds since the process started, which `performance.now()` measures
+// from `timeOrigin` — not from when this line runs. That distinction is the
+// reason it is used instead of a mark taken here: evaluating this file's import
+// graph pulls in the whole backend, and a mark taken after the imports would be
+// blind to the largest thing it needs to report on.
+function millisecondsSinceStart(): number {
+  return performance.now()
+}
+
 let apiToken = ''
 
-ipcMain.handle('get-api-token', () => apiToken)
+// Resolved once the backend has finished booting — successfully or not. Every
+// renderer request awaits the token before its fetch leaves (see the request
+// transform in `src/app/api-client.ts`), so gating the token is what keeps a
+// window that opens *during* the boot from firing requests at a server that is
+// not listening yet. Without it the renderer's three retries and their backoff
+// would spend about seven seconds arriving at the error screen.
+//
+// It resolves rather than rejects on a failed boot on purpose: the renderer is
+// already up and asking by then, and what it needs is for the request to go
+// out and fail the way an unreachable backend normally fails — the error
+// screen it already has. A rejection here would instead reach `Effect.promise`
+// in the api-client, which turns a rejected promise into a defect.
+let markBackendSettled: () => void = () => undefined
+
+const backendSettled = new Promise<void>((resolve) => {
+  markBackendSettled = resolve
+})
+
+ipcMain.handle('get-api-token', async () => {
+  await backendSettled
+
+  return apiToken
+})
 
 ipcMain.handle('window-minimize', () => {
   minimizeMainWindow()
@@ -91,10 +130,16 @@ if (!hasSingleInstanceLock) {
 // run without consulting any of them. Here the runtime is present exactly where
 // it is usable, so the question has to be asked to reach it.
 type Lifecycle =
-  | { runtime: MainRuntime; status: 'booting' }
-  | { runtime: MainRuntime; status: 'quitting' }
-  | { runtime: MainRuntime; status: 'running' }
+  | { backend: Backend; status: 'booting' }
+  | { backend: Backend; status: 'quitting' }
+  | { backend: Backend; status: 'running' }
   | { status: 'idle' }
+  // The window is up and the backend module is still being imported. It earns a
+  // state of its own because it is the one moment with something on screen and
+  // nothing behind it: there is no backend to dispose, but a quit landing here
+  // still has to stop the boot that is about to start, which is why it cannot
+  // simply be `idle`.
+  | { status: 'starting' }
 
 let lifecycle: Lifecycle = { status: 'idle' }
 
@@ -102,8 +147,28 @@ let lifecycle: Lifecycle = { status: 'idle' }
 // hold the app open.
 const disposeTimeoutMs = 3_000
 
-const createWindow = async () => {
+// The `--panel2` token both themes paint the loading screen in, converted to
+// the hex Electron wants. The window is now built before the renderer has
+// loaded anything, so whatever is set here is what the user actually sees for
+// the first frames — unset, that is white, and on a dark theme a white
+// frameless rectangle reads as a broken app rather than a starting one.
+//
+// `nativeTheme` is the closest the main process can get to the answer: the real
+// choice lives in the renderer's localStorage (`src/theme-bootstrap.ts` reads
+// `theme:v1`), which is unreachable from here. A user who has forced a theme
+// against their system setting gets one wrong-coloured frame instead of a
+// wrong-coloured flash.
+function windowBackgroundColor(): string {
+  return nativeTheme.shouldUseDarkColors ? '#181c24' : '#f6f7f9'
+}
+
+// Synchronous, and that is load-bearing rather than tidiness: the boot path
+// below depends on the window existing before the first tick of the layer
+// build, which an `async` function returning a discarded promise only happened
+// to deliver.
+function createWindow(): void {
   const window = new BrowserWindow({
+    backgroundColor: windowBackgroundColor(),
     frame: false,
     height: 880,
     titleBarStyle: 'hidden',
@@ -173,11 +238,12 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-// Quitting while the layer is still building interrupts it. That is a shutdown,
-// not a boot failure, so it must not raise a dialog racing the before-quit
-// handler's own exit.
-function isShutdownInterruption(cause: Cause.Cause<unknown>): boolean {
-  return lifecycle.status === 'quitting' || Cause.isInterruptedOnly(cause)
+// Asked through a function so the answer is opaque to narrowing. `lifecycle` is
+// module-level and mutable, and an await is exactly where a quit changes it —
+// but TypeScript narrows it from the assignment made before that await and
+// calls the inline comparison unreachable.
+function isQuitting(): boolean {
+  return lifecycle.status === 'quitting'
 }
 
 function reportBootFailure(error: unknown): void {
@@ -209,8 +275,19 @@ function reportBootFailure(error: unknown): void {
  * same `app.exit(0)` and a backend that wedges on every quit otherwise leaves
  * no trace of having done so.
  */
-async function shutDown(runtime: MainRuntime): Promise<void> {
+async function shutDown(backend: Backend): Promise<void> {
   let timer: ReturnType<typeof setTimeout> | undefined
+
+  // The window goes first, and this is the guarantee that used to come from
+  // never having opened one: a quit that lands mid-boot now finds a window on
+  // screen, and everything behind it is about to be disposed. Left up, it
+  // would spend its last seconds turning every request into an error.
+  closeMainWindow()
+
+  // Nothing should be left waiting on a backend that is being torn down. A
+  // renderer still holding its token request would otherwise sit on the
+  // spinner until the process exits underneath it.
+  markBackendSettled()
 
   const reportFailure = (error: unknown) => {
     log.warn(
@@ -239,7 +316,7 @@ async function shutDown(runtime: MainRuntime): Promise<void> {
     // that lacked one — a `dispose()` that throws where it should have rejected
     // would otherwise skip the `finally`, and the quit it skips has already
     // been prevented, so nothing would be left to release it.
-    const disposal = runtime
+    const disposal = backend
       .dispose()
       .then(() => 'disposed' as const, reportFailure)
 
@@ -271,27 +348,66 @@ app.on('ready', async () => {
 
   apiToken = randomBytes(32).toString('hex')
 
-  const runtime = makeMainRuntime({
+  lifecycle = { status: 'starting' }
+
+  // Opened first, before the backend module has even been loaded — which is the
+  // whole point. Importing it evaluates Effect, drizzle and the libsql driver,
+  // and building the layer graph then opens the app database, runs the DDL,
+  // reconciles interrupted queries and binds the port. None of that needs a
+  // window and all of it used to happen with nothing on screen. The renderer
+  // paints the spinner it already has through all of it now.
+  //
+  // What stops the window racing the server it talks to is `backendSettled`:
+  // the renderer awaits `get-api-token` before every request's fetch leaves.
+  createWindow()
+
+  const windowCreatedAt = millisecondsSinceStart()
+
+  const { makeBackend } = await import('./main/backend')
+
+  // A quit can land while that import is in flight. `before-quit` has no
+  // backend to dispose at that point, so it lets the quit through and leaves
+  // the lifecycle idle — and booting one here would open the database and bind
+  // the port on an app that is already on its way out.
+  if (lifecycle.status !== 'starting') {
+    markBackendSettled()
+
+    return
+  }
+
+  const backend = makeBackend({
     allowedOrigins: corsAllowedOrigins(),
     // Lets local agents read traces with plain curl during development.
     publicTraceReads: !app.isPackaged,
     token: apiToken
   })
 
-  lifecycle = { runtime, status: 'booting' }
+  lifecycle = { backend, status: 'booting' }
 
-  // Forces the runtime layer to build: the app database initializes,
-  // interrupted queries are reconciled, the encryption migration runs
-  // (safeStorage is only reliable once the app is ready), and only then
-  // does the HTTP server start listening.
-  const bootExit = await runtime.runPromiseExit(Effect.void)
+  const outcome = await backend.boot()
 
-  if (Exit.isFailure(bootExit)) {
-    if (isShutdownInterruption(bootExit.cause)) {
+  log.info(
+    `Startup: window at ${windowCreatedAt.toFixed(0)}ms, backend at ${millisecondsSinceStart().toFixed(0)}ms.`
+  )
+
+  if (outcome.status !== 'ready') {
+    // Released on this arm too. The renderer is up and waiting on the token by
+    // now, and holding it pending would leave it on the spinner behind the
+    // dialog below rather than letting the request fail and say so.
+    markBackendSettled()
+
+    // Quitting while the layer is still building interrupts it, and that is a
+    // shutdown rather than a boot failure — reporting it would raise a modal
+    // racing the before-quit handler's own exit. Two spellings of the same
+    // situation, and both are needed: the backend reports an interrupt-only
+    // cause, and the lifecycle knows about a quit that landed too early for the
+    // layer build to have noticed. The outcome half stays inline so that what
+    // is left below is narrowed to the arm that carries an error.
+    if (isQuitting() || outcome.status === 'interrupted') {
       return
     }
 
-    reportBootFailure(Cause.squash(bootExit.cause))
+    reportBootFailure(outcome.error)
     app.exit(1)
 
     return
@@ -299,16 +415,16 @@ app.on('ready', async () => {
 
   // The same question the failure arm asks through `isShutdownInterruption`,
   // asked on this arm too. A quit that landed while the boot was in flight has
-  // already started disposing the runtime this window would talk to, and is
-  // seconds from `app.exit(0)`: what it opens is a window whose every request
-  // fails, for as long as it survives.
+  // already started disposing the runtime, and `shutDown` has already closed
+  // the window — so there is nothing here to promote to `running`, and the
+  // token must not be handed to a renderer whose backend is mid-`dispose()`.
   if (lifecycle.status !== 'booting') {
     return
   }
 
-  lifecycle = { runtime, status: 'running' }
+  lifecycle = { backend, status: 'running' }
 
-  createWindow()
+  markBackendSettled()
 })
 
 app.on('second-instance', () => {
@@ -328,6 +444,19 @@ app.on('before-quit', (event) => {
     return
   }
 
+  // A window is up, but the backend module is still being imported: nothing has
+  // been acquired, so there is nothing to dispose and no reason to hold the
+  // quit. Dropping back to `idle` is also the signal the ready handler reads
+  // when its import finally resolves — without it, it would go on to boot a
+  // backend for an app that is already gone.
+  if (lifecycle.status === 'starting') {
+    lifecycle = { status: 'idle' }
+
+    markBackendSettled()
+
+    return
+  }
+
   // Every quit signal arriving during the dispose window has to keep being
   // prevented. Returning early without preventDefault let a second Cmd+Q — or
   // window-all-closed firing app.quit() — complete the quit and kill the
@@ -338,11 +467,11 @@ app.on('before-quit', (event) => {
     return
   }
 
-  const { runtime } = lifecycle
+  const { backend } = lifecycle
 
-  lifecycle = { runtime, status: 'quitting' }
+  lifecycle = { backend, status: 'quitting' }
 
-  void shutDown(runtime)
+  void shutDown(backend)
 })
 
 app.on('window-all-closed', () => {
@@ -357,7 +486,14 @@ app.on('activate', () => {
   // indistinguishable from the last-window-closed app this exists to revive —
   // except that what it would open talks to a runtime already inside
   // `dispose()`, seconds from `app.exit(0)`.
-  if (lifecycle.status !== 'running') {
+  //
+  // `starting` and `booting` are allowed through now that the boot path opens
+  // its window before the backend exists: a window closed while the backend is
+  // still coming up leaves an app that a dock click should revive, and what it
+  // opens waits on `backendSettled` like any other. Refusing them would strand
+  // a macOS user with no window until the boot finished, since the boot path no
+  // longer opens one when it does.
+  if (lifecycle.status === 'idle' || lifecycle.status === 'quitting') {
     return
   }
 

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -1,0 +1,59 @@
+// The backend behind a promise-shaped door, so `src/main.ts` can reach it
+// through a dynamic import.
+//
+// That indirection is the whole reason this module exists. Everything Effect
+// touches lives on this side of it: importing `@/server/runtime` pulls in
+// `effect`, `drizzle-orm` and the libsql driver, which together are around half
+// a second of module evaluation. Statically imported from `src/main.ts` that
+// half second was spent before Electron's `ready` even fired — so before any
+// window could exist, whatever else the app was going to do. Loaded from here,
+// it happens behind a window that is already on screen.
+//
+// Keeping it a real module boundary rather than a lazy call inside `runtime.ts`
+// is what makes Rollup emit it as its own chunk, which is what actually defers
+// the evaluation.
+import { Cause, Effect, Exit } from 'effect'
+
+import { makeMainRuntime, type MainRuntimeOptions } from '@/server/runtime'
+
+/**
+ * How the boot came back, with Effect's vocabulary already resolved into
+ * something `src/main.ts` can branch on without importing any of it.
+ */
+export type BootOutcome =
+  | { error: unknown; status: 'failed' }
+  // The layer build was interrupted rather than failing on its own, which is
+  // what a quit landing mid-boot looks like. A shutdown, not a boot failure —
+  // so nothing to report and no dialog to raise.
+  | { status: 'interrupted' }
+  | { status: 'ready' }
+
+export interface Backend {
+  boot: () => Promise<BootOutcome>
+  dispose: () => Promise<void>
+}
+
+export function makeBackend(options: MainRuntimeOptions): Backend {
+  const runtime = makeMainRuntime(options)
+
+  return {
+    // Forces the runtime layer to build: the app database initializes,
+    // interrupted queries are reconciled, the encryption migration runs
+    // (safeStorage is only reliable once the app is ready), and only then does
+    // the HTTP server start listening.
+    boot: async () => {
+      const exit = await runtime.runPromiseExit(Effect.void)
+
+      if (Exit.isFailure(exit)) {
+        if (Cause.isInterruptedOnly(exit.cause)) {
+          return { status: 'interrupted' }
+        }
+
+        return { error: Cause.squash(exit.cause), status: 'failed' }
+      }
+
+      return { status: 'ready' }
+    },
+    dispose: () => runtime.dispose()
+  }
+}

--- a/src/server/http/handlers/connection-tests.ts
+++ b/src/server/http/handlers/connection-tests.ts
@@ -39,7 +39,7 @@ export const ConnectionTestsLive = HttpApiBuilder.group(
           }
         }
 
-        const adapter = adapterFactory.create(resolved.connection)
+        const adapter = yield* adapterFactory.create(resolved.connection)
 
         return yield* Effect.tryPromise(() => adapter.testConnection()).pipe(
           Effect.as({ success: true }),

--- a/src/server/http/handlers/databases.ts
+++ b/src/server/http/handlers/databases.ts
@@ -66,7 +66,7 @@ export const DatabasesLive = HttpApiBuilder.group(
             })
           }
 
-          const adapter = adapterFactory.create(record.value.connection)
+          const adapter = yield* adapterFactory.create(record.value.connection)
 
           // Deliberately sequential. Running the probe alongside introspection
           // would double the connections every schema request opens, and

--- a/src/server/retention.test.ts
+++ b/src/server/retention.test.ts
@@ -14,7 +14,7 @@ import invariant from 'tiny-invariant'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { makeTestAppDatabase } from '@/test/effect-test-helper'
-import { RetentionLive } from './retention'
+import { firstSweepDelay, RetentionLive } from './retention'
 import { AppDatabase, type AppDatabaseClient } from './services/app-database'
 
 // The sweeps are the subject of their own tests, against their own databases.
@@ -64,6 +64,9 @@ function withRetention<A>(body: Effect.Effect<A, never, never>): Promise<A> {
           RetentionLive.pipe(Layer.provide(makeTestAppDatabase()))
         )
 
+        // Past the startup delay, so the cases below all start from the first
+        // pass having run. The delay itself is its own case.
+        yield* TestClock.adjust(firstSweepDelay)
         yield* settle
 
         return yield* body
@@ -88,6 +91,38 @@ describe('RetentionLive', () => {
     expect(swept).toEqual({ queries: 1, spans: 1 })
   })
 
+  // The sweeps used to start the instant the layer built, which put two
+  // synchronous DELETEs on the event loop while the window was still being
+  // created — the driver blocks the main process, so that was first paint
+  // waiting on retention. Nothing may run before the delay is up.
+  it('sweeps nothing until the startup delay is up', async () => {
+    const swept = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* Layer.build(
+            RetentionLive.pipe(Layer.provide(makeTestAppDatabase()))
+          )
+
+          // Everything the runtime has to offer short of moving the clock: if
+          // a sweep were still unscheduled, this is where it would run.
+          yield* settle
+
+          const beforeDelay = counts()
+
+          yield* TestClock.adjust(firstSweepDelay)
+          yield* settle
+
+          return { afterDelay: counts(), beforeDelay }
+        })
+      ).pipe(Effect.provide(captureLogs), Effect.provide(TestContext))
+    )
+
+    expect(swept).toEqual({
+      afterDelay: { queries: 1, spans: 1 },
+      beforeDelay: { queries: 0, spans: 0 }
+    })
+  })
+
   // The client the sweeps are handed, rather than one they went and found.
   // A sweep reaching a module singleton would pass every case in its own file,
   // where the two are the same database — this is the seam where they are not.
@@ -101,6 +136,7 @@ describe('RetentionLive', () => {
             RetentionLive.pipe(Layer.provide(Layer.succeedContext(context)))
           )
 
+          yield* TestClock.adjust(firstSweepDelay)
           yield* settle
 
           const { client } = Context.get(context, AppDatabase)
@@ -287,6 +323,7 @@ describe('RetentionLive', () => {
           scope
         )
 
+        yield* TestClock.adjust(firstSweepDelay)
         yield* settle
 
         // The runtime scope closes on before-quit, and a sweep left running

--- a/src/server/retention.ts
+++ b/src/server/retention.ts
@@ -8,6 +8,13 @@ import { deleteExpiredQueries } from '@/main/queries/query-retention'
 import { deleteExpiredSpans } from '@/main/tracing/trace-retention'
 import { AppDatabase, type AppDatabaseClient } from './services/app-database'
 
+// The sweeps used to start the moment the layer built, which put two DELETEs on
+// the event loop while the window was still being created. Forking was never
+// the protection it looked like: the libsql driver is synchronous, so a sweep
+// in progress is the main process blocked, first paint included. Late enough to
+// be clear of that, and mirroring `firstCheckDelay` in `updates.ts`.
+export const firstSweepDelay = Duration.seconds(20)
+
 interface MaintenanceSweep {
   name: string
   run: (client: AppDatabaseClient) => Promise<number>
@@ -54,11 +61,15 @@ export const RetentionLive = Layer.scopedDiscard(
     // cannot run before that has happened.
     const appDatabase = yield* AppDatabase
 
-    yield* runSweeps(appDatabase.client).pipe(
-      // `fixed`, not `spaced`: the cadence is anchored to when a pass started,
-      // so a slow sweep does not push every later day's maintenance back by
-      // however long it took.
-      Effect.repeat(Schedule.fixed(Duration.days(1))),
+    yield* Effect.sleep(firstSweepDelay).pipe(
+      Effect.andThen(
+        runSweeps(appDatabase.client).pipe(
+          // `fixed`, not `spaced`: the cadence is anchored to when a pass
+          // started, so a slow sweep does not push every later day's
+          // maintenance back by however long it took.
+          Effect.repeat(Schedule.fixed(Duration.days(1)))
+        )
+      ),
       Effect.forkScoped
     )
   })

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -68,5 +68,3 @@ export function makeMainRuntime(options: MainRuntimeOptions) {
 
   return ManagedRuntime.make(MainLive)
 }
-
-export type MainRuntime = ReturnType<typeof makeMainRuntime>

--- a/src/server/services/adapter-factory.ts
+++ b/src/server/services/adapter-factory.ts
@@ -13,8 +13,17 @@ export class AdapterFactory extends Effect.Service<AdapterFactory>()(
     sync: () => ({
       // One discriminated value, not a (type, connectionInfo) pair that could
       // disagree — see DatabaseConnection in the contract.
-      create: (connection: DatabaseConnection): DatabaseAdapter =>
-        createAdapter(connection)
+      //
+      // An Effect rather than the adapter itself because `createAdapter` loads
+      // its driver on demand now. `Effect.promise` is right despite the import
+      // being able to fail: a driver missing from the build is not a condition
+      // any caller can handle or any user can act on, so it belongs in the
+      // defect channel with the rest of `src/server/errors.ts` — a 500 — rather
+      // than in the contract.
+      create: (
+        connection: DatabaseConnection
+      ): Effect.Effect<DatabaseAdapter> =>
+        Effect.promise(() => createAdapter(connection))
     })
   }
 ) {}

--- a/src/server/services/query-runner.ts
+++ b/src/server/services/query-runner.ts
@@ -84,7 +84,7 @@ export class QueryRunner extends Effect.Service<QueryRunner>()('QueryRunner', {
         }
 
         return {
-          adapter: adapterFactory.create(record.value.connection),
+          adapter: yield* adapterFactory.create(record.value.connection),
           databaseType: record.value.connection.type
         }
       }).pipe(

--- a/src/test/effect-test-helper.ts
+++ b/src/test/effect-test-helper.ts
@@ -195,7 +195,11 @@ export function makeTestAdapterFactory(config: TestAdapterConfig = {}) {
         state.lastConnectionInfo = connection.connectionInfo
         state.lastType = connection.type
 
-        return {
+        // Wrapped because the real factory loads its driver on demand and so
+        // answers with an Effect. `succeed`, not `promise`: the stub has
+        // nothing to wait for, and keeping it synchronous means a test still
+        // observes the adapter in the same step it asks for one.
+        return Effect.succeed({
           cancel: config.cancel ?? (() => Promise.resolve()),
           getSchema:
             config.getSchema ?? (() => Promise.resolve(defaultTestSchema)),
@@ -207,7 +211,7 @@ export function makeTestAdapterFactory(config: TestAdapterConfig = {}) {
           runQuery:
             config.runQuery ?? (() => Promise.resolve(defaultTestQueryResult)),
           testConnection: config.testConnection ?? (() => Promise.resolve())
-        }
+        })
       }
     })
   )


### PR DESCRIPTION
The app took a long time to become usable, in both `yarn start` and the
packaged build, and the symptom was specific: no window appeared for a while.
Not a blank window — nothing.

## Measured

Dev build, 4–5 runs each, same launch method, time from process start to the
`BrowserWindow` existing:

|          | cold    | warm       |
| -------- | ------- | ---------- |
| Before   | 1372 ms | ~431 ms    |
| After    | ~910 ms | **~227 ms** |

Eager main-process bundle: **1,360 KB → 40 KB**.

`src/main.ts` now logs the breakdown on every launch, which is how the above
was measured and how the next person can check it:

```
Startup: window at 227ms, backend at 330ms.
```

## What was actually wrong

`main.ts` awaited the entire backend boot before `createWindow()`. But
measuring first moved the target twice:

- The layer build is only **~50 ms**. The larger cost is module evaluation
  happening before Electron's `ready` even fires — `effect` alone is 361 ms.
- Two plausible-sounding causes were ruled out and are worth not
  re-investigating: the renderer's data-loading waterfall was **already
  fixed**, and the 241 MB dev database is irrelevant (the packaged one is
  442 KB).

## Changes

1. **Window before backend.** The renderer paints the spinner it already has
   while the backend boots.
2. **`src/main/backend.ts`** (new) — the Effect/drizzle/libsql graph behind a
   dynamic import so it loads after the window. A real module boundary is what
   makes Rollup emit it as its own chunk; `build.lib` did *not* inline it.
3. **Lazy drivers** — `pg`/`mysql2`/`libsql` load on first connection. Needs
   no build change, since they are already Vite externals.
4. **Partial index** on unfinished queries — boot reconciliation was scanning
   a table whose rows each hold a full query result.
5. **Retention delayed 20 s** — libsql is synchronous, so its DELETEs were
   blocking first paint.
6. `backgroundColor` from `nativeTheme`, so the frameless window is not a
   white flash before the renderer paints.

### The safety catch

Opening the window early risks the renderer firing requests before the HTTP
server listens, which `retry: 3` and its backoff would turn into ~7 s ending
on the error screen. The renderer already awaits `get-api-token` inside the
request transform *before* any fetch leaves, so gating that one IPC handler on
backend readiness gates every request — no renderer change, no polling.

It resolves rather than rejects on a failed boot: `Effect.promise` in the
api-client turns a rejection into a defect, and what the renderer wants there
is the ordinary unreachable-backend path it already has.

## Verification

- 1553 tests pass; typecheck, lint and format clean.
- The two load-bearing new tests were **mutation-tested** — reverting the
  window ordering or the token gate makes them fail, so they are not vacuous.
- Six new cases cover the new branches, including the `starting` lifecycle
  state where a quit lands mid-import.
- Built and ran the **packaged** app, confirming the newly chunked
  `.vite/build` survives packaging (all chunks present in the asar).

That packaged run produced an accidental demonstration: it hung 6 s on a
macOS keychain prompt, and logged `window at 6312ms, backend at 6921ms`. The
old ordering would have shown nothing at all for those six seconds.

## Worth knowing

The suite is **flaky, and was before this branch**: three runs of identical
code gave 3 / 0 / 1 failures, different tests each time, all passing in
isolation. That is friction entry `20260819113459`. I confirmed the
nondeterminism but did not establish whether the rate changed — worth
knowing when reading CI on this PR.
