### PR TITLE
ci: run the checks for queued merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required for a merge queue: GitHub runs queued merges on a `gh-readonly-queue`
+  # ref, which matches neither trigger above. A workflow without this is invisible
+  # to the queue -- the merge is gated on checks that never run, and nothing says
+  # so. Every job below has to run here for the queue to be worth having, which is
+  # the whole point: these are the checks against the `main` a branch will land on,
+  # rather than against the one it was cut from.
+  merge_group:
 
 jobs:
   fallow:


### PR DESCRIPTION
Refs friction [`20260819151914-pull-requests-merge`](https://github.com/Artmann/squeal/tree/main/.agents/friction-log/20260819151914-pull-requests-merge) — *"Pull requests merge green and land red, because nothing rebases them onto the main they will sit on"* (`major`).

**The friction entry stays open.** This PR ships only the half that lives in the repository; the fix is not complete until the queue is switched on.

## The friction

Checks run against a PR's own base, and nothing re-runs them against the `main` the branch will land on. Two PRs that rename in one and use the old name in the other are both green, git reports no conflict, and `main` breaks the moment the second merges. Merging 22 green PRs broke `main` in three separate places at once.

## What this PR does

Adds `merge_group:` to `on:` in `ci.yml`. GitHub runs queued merges on a `gh-readonly-queue` ref, which matches neither `push: [main]` nor `pull_request: [main]` — so a workflow without this trigger is invisible to a merge queue. The merge is then gated on checks that never run, and nothing says so.

Verified all six jobs are reachable from the new trigger:

```
triggers: ['push', 'pull_request', 'merge_group']
jobs:     Fallow, Typecheck, Format, Lint, Test, Build
```

## What is left for you

`Artmann/squeal` has no branch protection and no rulesets today (`gh api …/branches/main/protection` → 404, `…/rulesets` → `[]`). After this merges, either use **Settings → Rules → New ruleset**, or run:

```sh
gh api repos/Artmann/squeal/rulesets --method POST --input - <<'JSON'
{
  "name": "main",
  "target": "branch",
  "enforcement": "active",
  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
  "rules": [
    { "type": "pull_request",
      "parameters": {
        "required_approving_review_count": 0,
        "dismiss_stale_reviews_on_push": false,
        "require_code_owner_review": false,
        "require_last_push_approval": false,
        "required_review_thread_resolution": false,
        "automatic_copilot_code_review_enabled": false,
        "allowed_merge_methods": ["squash", "merge", "rebase"]
      } },
    { "type": "merge_queue",
      "parameters": {
        "check_response_timeout_minutes": 60,
        "grouping_strategy": "ALLGREEN",
        "max_entries_to_build": 5,
        "max_entries_to_merge": 5,
        "merge_method": "SQUASH",
        "min_entries_to_merge": 1,
        "min_entries_to_merge_wait_minutes": 5
      } },
    { "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": true,
        "do_not_enforce_on_create": false,
        "required_status_checks": [
          { "context": "Fallow" }, { "context": "Typecheck" },
          { "context": "Format" }, { "context": "Lint" },
          { "context": "Test" },   { "context": "Build" }
        ]
      } }
  ]
}
JSON
```

Your token has `repo` scope and admin on the repo, so this call will go through.

## How to confirm it works

Open two PRs off the same `main`: one renames an exported symbol and updates its callers, the other adds a caller of the old name. Both go green. Queue both — the second must fail in the queue instead of on `main`.

Once that holds, `npx frog resolve 20260819151914-pull-requests-merge`.